### PR TITLE
tools: add Money S3 -> MyInvoice migration script (REST API v1)

### DIFF
--- a/tools/money-s3-import/.env.example
+++ b/tools/money-s3-import/.env.example
@@ -1,0 +1,22 @@
+# Money S3 -> MyInvoice migrace — vzor konfigurace.
+# Zkopiruj na `.env` a vypln. `.env` je v .gitignore (necommituj!).
+# Skripty ctou promenne prostredi; nastav je pred spustenim (PowerShell: $env:NAZEV="..."; bash: export NAZEV=...).
+
+# --- MyInvoice REST API ---
+MI_URL=https://mojeinstalace.example.com:9443     # adresa MyInvoice (HTTPS)
+MI_TOKEN=mi_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx     # Personal Access Token (scope read_write)
+
+# --- Money S3 (export-money.ps1, 32-bit) ---
+MONEY_DATA=C:\Users\Public\Documents\Solitea\Money S3\Data   # korenova slozka dat Money
+MONEY_AGENDA=AGENDA.001                            # ktera agenda
+MONEY_ICO=12345678                                 # TVE ICO (vlastni subjekt se vynecha z klientu)
+MONEY_OUT=money-export.json                        # vystupni JSON (vstup pro import)
+
+# --- import-myinvoice.py ---
+MI_EXPORT=money-export.json                         # cesta k exportu z faze 1
+MI_MARK_PAID=0                                      # 1 = oznacit vsechny prijate jako uhrazene (kdyz Money uhrady neevidoval)
+MI_SLEEP=0.1                                        # prodleva mezi zapisy (s); 0 = bez brzdy (riziko 429), 0.1 ~ 600/min
+
+# --- validace (validate-dph.py, validate-kh-doklady.py, gen-kh.py) ---
+RETURNS_DIR=C:\cesta\k\podanym\DPH                  # slozka s podanymi DPHDP3/DPHKH XML (podslozky YYYY_MM)
+MI_KH_DIR=.\mi-kh                                   # slozka s KH vygenerovanymi z MyInvoice (gen-kh.py)

--- a/tools/money-s3-import/.gitignore
+++ b/tools/money-s3-import/.gitignore
@@ -1,0 +1,15 @@
+# Konfigurace s credentials — NIKDY necommitovat
+.env
+
+# Exportovaná data z Money (obsahují reálné faktury/kontakty)
+money-export*.json
+
+# Vygenerované / pracovní výstupy
+mi-kh/
+conv/
+*.log
+*.sql.gz
+
+# Python
+__pycache__/
+*.pyc

