### PR TITLE
fix(import): paginate all Fakturoid pages — Link header is not implemented in API v3

### DIFF
--- a/api/src/Service/Import/FakturoidClient.php
+++ b/api/src/Service/Import/FakturoidClient.php
@@ -260,7 +260,10 @@ final class FakturoidClient
             foreach ($res['items'] as $item) {
                 yield $item;
             }
-            $hasMore = $res['next_page'] !== null && !empty($res['items']);
+            // Fakturoid API v3 neposílá RFC 5988 Link header (oproti komentáři u parseNextPage)
+            // — `next_page` je vždy null, takže původní podmínka ukončila smyčku po první stránce.
+            // Pokračujeme tedy dokud dostáváme plnou stránku (Fakturoid používá per_page=40).
+            $hasMore = count($res['items']) >= 40;
             $page++;
         } while ($hasMore);
     }


### PR DESCRIPTION
## Summary

When importing from a Fakturoid account, MyInvoice only ever pulls the first **40** invoices / contacts / expenses no matter how many there are. The pagination loop in `FakturoidClient::getAll()` ends after the first page because `next_page` is always `null`.

## Root cause

Fakturoid API v3 **does not emit the RFC 5988 `Link` header** despite the docblock comment that says it does:

```php
/**
 * Fakturoid používá RFC 5988 Link header pro pagination.
 * Format: <url>; rel="next", <url>; rel="last"
 */
private function parseNextPage(array $linkHeaders): ?string
```

Verified by raw `curl https://app.fakturoid.cz/api/v3/accounts/{slug}/invoices.json?page=N` — response only contains `X-RateLimit*`, `X-Request-Id`, `X-Runtime` and a few security headers. **No `Link` header on any page**.

The existing condition therefore evaluates to false after page 1, regardless of how many records exist:

```php
$hasMore = $res['next_page'] !== null && !empty($res['items']);
```

## Fix

Drop the dependency on the `Link` header and rely on the page size instead. Fakturoid uses a fixed `per_page=40` for `invoices.json`, `expenses.json`, and `subjects.json` — when we receive fewer than 40 items, we've reached the last page.

```diff
-            $hasMore = $res['next_page'] !== null && !empty($res['items']);
+            // Fakturoid API v3 neposílá RFC 5988 Link header (oproti komentáři u parseNextPage)
+            // — `next_page` je vždy null, takže původní podmínka ukončila smyčku po první stránce.
+            // Pokračujeme tedy dokud dostáváme plnou stránku (Fakturoid používá per_page=40).
+            $hasMore = count($res['items']) >= 40;
```

`parseNextPage()` is left intact in case Fakturoid ever adds the header back (or for the secondary `Link` extraction in `getAll` for `invoices.json` with multi-page; right now it's effectively dead code).

## Reproduction

Real account with **148 invoices** across 4 pages (40 + 40 + 40 + 28). Before the patch: dry-run reports `40 (z 40)`. After the patch: `148 (z 148)`.

```
Page 1 → 40 items, no Link header
Page 2 → 40 items, no Link header
Page 3 → 40 items, no Link header
Page 4 → 28 items, no Link header
Total: 148 ✅
```

## Test plan

- [ ] Run dry-run import on a Fakturoid account with > 40 invoices and confirm full count is detected
- [ ] Run real import and confirm all invoices/contacts/expenses land in DB
- [ ] Confirm idempotence — re-running shows everything as `přeskočeno (duplicita)`