### PR TITLE
fix(isdoc): správná cena položky pro faktury v cizí měně

### DIFF
--- a/api/src/Service/Import/IsdocParser.php
+++ b/api/src/Service/Import/IsdocParser.php
@@ -123,10 +123,11 @@ final class IsdocParser
             ?: null;
 
         // Items
+        $hasForeignCurrency = $currency !== $localCur;
         $items = [];
         foreach ($xpath->query('i:InvoiceLines/i:InvoiceLine', $root) ?: [] as $lineEl) {
             if (!$lineEl instanceof \DOMElement) continue;
-            $items[] = $this->parseLine($xpath, $lineEl);
+            $items[] = $this->parseLine($xpath, $lineEl, $hasForeignCurrency);
         }
 
         return [
@@ -175,14 +176,24 @@ final class IsdocParser
     /**
      * @return array<string,mixed>
      */
-    private function parseLine(\DOMXPath $xpath, \DOMElement $line): array
+    private function parseLine(\DOMXPath $xpath, \DOMElement $line, bool $hasForeignCurrency = false): array
     {
         $qtyEl = $xpath->query('i:InvoicedQuantity', $line)->item(0);
         $quantity = $qtyEl instanceof \DOMElement ? (float) $qtyEl->textContent : 1.0;
         $unit = $qtyEl instanceof \DOMElement ? ($qtyEl->getAttribute('unitCode') ?: 'ks') : 'ks';
 
-        $unitPrice = (float) ($this->text($xpath, 'i:UnitPrice', $line) ?: '0');
-        $vatRate   = (float) ($this->text($xpath, 'i:ClassifiedTaxCategory/i:Percent', $line) ?: '0');
+        if ($hasForeignCurrency) {
+            $lineAmountCurr = $this->text($xpath, 'i:LineExtensionAmountCurr', $line);
+            if ($lineAmountCurr !== '' && $quantity > 0.0) {
+                $unitPrice = (float) $lineAmountCurr / $quantity;
+            } else {
+                $unitPrice = (float) ($this->text($xpath, 'i:UnitPrice', $line) ?: '0');
+            }
+        } else {
+            $unitPrice = (float) ($this->text($xpath, 'i:UnitPrice', $line) ?: '0');
+        }
+
+        $vatRate = (float) ($this->text($xpath, 'i:ClassifiedTaxCategory/i:Percent', $line) ?: '0');
 
         return [
             'description'            => $this->text($xpath, 'i:Item/i:Description', $line),

--- a/api/tests/Unit/Service/Import/IsdocParserTest.php
+++ b/api/tests/Unit/Service/Import/IsdocParserTest.php
@@ -254,6 +254,105 @@ XML;
         self::assertSame('Praha 3', $result['invoices'][0]['client']['city']);
     }
 
+    public function testForeignCurrencyUnitPriceIsReadFromLineExtensionAmountCurr(): void
+    {
+        $ns = self::NS;
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="$ns">
+  <DocumentType>1</DocumentType>
+  <ID>2026-0007</ID>
+  <IssueDate>2026-05-04</IssueDate>
+  <LocalCurrencyCode>CZK</LocalCurrencyCode>
+  <ForeignCurrencyCode>EUR</ForeignCurrencyCode>
+  <CurrRate>24.36</CurrRate>
+  <RefCurrRate>1</RefCurrRate>
+  <PaymentMeans><Payment><Details><PaymentDueDate>2026-05-18</PaymentDueDate></Details></Payment></PaymentMeans>
+  <AccountingSupplierParty><Party><PartyIdentification><ID>01698401</ID></PartyIdentification></Party></AccountingSupplierParty>
+  <AccountingCustomerParty><Party><PartyIdentification><ID>27140130</ID></PartyIdentification></Party></AccountingCustomerParty>
+  <InvoiceLines>
+    <InvoiceLine>
+      <InvoicedQuantity unitCode="ks">1.0</InvoicedQuantity>
+      <LineExtensionAmountCurr>2520.0</LineExtensionAmountCurr>
+      <LineExtensionAmount>61387.2</LineExtensionAmount>
+      <UnitPrice>61387.2</UnitPrice>
+      <ClassifiedTaxCategory><Percent>21</Percent></ClassifiedTaxCategory>
+      <Item><Description>Vývoj systému</Description></Item>
+    </InvoiceLine>
+  </InvoiceLines>
+</Invoice>
+XML;
+        $result = $this->parser->parse($xml);
+        $item = $result['invoices'][0]['items'][0];
+        self::assertSame('EUR', $result['invoices'][0]['currency']);
+        self::assertSame(2520.0, $item['unit_price_without_vat']);
+    }
+
+    public function testForeignCurrencyMultipleQuantityUnitPriceDividedCorrectly(): void
+    {
+        $ns = self::NS;
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="$ns">
+  <DocumentType>1</DocumentType>
+  <ID>2026-0008</ID>
+  <IssueDate>2026-05-04</IssueDate>
+  <LocalCurrencyCode>CZK</LocalCurrencyCode>
+  <ForeignCurrencyCode>EUR</ForeignCurrencyCode>
+  <CurrRate>24.36</CurrRate>
+  <RefCurrRate>1</RefCurrRate>
+  <PaymentMeans><Payment><Details><PaymentDueDate>2026-05-18</PaymentDueDate></Details></Payment></PaymentMeans>
+  <AccountingSupplierParty><Party><PartyIdentification><ID>01698401</ID></PartyIdentification></Party></AccountingSupplierParty>
+  <AccountingCustomerParty><Party><PartyIdentification><ID>27140130</ID></PartyIdentification></Party></AccountingCustomerParty>
+  <InvoiceLines>
+    <InvoiceLine>
+      <InvoicedQuantity unitCode="hod">5.0</InvoicedQuantity>
+      <LineExtensionAmountCurr>500.0</LineExtensionAmountCurr>
+      <LineExtensionAmount>12180.0</LineExtensionAmount>
+      <UnitPrice>12180.0</UnitPrice>
+      <ClassifiedTaxCategory><Percent>21</Percent></ClassifiedTaxCategory>
+      <Item><Description>Konzultace</Description></Item>
+    </InvoiceLine>
+  </InvoiceLines>
+</Invoice>
+XML;
+        $result = $this->parser->parse($xml);
+        $item = $result['invoices'][0]['items'][0];
+        self::assertSame(100.0, $item['unit_price_without_vat']);
+    }
+
+    public function testForeignCurrencyFallsBackToUnitPriceWhenNoLineExtensionAmountCurr(): void
+    {
+        $ns = self::NS;
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="$ns">
+  <DocumentType>1</DocumentType>
+  <ID>2026-0009</ID>
+  <IssueDate>2026-05-04</IssueDate>
+  <LocalCurrencyCode>CZK</LocalCurrencyCode>
+  <ForeignCurrencyCode>EUR</ForeignCurrencyCode>
+  <CurrRate>24.36</CurrRate>
+  <RefCurrRate>1</RefCurrRate>
+  <PaymentMeans><Payment><Details><PaymentDueDate>2026-05-18</PaymentDueDate></Details></Payment></PaymentMeans>
+  <AccountingSupplierParty><Party><PartyIdentification><ID>01698401</ID></PartyIdentification></Party></AccountingSupplierParty>
+  <AccountingCustomerParty><Party><PartyIdentification><ID>27140130</ID></PartyIdentification></Party></AccountingCustomerParty>
+  <InvoiceLines>
+    <InvoiceLine>
+      <InvoicedQuantity unitCode="ks">1.0</InvoicedQuantity>
+      <LineExtensionAmount>61387.2</LineExtensionAmount>
+      <UnitPrice>2520.0</UnitPrice>
+      <ClassifiedTaxCategory><Percent>21</Percent></ClassifiedTaxCategory>
+      <Item><Description>Vývoj systému</Description></Item>
+    </InvoiceLine>
+  </InvoiceLines>
+</Invoice>
+XML;
+        $result = $this->parser->parse($xml);
+        $item = $result['invoices'][0]['items'][0];
+        self::assertSame(2520.0, $item['unit_price_without_vat']);
+    }
+
     public function testStreetNameWithoutBuildingNumberStaysIntact(): void
     {
         // Pokud zdrojový ISDOC od jiného systému posílá adresu v jednom poli


### PR DESCRIPTION
`<UnitPrice>` je dle ISDOC standardu vždy v lokální měně (CZK). Parser ho chybně používal jako cenu v měně faktury - u EUR faktury s kurzem 24,36 se importovalo 61 387,2 místo správných 2 520,0 EUR.

Oprava čte cenu z `<LineExtensionAmountCurr>  quantity`, což je jediné pole na úrovni řádku vyjádřené v cizí měně. Fallback na `<UnitPrice>` zůstává pro exportéry, kteří `*Curr` pole negenerují.