--- a/tools/money-s3-import/LICENSE
+++ b/tools/money-s3-import/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pavel Třešňák
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/money-s3-import/README.md
+++ b/tools/money-s3-import/README.md
@@ -1,0 +1,126 @@
+# Money S3 → MyInvoice — migrační nástroj (REST API)
+
+Převede data z účetního systému **Money S3** (Seyfor) do **MyInvoice** přes Public REST API v1.
+Migruje **kontakty + vydané faktury (vč. položek) + přijaté faktury** a umí sladit
+datum zdanitelného plnění (DUZP) s tvými reálně podanými přiznáními k DPH.
+
+> **Ověřeno na reálných datech:** výstupní DPH generovaná z MyInvoice se shoduje s podanými
+> přiznáními a kontrolním hlášením (ověřeno napříč více lety, doklad po dokladu).
+
+## Předpoklady
+- **Money S3** na Windows (data přes COM `mon2kdbe.BFTable`, 32-bit). **Testováno na Money S3 verze 26.300** (formát BF13 `.DAT`).
+- **MyInvoice ≥ 4.1.4** běžící, dostupné přes HTTPS (4.1.0 = EU reverse-charge v cizí měně; 4.1.4 = opravy KH sekcí, issue #35).
+- **API token** (Personal Access Token, scope `read_write`): MyInvoice → *Systém → API tokeny*.
+- **Python 3** (stdlib; pro fáze 3/4 navíc `pypdf`), **32-bit Windows PowerShell**.
+- Konfigurace přes proměnné prostředí — viz `.env.example`. **Žádná data/credentials se necommitují** (`.env` je v `.gitignore`).
+
+## Fáze
+
+| Fáze | Skript | Co dělá |
+|---|---|---|
+| 1 | `export-money.ps1` | Money S3 (COM, read-only) → `money-export.json` |
+| 2 | `import-myinvoice.py` | JSON → MyInvoice REST API (idempotentní) |
+| 3 *(volitelná, plátci DPH)* | `correct-duzp-from-kh.py` | sladí DUZP migrovaných faktur s podanými KH → SQL |
+| 4 *(volitelná)* | `validate-dph.py` | porovná DPH z MyInvoice proti podaným přiznáním |
+
+```powershell
+# 1) export z Money (32-bit PowerShell)
+$env:MONEY_ICO="12345678"
+C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe -NoProfile -File export-money.ps1
+```
+```bash
+# 2) import do MyInvoice
+MI_URL="https://myinvoice.example.com:9443"  MI_TOKEN="mi_pat_..."  python import-myinvoice.py
+# 3) (volitelně) sladění DUZP s podanými KH -> SQL ke kontrole a spuštění
+KH_DIR="cesta/ke/kontrolnim-hlasenim"  python correct-duzp-from-kh.py
+```
+
+---
+
+## Řešené případy a scénáře
+
+Migrace pokrývá tyto reálné situace (a jak je řeší):
+
+### Vydané faktury
+- **Běžná tuzemská faktura (21 %)** — položky se skládají z `VFaktPol` (`PocetMJ × Cena`, sazba `SazbaDPH`), klient z `Odberatel` (index do adresáře). Datum vystavení = DUZP.
+- **Více sazeb / sleva** — každý řádek vlastní sazba; sleva jako záporný řádek.
+- **Neplátcovské období** — faktury před registrací k DPH (0 %); převedou se beze změny.
+- **Post-datovaná / zpětně zaúčtovaná faktura** — DUZP na konci měsíce, ale `DatUcPr` (zaúčtování) až v dalším měsíci. Exportér bere `PlnenoDPH` (DUZP), takže spadne do správného období; `DUZP_OVERRIDE` / fáze 3 jen pro ruční korekce.
+- **Year-end přesun** — faktura z 31. 12. vykázaná až v dalším roce (časté u OSVČ). Nemusí být v žádném KH → ponechá se dle vystavení; do žádného období „nesedne" (vědomá výjimka).
+
+### Přijaté faktury
+- **Běžná tuzemská přijatá (21 %)** — v Money často bez položek → 1 souhrnný řádek, základ = celkem / 1,21.
+- **EU pořízení zboží v režimu reverse charge** — zahraniční dodavatel (DIČ mimo CZ), tuzemská daň se samovyměřuje. Migrace **věrně v původní měně** (např. EUR) + denní kurz: `currency_id` dle měny, `exchange_rate` = kurz, základ v cizí měně = `celkem / kurz` (RC = bez DPH v dokladu), `reverse_charge=true`, `vat_classification_code='23'`, `vendor_invoice_number` = číslo dokladu dodavatele (→ KH A.2 `c_evid_dd`). Výsledek: DPHDP3 ř. 3 (pořízení z JČS, CZK = cizí měna × kurz) + samovyměřená daň + ř. 43 mirror (daňově neutrální) + KH A.2. **Pozor: dodavatel musí mít zemi mimo CZ** (jinak A.2 `k_stat` vyjde chybně CZ); detekce dle prefixu DIČ. Vyžaduje MyInvoice **≥ 4.1.0**.
+- **Prodej + zápočet (protiúčet) na jednom dokladu** — např. nákup vozu s výkupem starého protiúčtem: nákup = tvůj odpočet (přijatá), výkup = tvůj prodej (vydaná, samostatný doklad). Stejný partner pak vystupuje jako odběratel i dodavatel.
+- **Úhrady přijatých** — Money je nemusí evidovat; volitelně lze označit všechny jako uhrazené (`MI_MARK_PAID=1`).
+- **Dobropis přijatý (opravný daňový doklad)** — Money má příznak `Dobropis`; importuje se jako `document_kind='credit_note'` se **zápornými** částkami (dle manuálu MyInvoice). `vendor_invoice_number` = číslo opravného dokladu dodavatele. Daň se promítne do ř. 40 (záporně). Pozor na zařazení v KH — viz Limity.
+
+### Datová úskalí Money S3
+- **Ghost záznamy** — COM čte i smazané/nahrazené doklady (GUI je neukazuje). Dedup dle `Doklad`, ponechat nejvyšší `Cislo`.
+- **Smazané unikátní doklady (limitace)** — COM (`mon2kdbe.BFTable`) čte i doklady smazané v Money GUI, které nemají duplikát (ghost-dedup je nezachytí), a **nevystavuje příznak smazání** (RecCount i indexy je zahrnují). Nelze je proto přes COM odfiltrovat → po importu zkontrolovat anomálie (nesmyslně malý/rozbitý doklad, např. fragment selhaného importu) a ručně smazat.
+- **Cross-year duplikát** — doklad z přelomu roku vedený ve dvou ročnících (ROK.xxx); ponechat ten, pod kterým byl podán.
+- **Adresář nemá e-maily** → placeholder `ico@imported.local`; reálné doplnit ručně po importu.
+
+### DPH agenda
+- **Velké vs malé doklady** — KH dělí na A.4/B.2 (> 10 000 Kč, per doklad) a A.5/B.3 (≤ 10 000 Kč, agregát). To určuje, co lze opravit z KH (jen velké).
+- **Opravné / dodatečné přiznání** — období s opravou; pro srovnání se bere efektivní (opravená) hodnota. Pozor na § 145a (dodatečné podané před vyměřením FÚ se sloučí s řádným).
+
+---
+
+## Datový model Money S3 — klíčová úskalí
+
+- **DUZP je v poli `PlnenoDPH`** (datum zdanitelného plnění, povinné u plátců DPH) — to je **autoritativní období DPH**. Exportér ho čte přímo. (U neplátce nebo starších dokladů může být prázdné → exportér použije fallback `Vystaveno`/`DatUcPr`.)
+- **`Vystaveno`** = datum vystavení, **`Splatno`** = splatnost, **`Uhrazeno`** = datum úhrady.
+- **`DatUcPr`** (datum účetního případu / zaúčtování) **NENÍ DUZP** — u dokladu z konce měsíce bývá až v dalším měsíci a poslal by ho do špatného období DPH. (Časté úskalí — exportér proto bere `PlnenoDPH`, ne `DatUcPr`.)
+- **Položky** vydaných: vazba přes sloupec `Cislo`. **Partner**: 1-based index v `Odberatel`/`Dodavatel` do `AdresarF`.
+
+## DPH přesnost — DUZP
+
+Primárním zdrojem DUZP je pole **`PlnenoDPH`** z Money (čte ho exportér přímo) — období DPH tak sedí bez dalších kroků.
+
+**Volitelné křížové ověření (fáze 3)** proti tvým **podaným kontrolním hlášením**, když chceš jistotu shody s tím, co je u FÚ:
+- **A.4** (vydané > 10 000): `c_evid_dd` (číslo dokladu) + `dppd` (DUZP) → přímé sladění.
+- **B.2** (přijaté > 10 000): `dic_dod` + `zakl_dane1` + `dppd` → párování DIČ + základ.
+
+`correct-duzp-from-kh.py` to vytáhne ze `DPHKH1-*.zip` (strojový XML) i z PDF (fallback) a vygeneruje SQL ke kontrole. Užitečné hlavně tam, kde byl odpočet uplatněn v jiném období, než je DUZP.
+
+## Limity (čím je dáno)
+- **DUZP malých přijatých (B.3 ≤ 10 000)** — z `PlnenoDPH` (v Money jsou). V KH figurují jen agregátem, takže fáze 3 je neumí ověřit po jednotlivých dokladech — spoléhá se na `PlnenoDPH`. (Rozpad DPH po sazbách rekonstruuje importér z celku přes `DEFAULT_PURCHASE_VAT_RATE`, ne z položek → drobné haléřové zaokrouhlení.)
+- **KH B.2 — VYŘEŠENO ve v4.1.4 (issue #35):** dříve se EU pořízení (A.2) duplikovalo i do B.2 a přijatý dobropis nad 10 000 Kč padal do sumace B.3. Od v4.1.4 opraveno (daň byla správně i předtím, šlo o zařazení do sekcí). Na starší verzi limitace platí.
+- **⚠️ Snížená sazba DPH u přijatých (10 %/15 %) — DŮLEŽITÉ:** přijaté faktury jsou v Money S3 typicky **bez položek** (header), a COM (`mon2kdbe.BFTable`) **nevystavuje rozpad DPH po sazbách** (jen `CelkemSDPH`; `KodDPH` sazbu nerozlišuje). Importér je proto účtuje sazbou `DEFAULT_PURCHASE_VAT_RATE` (21 %). **Doklady se sníženou sazbou** (např. **časopisy/periodika** 10 %, potraviny 15 %) je nutné po importu **opravit ručně podle dokladu** (sazba/rozpad). Pozn.: MyInvoice číselník `vat_rates` historické 10/15 % standardně neseeduje (jen 21/12/0 od 2024) — nahlášeno autorovi (**issue #36**, seed `valid_to`); schéma to podporuje.
+- **Daň z příjmů (DPFDP5)** — v MyInvoice zatím MVP (počítá příjem včetně DPH, bez podpory výdajových paušálů); ověř před použitím k podání.
+- **Skenovaná PDF** bez textové vrstvy nelze strojově číst.
+
+## Validace (fáze 4)
+`validate-dph.py` porovná měsíční výstupní/celkovou DPH z MyInvoice (export z DB) proti
+podaným přiznáním (`DPHDP3-*.xml` / `DPH_MFCR-*.xml`, oprava-aware). Doporučeno doplnit
+namátkovou kontrolu několika dokladů proti PDF faktur.
+
+## Konfigurace importéru (`import-myinvoice.py`, nahoře)
+| Proměnná | Význam |
+|---|---|
+| `MI_URL` / `MI_TOKEN` / `MI_EXPORT` | URL, API token, cesta k JSON |
+| `DEFAULT_PURCHASE_VAT_RATE` | sazba přijatých bez položek (def. 21) |
+| `MI_MARK_PAID` (env) | `1` = označit všechny přijaté jako uhrazené (když je zdroj neeviduje) |
+| `MI_SLEEP` (env) | prodleva mezi zápisy v s (default 0; `0.1` ≈ 600/min při server rate-limitu) |
+| `DUZP_OVERRIDE` | ruční oprava DUZP post-datovaných `{"doklad":"YYYY-MM-DD"}` |
+| `VAT_MAP` | mapování sazby → vat_rate_id (ověř `/api/v1/codebooks/vat-rates`) |
+
+## Re-import (čistý)
+1. Snapshot / záloha MyInvoice DB.
+2. `truncate-transactional.sql` — vyprázdní transakční tabulky (clients, invoices*, purchase_invoices*, …) — NE supplier/users/api_tokens/číselníky.
+3. `export-money.ps1` → `import-myinvoice.py` (DUZP z `PlnenoDPH`; `MI_MARK_PAID=1` pro „vše uhrazené") → *(volitelně)* `correct-duzp-from-kh.py` + `validate-dph.py`.
+
+## Soubory
+```
+export-money.ps1            # fáze 1: Money COM → JSON (read-only, 32-bit PowerShell)
+import-myinvoice.py         # fáze 2: JSON → REST API (idempotentní, EU reverse charge, validace IČ)
+truncate-transactional.sql  # čistý re-import: vyprázdní transakční tabulky (NE supplier/users/api_tokens/číselníky)
+correct-duzp-from-kh.py     # (volitelné) křížové ověření DUZP z podaných KH
+validate-dph.py             # (volitelné) srovnání měsíční DPH proti podaným přiznáním
+validate-kh-doklady.py      # (volitelné) kontrola čísel dokladů A.4 (vydané) + B.2 (přijaté) vs podaná KH
+README.md / LICENSE
+```
+
+## Licence / sdílení
+MIT. Komunitní nástroj. Před sdílením odstraň konkrétní IČO/jména/URL z konfigurací.

--- a/tools/money-s3-import/correct-duzp-from-kh.py
+++ b/tools/money-s3-import/correct-duzp-from-kh.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+FÁZE 3 (volitelná, doporučená pro plátce DPH):
+Sladí datum zdanitelného plnění (DUZP) migrovaných faktur s tvými REÁLNĚ PODANÝMI
+přiznáními tak, že vytáhne autoritativní DUZP z tvých podaných kontrolních hlášení (KH).
+
+PROČ: Money S3 nedrží spolehlivě skutečné DUZP, které jsi podal na finanční úřad.
+- U vydaných faktur se konvence datových polí (DatUcPr vs DatVyst) v čase mění.
+- U přijatých faktur Money zná jen datum zaúčtování, ne vendorův daňový bod.
+Jediný autoritativní zdroj DUZP = tvé podané KH:
+  - sekce A.4 (vydané > 10 000 Kč): položka `c_evid_dd` (číslo dokladu) + `dppd` (DUZP)
+  - sekce B.2 (přijaté > 10 000 Kč): `dic_dod` (DIČ dodavatele) + `zakl_dane1` + `dppd`
+Malé doklady (A.5/B.3 < 10 000) jsou v KH jen agregát bez per-dokladu → zůstanou na
+datu z Money (uvnitř měsíce přesné, DPH-neutrální).
+
+VÝSTUP: SQL soubor s UPDATE příkazy. Zkontroluj a spusť proti databázi MyInvoice.
+
+KONFIGURACE (env nebo uprav níže):
+  KH_DIR   = složka s podanými KH (podsložky <rok>_<měsíc>/, uvnitř DPHKH1-*.zip nebo .pdf)
+  EXPORT   = money-export.json (z export-money.ps1)
+  OUT_SQL  = výstupní SQL
+Spuštění:  KH_DIR=... EXPORT=money-export.json python correct-duzp-from-kh.py
+"""
+import os, glob, zipfile, re, json, sys
+try:
+    import pypdf
+except ImportError:
+    pypdf = None
+
+KH_DIR  = os.environ.get("KH_DIR", r".\kontrolni-hlaseni")
+EXPORT  = os.environ.get("EXPORT", "money-export.json")
+OUT_SQL = os.environ.get("OUT_SQL", "fix-duzp.sql")
+# Regex čísla dokladu v PDF (fallback když chybí strojový XML). Uprav dle svého číslování.
+DOCNO_RE = os.environ.get("DOCNO_RE", r"\d{4,}")
+
+def conv(d):  # "DD.MM.YYYY" -> "YYYY-MM-DD"
+    p = d.replace(" ", "").split(".")
+    return "%04d-%02d-%02d" % (int(p[2]), int(p[1]), int(p[0])) if len(p) == 3 else None
+
+def kh_texts(folder):
+    """Vrátí (xml_texts, pdf_texts) pro období; preferuje strojový XML ze zipu."""
+    xmls, pdfs = [], []
+    for z in glob.glob(os.path.join(folder, "**", "DPHKH1-*.zip"), recursive=True):
+        try:
+            with zipfile.ZipFile(z) as zf:
+                for n in zf.namelist():
+                    if n.lower().endswith(".xml"):
+                        xmls.append(zf.read(n).decode("utf-8", "replace"))
+        except Exception:
+            pass
+    if not xmls and pypdf:
+        for f in glob.glob(os.path.join(folder, "DPHKH1-*.pdf")):
+            if "potvrzeni" in os.path.basename(f):
+                continue
+            try:
+                pdfs.append("\n".join(p.extract_text() for p in pypdf.PdfReader(f).pages))
+            except Exception:
+                pass
+    return xmls, pdfs
+
+def main():
+    if not os.path.isdir(KH_DIR):
+        print("CHYBA: KH_DIR neexistuje:", KH_DIR); sys.exit(1)
+    a4 = {}                # c_evid_dd (varsymbol) -> dppd     (vydané)
+    b2 = []               # (dic_bez_CZ, zaklad_round, dppd)   (přijaté)
+    for folder in sorted(glob.glob(os.path.join(KH_DIR, "[0-9]" * 4 + "_" + "[0-9]" * 2))):
+        xmls, pdfs = kh_texts(folder)
+        for x in xmls:
+            for m in re.finditer(r'<VetaA4\b[^>]*?c_evid_dd="([^"]*)"[^>]*?dppd="([^"]*)"', x):
+                a4[m.group(1).strip()] = conv(m.group(2))
+            for m in re.finditer(r'<VetaA4\b[^>]*?dppd="([^"]*)"[^>]*?c_evid_dd="([^"]*)"', x):
+                a4[m.group(2).strip()] = conv(m.group(1))
+            for m in re.finditer(r'<VetaB2\b[^>]*>', x):
+                tag = m.group(0)
+                dic = re.search(r'dic_dod="([^"]*)"', tag)
+                dp  = re.search(r'dppd="([^"]*)"', tag)
+                zb  = re.search(r'zakl_dane1="([^"]*)"', tag)
+                if dic and dp and zb:
+                    b2.append((dic.group(1).strip().upper().replace("CZ", ""),
+                               round(float(zb.group(1))), conv(dp.group(1))))
+        for t in pdfs:        # PDF fallback jen pro A.4 (číslo+datum jsou vedle sebe)
+            for m in re.finditer(r"\b(%s)\s+(\d{2}\.\d{2}\.\d{4})" % DOCNO_RE, t):
+                a4.setdefault(m.group(1), conv(m.group(2)))
+    print("KH: A.4 (vydané) %d | B.2 (přijaté) %d" % (len(a4), len(b2)))
+
+    d = json.load(open(EXPORT, encoding="utf-8"))
+    dic_by_idx = {a["index"]: (a.get("dic") or "").strip().upper().replace("CZ", "") for a in d["adresar"]}
+    from collections import defaultdict
+    b2idx = defaultdict(list)
+    for dic, base, dp in b2:
+        b2idx[(dic, base)].append(dp)
+
+    L = ["-- FÁZE 3: oprava DUZP z podaných KH (vydané A.4 + přijaté B.2)"]
+    n_v = n_p = 0
+    for inv in d["issued"]:
+        dp = a4.get(inv["doklad"])
+        if dp and dp != inv["tax_date"]:
+            L.append("UPDATE invoices SET tax_date='%s', issue_date='%s' WHERE varsymbol='%s' AND invoice_type='invoice';" % (dp, dp, inv["doklad"]))
+            n_v += 1
+    for p in d["received"]:
+        dic = dic_by_idx.get(p["dodavatel"], "")
+        base = round(p["total_with_vat"] / 1.21)
+        cand = b2idx.get((dic, base)) or b2idx.get((dic, base + 1)) or b2idx.get((dic, base - 1))
+        if cand and cand[0] and cand[0] != p["tax_date"]:
+            L.append("UPDATE purchase_invoices SET tax_date='%s' WHERE vendor_invoice_number='%s';" % (cand[0], p["doklad"]))
+            n_p += 1
+    open(OUT_SQL, "w", encoding="utf-8").write("\n".join(L) + "\n")
+    print("%s: vydané %d + přijaté %d UPDATE. Zkontroluj a spusť proti DB MyInvoice." % (OUT_SQL, n_v, n_p))
+
+if __name__ == "__main__":
+    main()

--- a/tools/money-s3-import/export-money.ps1
+++ b/tools/money-s3-import/export-money.ps1
@@ -1,0 +1,168 @@
+# === FAZE 1: Export Money S3 -> JSON (32-bit, READ-ONLY) ===
+# Cte data Money S3 pres COM (mon2kdbe.BFTable) a zapise money-export.json pro import-myinvoice.py.
+# MUSI bezet 32-bit Windows PowerShell:
+#   C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe -NoProfile -File export-money.ps1
+# (RemoteSigned policy spousti lokalni .ps1 bez -ExecutionPolicy Bypass)
+#
+# ===================== KONFIGURACE (uprav dle sebe) =====================
+$DataRoot    = if ($env:MONEY_DATA) { $env:MONEY_DATA } else { "C:\Users\Public\Documents\Solitea\Money S3\Data" }
+$AgendaName  = if ($env:MONEY_AGENDA) { $env:MONEY_AGENDA } else { "AGENDA.001" }   # ktera agenda
+$OutJson     = if ($env:MONEY_OUT) { $env:MONEY_OUT } else { "$PSScriptRoot\money-export.json" }
+$SupplierICO = if ($env:MONEY_ICO) { $env:MONEY_ICO } else { "12345678" }   # ZADEJ sve ICO (env MONEY_ICO nebo zde)            # tvoje ICO (vynecha se z klientu)
+$YearFrom    = 1; $YearTo = 10                                                        # ROK.001..ROK.010 (rozsah let)
+# =======================================================================
+$ErrorActionPreference = "Stop"
+$Agenda = "$DataRoot\$AgendaName"
+
+function NewTbl($path) { $t = New-Object -ComObject "mon2kdbe.BFTable"; $t.Open($path) | Out-Null; return $t }
+function Fmt-Date($v) { if ($v -is [datetime]) { return $v.ToString("yyyy-MM-dd") } ; if ($v) { try { return ([datetime]$v).ToString("yyyy-MM-dd") } catch { return $null } } ; return $null }
+function ColVal($t,$c) { try { return $t.Value($c) } catch { return $null } }
+
+# --- 1. AdresarF (raw poradi = index pro Odberatel/Dodavatel) ---
+Write-Host "Ctu AdresarF..."
+$adr = @()
+$t = NewTbl "$Agenda\AdresarF.DAT"; $t.Top() | Out-Null; $idx = 0
+while (-not $t.EOF) {
+  $idx++
+  $adr += [pscustomobject]@{
+    index        = $idx
+    company_name = ("" + (ColVal $t "ObchNazev"));
+    nazev        = ("" + (ColVal $t "Nazev"))
+    ic           = ("" + (ColVal $t "ICO")).Trim()
+    dic          = ("" + (ColVal $t "DIC")).Trim()
+    street       = ("" + (ColVal $t "Ulice")).Trim()
+    city         = ("" + (ColVal $t "Misto")).Trim()
+    zip          = (("" + (ColVal $t "PSC")) -replace "\s","")
+    country_code = ("" + (ColVal $t "KodStatu")).Trim()
+  }
+  $t.Next() | Out-Null
+}
+$t.Close()
+Write-Host ("  AdresarF: " + $adr.Count + " zaznamu")
+
+# --- helper: nacti hlavicky + dedup ghost (dle Doklad, ponech nejvyssi Cislo) ---
+function ReadHeaders($path, $partnerCol) {
+  $rows = @{}   # Doklad -> record (keep highest Cislo)
+  $t = NewTbl $path; $t.Top() | Out-Null
+  while (-not $t.EOF) {
+    $dok = "" + (ColVal $t "Doklad")
+    $cis = [int](ColVal $t "Cislo")
+    # DUZP = autoritativni pole PlnenoDPH (datum zd. plneni), vystaveni = Vystaveno.
+    # NE DatUcPr (datum ucetniho pripadu/zauctovani) - to muze byt o mesic pozdeji a poslalo by doklad do spatneho obdobi DPH.
+    $vyst = (ColVal $t "Vystaveno"); if (-not $vyst) { $vyst = (ColVal $t "DatUcPr") }   # fallback DatUcPr
+    $duzp = (ColVal $t "PlnenoDPH"); if (-not $duzp) { $duzp = (ColVal $t "DatUcPr") }   # fallback DatUcPr
+    $rec = [pscustomobject]@{
+      doklad   = $dok
+      cislo    = $cis
+      popis    = ("" + (ColVal $t "Popis"))
+      issue    = Fmt-Date $vyst   # datum vystaveni
+      taxdate  = Fmt-Date $duzp   # DUZP (datum zdanitelneho plneni) = obdobi DPH
+      duedate  = Fmt-Date (ColVal $t "Splatno")   # datum splatnosti
+      total    = [double](ColVal $t "CelkemSDPH")
+      paid     = Fmt-Date (ColVal $t "Uhrazeno")  # datum uhrady (prazdne = neuhrazeno)
+      mena     = ("" + (ColVal $t "Mena")).Trim()
+      kurs     = [double](ColVal $t "Kurs")
+      partner  = [int](ColVal $t $partnerCol)
+      koddph   = ("" + (ColVal $t "KodDPH"))
+      guid     = ("" + (ColVal $t "GUID"))
+      prijatdokl = ("" + (ColVal $t "PrijatDokl"))   # cislo dokladu dodavatele (jen prijate) -> KH A.2 c_evid_dd
+      dobropis = [bool](ColVal $t "Dobropis")        # priznak dobropisu (opravny danovy doklad) -> credit_note, castky zaporne
+    }
+    if (-not $rows.ContainsKey($dok) -or $rows[$dok].cislo -lt $cis) { $rows[$dok] = $rec }
+    $t.Next() | Out-Null
+  }
+  $t.Close()
+  return $rows
+}
+
+# --- helper: nacti polozky -> hash Cislo -> [polozky] ---
+function ReadItems($path) {
+  $map = @{}
+  if (-not (Test-Path $path)) { return $map }
+  $t = NewTbl $path; $t.Top() | Out-Null; $any = $false
+  while (-not $t.EOF) {
+    $any = $true
+    $cis = [int](ColVal $t "Cislo")
+    $it = [pscustomobject]@{
+      poradi = [int](ColVal $t "Poradi")
+      popis  = ("" + (ColVal $t "Popis"))
+      pocet  = [double](ColVal $t "PocetMJ")
+      cena   = [double](ColVal $t "Cena")
+      cenatyp= [int](ColVal $t "CenaTyp")
+      sazba  = [double](ColVal $t "SazbaDPH")
+      sleva  = [double](ColVal $t "Sleva")
+    }
+    if (-not $map.ContainsKey($cis)) { $map[$cis] = @() }
+    $map[$cis] += $it
+    $t.Next() | Out-Null
+  }
+  $t.Close()
+  return $map
+}
+
+# --- 2. projdi roky ROK.001..ROK.010 (2017..2026) ---
+$issued = @()
+$received = @()
+for ($r = $YearFrom; $r -le $YearTo; $r++) {
+  $year = 2016 + $r
+  $rok = "$Agenda\ROK." + ("{0:D3}" -f $r)
+  if (-not (Test-Path $rok)) { continue }
+  # vydane
+  if (Test-Path "$rok\VFaktury.DAT") {
+    $vh = ReadHeaders "$rok\VFaktury.DAT" "Odberatel"
+    $vi = ReadItems "$rok\VFaktPol.DAT"
+    foreach ($k in $vh.Keys) {
+      $h = $vh[$k]
+      $items = @()
+      if ($vi.ContainsKey($h.cislo)) { $items = $vi[$h.cislo] | Sort-Object poradi }
+      $issued += [pscustomobject]@{
+        year=$year; doklad=$h.doklad; cislo=$h.cislo; popis=$h.popis
+        issue_date=$h.issue; tax_date=$h.taxdate; due_date=$h.duedate; total_with_vat=$h.total; paid_date=$h.paid
+        mena=$h.mena; kurs=$h.kurs; odberatel=$h.partner; koddph=$h.koddph; guid=$h.guid
+        items=$items
+      }
+    }
+  }
+  # prijate
+  if (Test-Path "$rok\PFaktury.DAT") {
+    $ph = ReadHeaders "$rok\PFaktury.DAT" "Dodavatel"
+    foreach ($k in $ph.Keys) {
+      $h = $ph[$k]
+      $received += [pscustomobject]@{
+        year=$year; doklad=$h.doklad; cislo=$h.cislo; popis=$h.popis
+        issue_date=$h.issue; tax_date=$h.taxdate; due_date=$h.duedate; total_with_vat=$h.total; paid_date=$h.paid
+        mena=$h.mena; kurs=$h.kurs; dodavatel=$h.partner; koddph=$h.koddph; guid=$h.guid; prijatdokl=$h.prijatdokl; dobropis=$h.dobropis
+      }
+    }
+  }
+}
+
+$out = [pscustomobject]@{
+  exported_at = (Get-Date).ToString("s")
+  supplier_ico = $SupplierICO
+  adresar = $adr
+  issued = $issued
+  received = $received
+}
+$json = $out | ConvertTo-Json -Depth 8
+$enc = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($OutJson, $json, $enc)
+
+# --- souhrn ---
+Write-Host ""
+Write-Host "=== SOUHRN EXPORTU ==="
+Write-Host ("AdresarF zaznamu : " + $adr.Count)
+Write-Host ("Vydane faktury   : " + $issued.Count)
+Write-Host ("Prijate faktury  : " + $received.Count)
+$byYearV = $issued | Group-Object year | Sort-Object Name | ForEach-Object { $_.Name + ":" + $_.Count }
+$byYearP = $received | Group-Object year | Sort-Object Name | ForEach-Object { $_.Name + ":" + $_.Count }
+Write-Host ("Vydane/rok  : " + ($byYearV -join "  "))
+Write-Host ("Prijate/rok : " + ($byYearP -join "  "))
+$sumV = ($issued | Measure-Object total_with_vat -Sum).Sum
+$sumP = ($received | Measure-Object total_with_vat -Sum).Sum
+Write-Host ("Suma vydane (s DPH)  : " + $sumV)
+Write-Host ("Suma prijate (s DPH) : " + $sumP)
+$noItems = ($issued | Where-Object { $_.items.Count -eq 0 }).Count
+Write-Host ("Vydane bez polozek   : " + $noItems)
+Write-Host ("JSON zapsan: " + $OutJson + " (" + [math]::Round((Get-Item $OutJson).Length/1kb,1) + " kB)")
+Write-Host "HOTOVO"

--- a/tools/money-s3-import/gen-kh.py
+++ b/tools/money-s3-import/gen-kh.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Vygeneruje kontrolní hlášení (DPHKH1 XML) z MyInvoice pro všechna podaná období
+a uloží do MI_KH_DIR jako <YYYY-MM>.xml. Vstup pro `validate-kh-doklady.py`.
+
+ENV:
+  MI_URL      = adresa MyInvoice (HTTPS)
+  MI_TOKEN    = Personal Access Token
+  RETURNS_DIR = složka s podanými KH (podsložky YYYY_MM) — určuje, která období generovat
+  MI_KH_DIR   = výstupní složka (default .\\mi-kh)
+Spuštění:  MI_URL=... MI_TOKEN=... RETURNS_DIR=... python gen-kh.py
+"""
+import os, re, glob, time, urllib.request
+
+BASE = os.environ.get("MI_URL", "https://localhost:9443").rstrip("/")
+TOK  = os.environ.get("MI_TOKEN", "").strip()
+RET  = os.environ.get("RETURNS_DIR", r".\priznani-dph")
+OUT  = os.environ.get("MI_KH_DIR", r".\mi-kh")
+if not TOK:
+    raise SystemExit("CHYBA: MI_TOKEN prázdný")
+os.makedirs(OUT, exist_ok=True)
+
+def api_xml(y, m):
+    req = urllib.request.Request("%s/api/v1/reports/dphkh1?year=%d&month=%d" % (BASE, y, m))
+    req.add_header("Authorization", "Bearer " + TOK)
+    for _ in range(4):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                return r.read().decode("utf-8", "replace")
+        except Exception:
+            time.sleep(2)
+    return None
+
+n = skip = 0
+for folder in sorted(glob.glob(os.path.join(RET, "*"))):
+    b = os.path.basename(folder)
+    if not re.fullmatch(r"\d{4}_\d{2}", b):
+        continue
+    y, m = map(int, b.split("_"))
+    xml = api_xml(y, m)
+    if xml and xml.lstrip().startswith("<?xml"):
+        open(os.path.join(OUT, "%04d-%02d.xml" % (y, m)), "w", encoding="utf-8").write(xml)
+        n += 1
+    else:
+        skip += 1
+print("vygenerováno MI KH: %d, přeskočeno: %d -> %s" % (n, skip, OUT))

--- a/tools/money-s3-import/import-myinvoice.py
+++ b/tools/money-s3-import/import-myinvoice.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Money S3 -> MyInvoice import (faze 2). Cte money-export.json (vystup export-money.ps1)
+a tlaci data pres MyInvoice REST API v1. Community verze, idempotentni.
+
+CO DELA:
+  - klienti (dedup dle ICO; odberatel se urci az dle vystavenych faktur)
+  - vydane faktury vc. polozek (issue_date=DUZP, due_date=splatnost, paid_at=uhrazeno)
+  - prijate faktury (default sazba 21 %); EU porizeni s reverse-charge se detekuje
+    automaticky dle DIC dodavatele (zahranicni EU) -> DPHDP3 r.3, danove neutralni
+
+KONFIGURACE (env promenne nebo uprav nize):
+  MI_TOKEN  = API token (Personal Access Token, scope read_write)  [POVINNE]
+  MI_URL    = URL MyInvoice instance (napr. https://myinvoice.example.com:9443)
+  MI_EXPORT = cesta k money-export.json
+Spusteni:   MI_TOKEN=mi_pat_xxx  MI_URL=https://...  python import-myinvoice.py
+Idempotence: opakovane spusteni preskoci jiz existujici (dle ICO/varsymbol/cisla).
+"""
+import os, sys, json, time, urllib.request, urllib.error
+
+# ===================== KONFIGURACE =====================
+BASE      = os.environ.get("MI_URL", "https://localhost:9443").rstrip("/")
+EXPORT    = os.environ.get("MI_EXPORT", os.path.join(os.path.dirname(os.path.abspath(__file__)), "money-export.json"))
+TOKEN     = os.environ.get("MI_TOKEN", "").strip()
+DEFAULT_PURCHASE_VAT_RATE = 21          # sazba pro prijate faktury (Money je casto bez polozek)
+MARK_RECEIVED_PAID = os.environ.get("MI_MARK_PAID", "0") == "1"   # MI_MARK_PAID=1 = oznacit vsechny prijate jako paid (kdyz Money uhrady neevidoval)
+# Rucni oprava DUZP pro post-datovane faktury (Money DatUcPr = datum tisku, ne skutecne DUZP).
+# Pozna se: faktura vystavena na konci mesice s DUZP 1. dalsiho mesice. Format {"doklad":"YYYY-MM-DD"}.
+DUZP_OVERRIDE = {}                      # napr. {"2412345":"2025-01-01"}
+# ======================================================
+
+MUT_SLEEP = float(os.environ.get("MI_SLEEP", "0"))   # prodleva mezi zapisy (s); 0 = bez brzdy (vyzaduje zvednuty serverovy rate-limit, jinak 429 retry); 0.1 ≈ 600/min
+VAT_MAP = {21: 1, 12: 2, 0: 3}          # SazbaDPH -> vat_rate_id (zjisti si /api/v1/codebooks/vat-rates)
+EU_ACQUISITION_CLASS = "23"            # vat_classification kod 23 = porizeni zbozi z JCS (reverse charge) -> DPHDP3 r.3 + r.43 + KH A.2
+EU_RC_PREFIXES = {"DE","SK","AT","PL","HU","SI","NL","BE","FR","IT","ES","DK","SE","FI",
+                  "IE","PT","LU","RO","BG","HR","GR","EE","LV","LT","MT","CY"}
+if not TOKEN:
+    print("CHYBA: nastav MI_TOKEN (API token)."); sys.exit(1)
+
+def as_list(x):
+    if x is None: return []
+    if isinstance(x, dict): return [x]
+    return x if isinstance(x, list) else []
+
+def call(method, path, body=None, mut=False):
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    for _ in range(7):
+        req = urllib.request.Request(BASE + path, data=data, method=method)
+        req.add_header("Authorization", "Bearer " + TOKEN)
+        if data is not None: req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=40) as r:
+                out = r.read()
+                if mut: time.sleep(MUT_SLEEP)
+                return r.status, (json.loads(out) if out else {})
+        except urllib.error.HTTPError as e:
+            if e.code == 429:
+                ra = e.headers.get("Retry-After"); time.sleep(min(int(ra) if (ra and ra.isdigit()) else 35, 65)); continue
+            if e.code >= 500: time.sleep(5); continue
+            try: return e.code, json.loads(e.read())
+            except: return e.code, {}
+        except Exception:
+            time.sleep(4); continue
+    return 0, {"error": "retry exhausted"}
+
+def collect(o, key, acc):
+    if isinstance(o, dict):
+        for k, v in o.items():
+            if k == key and isinstance(v, str): acc.add(v)
+            else: collect(v, key, acc)
+    elif isinstance(o, list):
+        for v in o: collect(v, key, acc)
+
+def fetch_all_key(path, key):
+    acc = set(); page = 1
+    while True:
+        st, r = call("GET", "%s?per_page=200&page=%d" % (path, page))
+        if st != 200: break
+        collect(r, key, acc)
+        meta = r.get("meta") or {}
+        if page >= (meta.get("pages", 1) or 1): break
+        page += 1
+        if page > 60: break
+    return acc
+
+def ne(s, d): s = (s or "").strip(); return s if s else d
+
+def valid_ic(ic):
+    """Validace ceskeho ICO: 8 cislic + kontrolni cislice (mod 11). Cizi/nevalidni -> False."""
+    ic = (ic or "").strip()
+    if not (ic.isdigit() and len(ic) == 8): return False
+    s = sum(int(ic[i]) * (8 - i) for i in range(7))
+    return (11 - s % 11) % 10 == int(ic[7])
+
+d = json.load(open(EXPORT, encoding="utf-8"))
+SUP_ICO = d.get("supplier_ico", "")
+adr_by_idx = {a["index"]: a for a in d["adresar"]}
+
+print("== codebooks ==")
+_, cc = call("GET", "/api/v1/codebooks/countries")
+COUNTRIES = {c["iso2"]: c["id"] for c in cc}; CZ = COUNTRIES.get("CZ", 1)
+_, cur = call("GET", "/api/v1/codebooks/currencies")
+CURRENCIES = {c["code"]: c["id"] for c in cur} if isinstance(cur, list) else {}
+if not CURRENCIES: CURRENCIES = {"CZK": 1, "EUR": 2}
+
+def country_of(code, dic):
+    code = (code or "").strip().upper()
+    if code in COUNTRIES: return COUNTRIES[code]
+    pref = (dic or "").strip().upper()[:2]
+    return COUNTRIES.get(pref, CZ)
+
+print("== preload (idempotence) ==")
+ic_to_id = {}; dic_to_id = {}; page = 1
+while True:
+    st, r = call("GET", "/api/v1/clients?per_page=200&page=%d" % page)
+    if st != 200: break
+    for c in (r.get("data") or r.get("clients") or []):
+        if c.get("ic"): ic_to_id[str(c["ic"]).strip()] = c["id"]
+        if c.get("dic"): dic_to_id[str(c["dic"]).strip().upper()] = c["id"]
+    meta = r.get("meta") or {}
+    if page >= (meta.get("pages", 1) or 1): break
+    page += 1
+existing_vs  = fetch_all_key("/api/v1/invoices", "varsymbol")
+existing_vin = fetch_all_key("/api/v1/purchase-invoices", "vendor_invoice_number")
+print("  klienti(ic):%d vydane(vs):%d prijate(vin):%d" % (len(ic_to_id), len(existing_vs), len(existing_vin)))
+
+errs = []
+# ---------- KLIENTI ----------
+print("== KLIENTI ==")
+index_to_id = {}; c_new = c_skip = c_err = 0
+# Role se nastavi az ve FINALNIM pruchodu dle SKUTECNE vytvorenych faktur (ground truth) -
+# create-time odhad dle export indexu je nespolehlivy (dedup, vendor dobropisy v issued).
+real_customers = set(); real_vendors = set()   # cid -> ma vytvorenou vydanou / prijatou
+cid_body = {}                                   # cid -> telo klienta (pro finalni PUT role)
+for a in d["adresar"]:
+    if a["index"] == 1 or (a["ic"] and a["ic"] == SUP_ICO): continue
+    ic_raw = (a["ic"] or "").strip()
+    dic = (a.get("dic") or "").strip()
+    ic = ic_raw if valid_ic(ic_raw) else ""        # cizi/nevalidni ICO se nepouzije jako ic (jinak API klienta odmitne -> doklad by se preskocil)
+    if ic_raw and not ic:
+        print("  ! nevalidni ICO '%s' (%s) -> zakladam bez ICO%s" % (ic_raw, ne(a["company_name"], a.get("nazev") or "?"), (", dedup dle DIC" if dic else "")))
+    if ic and ic in ic_to_id: index_to_id[a["index"]] = ic_to_id[ic]; c_skip += 1; continue
+    if not ic and dic and dic.upper() in dic_to_id: index_to_id[a["index"]] = dic_to_id[dic.upper()]; c_skip += 1; continue
+    name = ne(a["company_name"], a.get("nazev") or ("Klient %d" % a["index"]))
+    email = (ic + "@imported.local") if ic else ((dic.lower() + "@imported.local") if dic else ("adr%d@imported.local" % a["index"]))
+    body = {"company_name": name, "street": ne(a["street"], "neuvedeno"), "city": ne(a["city"], "neuvedeno"),
+            "zip": ne(a["zip"], "00000"), "country_id": country_of(a.get("country_code"), dic),
+            "main_email": email, "language": "cs",
+            "is_customer": False, "is_vendor": True}   # default vendor (API vynuti is_customer pri obou false!); finalni pruchod opravi 4 odberatele
+    if ic: body["ic"] = ic
+    if dic: body["dic"] = dic
+    st, r = call("POST", "/api/v1/clients", body, mut=True)
+    if st == 201:
+        index_to_id[a["index"]] = r["id"]
+        if ic: ic_to_id[ic] = r["id"]
+        if dic: dic_to_id[dic.upper()] = r["id"]
+        cid_body[r["id"]] = body
+        c_new += 1
+    else:
+        c_err += 1; errs.append("KLIENT %s: %s %s" % (name, st, json.dumps(r, ensure_ascii=False)[:140]))
+print("  novych:%d skip:%d chyb:%d" % (c_new, c_skip, c_err))
+
+# ---------- VYDANE ----------
+print("== VYDANE FAKTURY ==")
+v_new = v_skip = v_err = 0
+for inv in d["issued"]:
+    vs = inv["doklad"]
+    if vs in existing_vs: v_skip += 1; continue
+    cid = index_to_id.get(inv["odberatel"])
+    if not cid: v_err += 1; errs.append("VYDANA %s: chybi klient idx %s" % (vs, inv["odberatel"])); continue
+    duzp = DUZP_OVERRIDE.get(vs, inv["tax_date"])     # DUZP = DatUcPr (s rucni opravou pro post-datovane)
+    items = []
+    for it in as_list(inv.get("items")):
+        rid = VAT_MAP.get(int(round(it["sazba"])), 1)
+        items.append({"description": ne(it["popis"], "Polozka"), "quantity": it["pocet"],
+                      "unit_price_without_vat": it["cena"], "vat_rate_id": rid})
+        if it.get("sleva"): items.append({"description": "Sleva", "quantity": 1, "unit_price_without_vat": -it["sleva"], "vat_rate_id": rid})
+    if not items:
+        items = [{"description": ne(inv["popis"], "Sluzba"), "quantity": 1,
+                  "unit_price_without_vat": round(inv["total_with_vat"]/(1+DEFAULT_PURCHASE_VAT_RATE/100), 2), "vat_rate_id": 1}]
+    body = {"client_id": cid, "invoice_type": "invoice", "currency_id": 1, "varsymbol": vs, "items": items}
+    if duzp: body["issue_date"] = duzp; body["tax_date"] = duzp     # vystaveni = DUZP
+    if inv.get("due_date"): body["due_date"] = inv["due_date"]       # splatnost (Money Splatno)
+    st, r = call("POST", "/api/v1/invoices", body, mut=True)
+    if st != 201: v_err += 1; errs.append("VYDANA %s: %s %s" % (vs, st, json.dumps(r, ensure_ascii=False)[:140])); continue
+    iid = r["id"]
+    call("POST", "/api/v1/invoices/%d/issue" % iid, {}, mut=True)
+    if inv.get("paid_date"):
+        call("POST", "/api/v1/invoices/%d/mark-paid" % iid, {"paid_at": inv["paid_date"]}, mut=True)  # pole je paid_at!
+    real_customers.add(cid)   # tento klient skutecne dostal vydanou fakturu = odberatel
+    v_new += 1
+print("  novych:%d skip:%d chyb:%d" % (v_new, v_skip, v_err))
+
+# ---------- PRIJATE (vc. auto-detekce EU reverse charge) ----------
+print("== PRIJATE FAKTURY ==")
+p_new = p_skip = p_err = p_rc = 0
+for p in d["received"]:
+    doklad = p["doklad"]
+    vend = adr_by_idx.get(p["dodavatel"], {})
+    dic_pref = (vend.get("dic") or "").strip().upper()[:2]
+    is_eu_rc = dic_pref in EU_RC_PREFIXES                 # EU porizeni s reverse charge (dle prefixu DIC dodavatele)
+    # vendor_invoice_number = cislo dokladu DODAVATELE = Money PrijatDokl (= KH c_evid_dd); fallback Money Doklad
+    vin = (p.get("prijatdokl") or "").strip() or doklad
+    if not vin or vin in existing_vin: p_skip += 1; continue
+    vid = index_to_id.get(p["dodavatel"])
+    if not vid: p_err += 1; errs.append("PRIJATA %s: chybi dodavatel idx %s" % (vin, p["dodavatel"])); continue
+    mena = (p.get("mena") or "").strip().upper()
+    kurs = p.get("kurs") or 0
+    cur_id = 1
+    item = {"description": ne(p["popis"], "Nakup"), "quantity": 1, "vat_rate_id": 1}
+    if is_eu_rc:
+        item["vat_classification_code"] = EU_ACQUISITION_CLASS   # 23 -> r.3 + r.43 + KH A.2 (MyInvoice samovymeri dan ze sazby)
+        if mena and mena != "CZK" and kurs and CURRENCIES.get(mena):
+            cur_id = CURRENCIES[mena]                             # verne v puvodni mene
+            item["unit_price_without_vat"] = round(p["total_with_vat"]/kurs, 2)   # RC = bez DPH; zaklad v cizi mene = CZK celkem / kurz; MyInvoice prepocte kurzem zpet
+        else:
+            item["unit_price_without_vat"] = p["total_with_vat"]  # fallback: zaklad rovnou v CZK
+    else:
+        item["unit_price_without_vat"] = round(p["total_with_vat"]/(1+DEFAULT_PURCHASE_VAT_RATE/100), 2)
+    is_dobropis = bool(p.get("dobropis")) or (p["total_with_vat"] < 0)   # dobropis (opravny danovy doklad) -> credit_note, castky zaporne (dle manualu MyInvoice)
+    body = {"vendor_id": vid, "vendor_invoice_number": vin,
+            "document_kind": "credit_note" if is_dobropis else "invoice", "currency_id": cur_id,
+            "reverse_charge": bool(is_eu_rc), "items": [item]}
+    duzp = p["tax_date"]
+    if cur_id != 1 and kurs: body["exchange_rate"] = kurs; body["exchange_rate_date"] = duzp
+    if p.get("issue_date"): body["issue_date"] = p["issue_date"]; body["received_at"] = p["issue_date"]
+    if duzp: body["tax_date"] = duzp
+    body["due_date"] = p.get("due_date") or p.get("issue_date") or duzp
+    st, r = call("POST", "/api/v1/purchase-invoices", body, mut=True)
+    if st != 201: p_err += 1; errs.append("PRIJATA %s: %s %s" % (vin, st, json.dumps(r, ensure_ascii=False)[:140])); continue
+    pid = r["id"]
+    call("POST", "/api/v1/purchase-invoices/%d/transition" % pid, {"target": "received"}, mut=True)
+    if p.get("paid_date") or MARK_RECEIVED_PAID:
+        pay = p.get("paid_date") or duzp or p.get("issue_date")
+        s, _ = call("POST", "/api/v1/purchase-invoices/%d/transition" % pid, {"target": "paid", "paid_date": pay}, mut=True)
+        if s not in (200, 201):
+            call("POST", "/api/v1/purchase-invoices/%d/transition" % pid, {"target": "booked"}, mut=True)
+            call("POST", "/api/v1/purchase-invoices/%d/transition" % pid, {"target": "paid", "paid_date": pay}, mut=True)
+    real_vendors.add(vid)   # tento klient skutecne dostal prijatou fakturu = dodavatel
+    if is_eu_rc: p_rc += 1
+    p_new += 1
+print("  novych:%d (z toho EU reverse-charge:%d) skip:%d chyb:%d" % (p_new, p_rc, p_skip, p_err))
+
+# ---------- FINALNI PRUCHOD: role dle skutecne vytvorenych faktur ----------
+print("== ROLE (dle skutecnych faktur) ==")
+r_cust = r_vend = 0
+for cid in sorted(real_customers | real_vendors):
+    b = dict(cid_body.get(cid) or {})
+    if not b: continue
+    b["is_customer"] = cid in real_customers
+    b["is_vendor"] = cid in real_vendors
+    call("PUT", "/api/v1/clients/%d" % cid, b, mut=True)
+    if b["is_customer"]: r_cust += 1
+    if b["is_vendor"]: r_vend += 1
+print("  odberatelu:%d dodavatelu:%d" % (r_cust, r_vend))
+
+print("\n== CHYBY (max 25) =="); [print(" -", e) for e in errs[:25]]
+print("\nHOTOVO. klienti:+%d vydane:+%d prijate:+%d chyb:%d" % (c_new, v_new, p_new, len(errs)))

--- a/tools/money-s3-import/truncate-transactional.sql
+++ b/tools/money-s3-import/truncate-transactional.sql
@@ -1,0 +1,20 @@
+-- MyInvoice — vyčištění transakčních tabulek před čistým re-importem.
+-- POZOR: smaže faktury, klienty a odvozené tabulky. NESMAŽE supplier/users/api_tokens/číselníky.
+-- Vždy nejprve plná záloha DB! (mariadb-dump)
+USE myinvoice;
+SET FOREIGN_KEY_CHECKS=0;
+TRUNCATE TABLE invoice_items;
+TRUNCATE TABLE invoice_pdfs;
+TRUNCATE TABLE invoice_attachments;
+TRUNCATE TABLE invoice_counters;
+TRUNCATE TABLE invoices;
+TRUNCATE TABLE purchase_invoice_items;
+TRUNCATE TABLE purchase_invoice_counters;
+TRUNCATE TABLE purchase_invoices;
+TRUNCATE TABLE clients;
+TRUNCATE TABLE tax_submissions;
+TRUNCATE TABLE client_revenue_cache;
+TRUNCATE TABLE project_revenue_cache;
+TRUNCATE TABLE crm_monthly_summary;
+TRUNCATE TABLE payment_matches;
+SET FOREIGN_KEY_CHECKS=1;

--- a/tools/money-s3-import/validate-dph.py
+++ b/tools/money-s3-import/validate-dph.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+FÁZE 4 (volitelná): porovná DPH vypočtenou MyInvoice proti tvým REÁLNĚ PODANÝM přiznáním.
+Kontroluje VÝSTUPNÍ DPH (ř.1) i CELOU DAŇ (dano_da) po měsících.
+
+VSTUP (stdin): měsíční součty z databáze MyInvoice ve formátu řádků:
+    YYYY-MM O <vystupni_dph>      (output = SUM(invoices.total_vat))
+    YYYY-MM I <vstupni_dph>       (input  = SUM(purchase_invoices.total_vat))
+Příklad získání z MariaDB (uprav dle svého DB jména):
+    SELECT CONCAT(YEAR(tax_date),'-',LPAD(MONTH(tax_date),2,'0')),'O',ROUND(SUM(total_vat),2)
+      FROM invoices WHERE invoice_type='invoice' AND status<>'cancelled' GROUP BY 1;
+    SELECT CONCAT(YEAR(tax_date),'-',LPAD(MONTH(tax_date),2,'0')),'I',ROUND(SUM(total_vat),2)
+      FROM purchase_invoices WHERE status<>'cancelled' GROUP BY 1;
+  ... a oba výstupy (tab/mezera oddělené) pošli na stdin tohoto skriptu.
+
+KONFIGURACE:
+  RETURNS_DIR = složka s podanými přiznáními (podsložky <rok>_<měsíc>/ s DPHDP3-*.xml / DPH_MFCR-*.xml)
+Spuštění:  <db-dump> | RETURNS_DIR=... python validate-dph.py
+"""
+import os, glob, re, sys
+RETURNS_DIR = os.environ.get("RETURNS_DIR", r".\priznani-dph")
+TOL = int(os.environ.get("TOL", "2"))   # tolerance v Kč (zaokrouhlení)
+
+OUT, IN = {}, {}
+for line in sys.stdin.read().splitlines():
+    m = re.match(r"^\s*(\d{4}-\d{2})\s+(O|I)\s+(-?[\d.]+)\s*$", line)
+    if m:
+        (OUT if m.group(2) == "O" else IN)[m.group(1)] = float(m.group(3))
+
+def filed_return(folder):
+    """Efektivní podané přiznání období: preferuje opravné, ignoruje dodatečné (rozdíly) a potvrzení."""
+    cands = []
+    for pat in ("DPHDP3-*.xml", "DPH_MFCR-*.xml"):
+        cands += glob.glob(os.path.join(folder, "**", pat), recursive=True)
+    cands = [f for f in cands if not any(s in os.path.basename(f) for s in ("potvrzeni", "pracovni", "platba"))]
+    if not cands:
+        return None
+    op = [f for f in cands if "oprav" in f.lower()]
+    if op:
+        return sorted(op)[-1]
+    main = [f for f in cands if "dodate" not in f.lower() and "dodateč" not in f.lower()]
+    return sorted(main)[-1] if main else None
+
+def attr(xml, tag, a):
+    m = re.search(r'<%s\b[^>]*\b%s="(-?\d+)"' % (tag, a), xml)
+    return int(m.group(1)) if m else None
+
+out_ok = due_ok = 0; out_mis = []; due_mis = []
+for folder in sorted(glob.glob(os.path.join(RETURNS_DIR, "[0-9]" * 4 + "_" + "[0-9]" * 2))):
+    base = os.path.basename(folder); ym = base.replace("_", "-")
+    f = filed_return(folder)
+    if not f:
+        continue
+    xml = open(f, encoding="utf-8", errors="replace").read()
+    f_out = attr(xml, "Veta1", "dan23")
+    f_due = attr(xml, "Veta6", "dano_da")
+    if f_due is None:
+        no = attr(xml, "Veta6", "dano_no")        # nadměrný odpočet = záporná daň
+        f_due = -no if no is not None else None
+    mi_out = OUT.get(ym); mi_in = IN.get(ym, 0.0)
+    if f_out is not None and mi_out is not None:
+        if abs(round(mi_out) - f_out) <= TOL: out_ok += 1
+        else: out_mis.append((ym, f_out, round(mi_out)))
+    if f_due is not None and mi_out is not None:
+        mi_due = round(mi_out - mi_in)
+        if abs(mi_due - f_due) <= TOL: due_ok += 1
+        else: due_mis.append((ym, f_due, mi_due))
+
+print("VÝSTUPNÍ DPH (ř.1): shoda %d | neshoda %d" % (out_ok, len(out_mis)))
+for m in out_mis: print("   %-9s podáno=%-9s MyInvoice=%-9s" % m)
+print("CELÁ DAŇ (dano_da):  shoda %d | neshoda %d" % (due_ok, len(due_mis)))
+for m in due_mis: print("   %-9s podáno=%-9s MyInvoice=%-9s diff=%+d" % (m[0], m[1], m[2], m[2]-m[1]))

--- a/tools/money-s3-import/validate-kh-doklady.py
+++ b/tools/money-s3-import/validate-kh-doklady.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+KONTROLA ČÍSEL DOKLADŮ A DIČ velkých faktur v kontrolním hlášení (KH) — MyInvoice vs reálně podaná KH.
+Porovná `c_evid_dd` (čísla dokladů) v sekcích:
+  - A.4 = vydané faktury > 10 000 Kč (číslo tvého dokladu),
+  - B.2 = přijaté faktury > 10 000 Kč (číslo dokladu DODAVATELE).
+Navíc u shodných čísel dokladů porovná **DIČ protistrany** (A.4 `dic_odb`, B.2 `dic_dod`, A.2 `vatid_dod`).
+Tím se ověří, že migrace dala do `vendor_invoice_number` správné číslo dodavatele (ne interní číslo),
+správné DIČ, a že doklady spadly do správných období DPH.
+
+VSTUP (env):
+  RETURNS_DIR = složka s podanými KH (podsložky <YYYY_MM>/ s DPHKH_MFCR-*.xml; opravné v <YYYY_MM>_opravne/)
+  MI_KH_DIR   = složka s KH vygenerovanými z MyInvoice, soubory pojmenované <YYYY-MM>.xml
+                (vygeneruj např.:  GET /api/v1/reports/dphkh1?year=Y&month=M  →  ulož jako 2024-03.xml)
+Spuštění:  RETURNS_DIR=... MI_KH_DIR=... python validate-kh-doklady.py
+
+Pozn.: EU pořízení zboží (reverse charge) patří do A.2. MyInvoice ho navíc listuje i v B.2 (s daní 0) —
+skript to rozpozná (B.2 navíc, které je zároveň v A.2) a hlásí zvlášť jako "RC duplicita v B.2",
+ne jako reálnou neshodu.
+"""
+import os, glob, re
+
+RETURNS_DIR = os.environ.get("RETURNS_DIR", r".\priznani-dph")
+MI_KH_DIR   = os.environ.get("MI_KH_DIR", r".\myinvoice-kh")
+
+def read(f): return open(f, encoding="utf-8", errors="replace").read()
+def evset(xml, tag):
+    out = set()
+    for m in re.findall("<" + tag + r"\b[^>]*>", xml):
+        e = re.search(r'c_evid_dd="([^"]*)"', m)
+        if e: out.add(e.group(1).strip())
+    return out
+
+def dicmap(xml, tag, dic_attr):
+    """c_evid_dd -> DIČ protistrany (A.4 dic_odb, B.2 dic_dod, A.2 vatid_dod)."""
+    out = {}
+    for m in re.findall("<" + tag + r"\b[^>]*>", xml):
+        e = re.search(r'c_evid_dd="([^"]*)"', m)
+        d = re.search(dic_attr + r'="([^"]*)"', m)
+        if e: out[e.group(1).strip()] = (d.group(1).strip() if d else "")
+    return out
+
+# podaná KH: období -> efektivní složka (opravné > řádné; dodatečné ignoruj)
+filed = {}
+for p in sorted(glob.glob(os.path.join(RETURNS_DIR, "*"))):
+    if not os.path.isdir(p): continue
+    b = os.path.basename(p); m = re.match(r"(\d{4})_(\d{2})", b)
+    if not m: continue
+    per = "%s-%s" % (m.group(1), m.group(2)); low = b.lower()
+    rank = 2 if "oprav" in low else (0 if ("dodate" in low or "dodateč" in low) else 1)
+    if per not in filed or rank > filed[per][0]: filed[per] = (rank, p)
+
+a4bad = b2bad = rcdup = miss = ok = dicbad = 0
+for per in sorted(filed):
+    folder = filed[per][1]
+    fk = glob.glob(os.path.join(folder, "DPHKH_MFCR-*.xml")) or glob.glob(os.path.join(folder, "DPHKH1-*.xml"))
+    if not fk: continue
+    mk = glob.glob(os.path.join(MI_KH_DIR, per + ".xml"))
+    if not mk:
+        miss += 1; continue
+    fx, mx = read(fk[0]), read(mk[0])
+    fA, fB = evset(fx, "VetaA4"), evset(fx, "VetaB2")
+    mA, mB, mA2 = evset(mx, "VetaA4"), evset(mx, "VetaB2"), evset(mx, "VetaA2")
+    bad = False
+    if mA != fA:
+        a4bad += 1; bad = True
+        print("  %s  A.4  chybí:%s  navíc:%s" % (per, sorted(fA - mA), sorted(mA - fA)))
+    extra, missB = mB - fB, fB - mB
+    rc, real = extra & mA2, extra - mA2     # B.2 navíc & zároveň v A.2 = EU pořízení listované i v B.2
+    if rc: rcdup += 1; print("  %s  B.2  RC duplicita (EU pořízení i v B.2): %s" % (per, sorted(rc)))
+    if real or missB:
+        b2bad += 1; bad = True
+        print("  %s  B.2  chybí:%s  navíc(mimo RC):%s" % (per, sorted(missB), sorted(real)))
+    # DIČ protistran u shodných čísel dokladů (A.4 dic_odb, B.2 dic_dod, A.2 vatid_dod)
+    dbad = False
+    for tag, attr, sec in [("VetaA4","dic_odb","A.4"), ("VetaB2","dic_dod","B.2"), ("VetaA2","vatid_dod","A.2")]:
+        fdm, mdm = dicmap(fx, tag, attr), dicmap(mx, tag, attr)
+        for ev, fdic in fdm.items():
+            if ev in mdm and mdm[ev] != fdic:
+                dbad = True
+                print("  %s  %s  DIČ neshoda doklad=%s  filed=%s  MI=%s" % (per, sec, ev, fdic, mdm[ev]))
+    if dbad: dicbad += 1; bad = True
+    if not bad and not rc: ok += 1
+
+print("\n=== SOUHRN ===")
+print("období OK:%d  A.4 čísla neshod:%d  B.2 čísla reálných neshod:%d  B.2 RC duplicit:%d  DIČ neshod (období):%d  bez MyInvoice KH:%d"
+      % (ok, a4bad, b2bad, rcdup, dicbad, miss))


### PR DESCRIPTION
## Popis

Přidává nástroj pro **migraci dat z Money S3** (Seyfor, formát BF13 `.DAT`) do MyInvoice přes **Public REST API v1**. Doplňuje stávající nativní importy (ISDOC/Pohoda/PDF, jen vydané) — migruje **kontakty + vydané faktury (vč. položek) + přijaté faktury** v jednom běhu, vč. EU pořízení v režimu reverse charge.

Umístění: `tools/money-s3-import/`. Testováno na **Money S3 26.300**, vyžaduje **MyInvoice ≥ 4.1.4**.

### Dvě fáze
1. **`export-money.ps1`** — 32-bit PowerShell, čte Money S3 přes COM (`mon2kdbe.BFTable`), **read-only** → `money-export.json`.
2. **`import-myinvoice.py`** — Python (pouze stdlib), JSON → REST API v1, **idempotentní** (přeskočí již existující dle IČO / variabilního symbolu / čísla dokladu — opakovaný běh bez duplikátů).

### Funkce
- Klienti (dedup dle IČO, validace IČO mod-11; role odběratel/dodavatel dle skutečných faktur).
- Vydané faktury vč. položek (množství, sazby DPH, sleva).
- Přijaté faktury; **auto-detekce EU reverse-charge** dle DIČ dodavatele (země mimo CZ) → věrně v původní měně + denním kurzu, samovyměření, **KH sekce A.2** (číslo dokladu dodavatele jako `c_evid_dd`).
- Datum vystavení / DUZP / splatnost / úhrada dle Money.

### Ověření
DPHDP3 i kontrolní hlášení (DPHKH1) vygenerované z naimportovaných dat se shodují s **reálně podanými přiznáními** napříč více lety. Přiložené validátory porovnávají měsíční DPH (`validate-dph.py`) a v KH **čísla dokladů i DIČ protistran** v sekcích A.4/B.2/A.2 (`validate-kh-doklady.py`).

### Záludnosti datového modelu Money S3 (řeší nástroj, popsáno v README)
- **Datum vystavení = `Vystaveno`, DUZP = `PlnenoDPH`** (autoritativní pole pro období DPH), splatnost = `Splatno`, úhrada = `Uhrazeno`. (`DatUcPr` = datum zaúčtování, může být v jiném měsíci → nepoužívat pro období DPH; jen fallback.)
- **Položky vydaných** — vazba přes sloupec `Cislo`, řádek = `PocetMJ × Cena`.
- **Klient/dodavatel** = 1-based index do `AdresarF` (sloupec `Odberatel`/`Dodavatel`).
- **Ghost záznamy** — BFTable čte i smazané/přečíslované; dedup dle `Doklad`, ponechat nejvyšší `Cislo`. Smazané *unikátní* doklady COM neoznačuje → po importu zkontrolovat anomálie.
- **Přijaté jsou v Money typicky bez položek** (header) a COM nevystavuje rozpad DPH po sazbách → importér účtuje výchozí sazbou (21 %). **Doklady se sníženou sazbou** (časopisy/periodika 10 %, potraviny 15 %) je nutné po importu opravit ručně dle dokladu (číselník historických sazeb v MyInvoice — viz #36).

### Soubory (`tools/money-s3-import/`)
`export-money.ps1`, `import-myinvoice.py`, `correct-duzp-from-kh.py` (sladění DUZP z podaných KH), `gen-kh.py` (generování MyInvoice KH pro validaci), `validate-dph.py`, `validate-kh-doklady.py`, `truncate-transactional.sql` (čistý re-import), `README.md`, `LICENSE` (MIT), `.env.example`, `.gitignore`.

### Bezpečnost / konfigurace
Vše přes proměnné prostředí (`MI_URL`, `MI_TOKEN`, `MONEY_ICO`, …) — **žádná data ani credentials v repu**; `.env.example` jako vzor, `.env` v `.gitignore`. Read-only přístup k Money.

Rád doplním cokoli (rozdělím commity, upravím umístění, doplním smoke-test postup). Děkuji za ochotu nástroj zařadit.
