### PR TITLE
fix: expose vat_classification_code on invoice item read

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3936,6 +3936,7 @@ components:
           example: 21
           description: "Snapshot procentní hodnoty DPH v okamžiku přidání položky (drží se i po případné změně sazby v číselníku)"
         vat_code: { type: string, nullable: true, example: "STD", description: "Kód sazby ze snapshot-u (STD / RED1 / RED2 / ZERO / FREE)" }
+        vat_classification_code: { type: string, nullable: true, example: "3", description: "Kód klasifikace plnění pro DPH přiznání / Kontrolní hlášení (default podle sazby + reverse charge + země klienta). U neplátce DPH bez významu." }
         total_without_vat: { type: number, format: float }
         total_vat: { type: number, format: float }
         total_with_vat: { type: number, format: float }
@@ -3957,6 +3958,7 @@ components:
         unit_price_without_vat: { type: number, format: float, description: "Jednotková cena BEZ DPH. Může být záporná pro slevový řádek, ale ne současně se záporným množstvím." }
         vat_rate_id: { type: integer, description: "FK do /codebooks/vat-rates (kontextově k supplierovi)" }
         order_index: { type: integer, description: "Pořadí v rámci faktury. Default = pozice v poli." }
+        vat_classification_code: { type: string, nullable: true, description: "Volitelný kód klasifikace plnění (DPH přiznání / KH). Když nevyplněno, server dopočítá default podle sazby + reverse charge + země klienta." }
 
     RecurringTemplate:
       type: object

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -124,6 +124,7 @@ final class InvoiceRepository
                     ii.unit_price_without_vat, ii.vat_rate_id, ii.vat_rate_snapshot,
                     ii.total_without_vat, ii.total_vat, ii.total_with_vat,
                     ii.order_index, ii.item_kind, ii.linked_work_report_id,
+                    ii.vat_classification_code,
                     vr.code AS vat_code, vr.label_cs AS vat_label_cs, vr.label_en AS vat_label_en
                FROM invoice_items ii
                JOIN vat_rates vr ON vr.id = ii.vat_rate_id

--- a/api/tests/Integration/InvoiceItemVatClassificationTest.php
+++ b/api/tests/Integration/InvoiceItemVatClassificationTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Integration;
+
+use MyInvoice\Bootstrap;
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Service\Invoice\InvoiceCalculator;
+use PDO;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regrese: itemsFor() / find() musí vracet vat_classification_code na položkách.
+ *
+ * Sloupec invoice_items.vat_classification_code je v DB vyplněný (replaceItems
+ * ho defaultuje podle sazby + reverse charge + země klienta) a slouží DPH
+ * výkazům, ale čtecí SELECT v itemsFor() ho dřív nevybíral — API ho na
+ * položkách nevracelo (jen na hlavičce faktury). To rozbíjelo GET→PUT
+ * round-trip: ruční klasifikace na řádku se při uložení zpět ztratila.
+ *
+ * Používá existující supplier/client/currency/vat_rate z dev DB; uklízí po sobě.
+ */
+#[Group('integration')]
+final class InvoiceItemVatClassificationTest extends TestCase
+{
+    private Connection $db;
+    private InvoiceRepository $repo;
+    private InvoiceCalculator $calc;
+
+    private int $clientId = 0;
+    private int $currencyId = 0;
+    private int $vatRateId = 0;
+    private int $userId = 0;
+
+    /** @var int[] */
+    private array $createdInvoiceIds = [];
+
+    protected function setUp(): void
+    {
+        $rootDir = dirname(__DIR__, 3);
+        if (!is_file($rootDir . '/cfg.php')) {
+            $this->markTestSkipped('cfg.php missing');
+        }
+
+        try {
+            $container = Bootstrap::buildApp()->getContainer();
+            if ($container === null) {
+                $this->markTestSkipped('Container not available');
+            }
+            $this->db = $container->get(Connection::class);
+            $this->repo = $container->get(InvoiceRepository::class);
+            $this->calc = $container->get(InvoiceCalculator::class);
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('DI unavailable: ' . $e->getMessage());
+        }
+
+        $pdo = $this->db->pdo();
+
+        $supplierId = (int) $pdo->query('SELECT id FROM supplier ORDER BY id LIMIT 1')->fetchColumn();
+        if ($supplierId <= 0) {
+            $this->markTestSkipped('Žádný supplier');
+        }
+
+        $stmt = $pdo->prepare('SELECT id FROM clients WHERE supplier_id = ? AND archived_at IS NULL LIMIT 1');
+        $stmt->execute([$supplierId]);
+        $this->clientId = (int) $stmt->fetchColumn();
+        if ($this->clientId <= 0) {
+            $this->markTestSkipped("Supplier #{$supplierId} nemá klienty");
+        }
+
+        $stmt = $pdo->prepare('SELECT id FROM currencies WHERE supplier_id = ? AND is_active = 1 LIMIT 1');
+        $stmt->execute([$supplierId]);
+        $this->currencyId = (int) $stmt->fetchColumn();
+        if ($this->currencyId <= 0) {
+            $this->markTestSkipped('Supplier nemá aktivní měnu');
+        }
+
+        $this->vatRateId = (int) $pdo->query(
+            'SELECT id FROM vat_rates
+              WHERE is_reverse_charge = 0
+                AND (valid_from IS NULL OR valid_from <= CURDATE())
+                AND (valid_to IS NULL OR valid_to >= CURDATE())
+              ORDER BY is_default DESC, rate_percent DESC LIMIT 1'
+        )->fetchColumn();
+        if ($this->vatRateId <= 0) {
+            $this->markTestSkipped('Žádná použitelná VAT sazba');
+        }
+
+        $this->userId = (int) $pdo->query('SELECT id FROM users ORDER BY id LIMIT 1')->fetchColumn();
+        if ($this->userId <= 0) {
+            $this->markTestSkipped('Žádný uživatel');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->db) && $this->createdInvoiceIds !== []) {
+            $pdo = $this->db->pdo();
+            foreach ($this->createdInvoiceIds as $id) {
+                $pdo->prepare('DELETE FROM invoice_items WHERE invoice_id = ?')->execute([$id]);
+                $pdo->prepare('DELETE FROM invoices WHERE id = ?')->execute([$id]);
+            }
+        }
+        if (isset($this->db)) {
+            $this->db->close();
+        }
+    }
+
+    public function testItemsForExposesVatClassificationCode(): void
+    {
+        $today = (new \DateTimeImmutable('today'))->format('Y-m-d');
+        $id = $this->repo->createDraft([
+            'invoice_type'     => 'invoice',
+            'client_id'        => $this->clientId,
+            'issue_date'       => $today,
+            'tax_date'         => $today,
+            'due_date'         => $today,
+            'currency_id'      => $this->currencyId,
+            'reverse_charge'   => false,
+            'language'         => 'cs',
+            'discount_percent' => 0,
+        ], $this->userId);
+        $this->createdInvoiceIds[] = $id;
+
+        // Položka BEZ explicitní klasifikace — replaceItems ji má dopočítat a uložit.
+        $this->repo->replaceItems($id, [[
+            'description'            => 'TEST položka (PHPUnit)',
+            'quantity'               => 1,
+            'unit'                   => 'ks',
+            'unit_price_without_vat' => 1000,
+            'vat_rate_id'            => $this->vatRateId,
+            'order_index'            => 0,
+        ]]);
+        $this->calc->recompute($id);
+
+        $items = $this->repo->itemsFor($id);
+        $this->assertNotEmpty($items, 'itemsFor() má vrátit alespoň jednu položku');
+        $item = $items[0];
+
+        $this->assertArrayHasKey(
+            'vat_classification_code',
+            $item,
+            'itemsFor() musí vracet vat_classification_code (čtecí SELECT ho dřív vynechával)'
+        );
+        $this->assertNotNull(
+            $item['vat_classification_code'],
+            'replaceItems klasifikaci defaultuje, takže po uložení nesmí být null'
+        );
+
+        // Konzistence s DB jako zdrojem pravdy.
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT vat_classification_code FROM invoice_items
+              WHERE invoice_id = ? ORDER BY order_index, id LIMIT 1'
+        );
+        $stmt->execute([$id]);
+        $this->assertSame(
+            (string) $stmt->fetchColumn(),
+            (string) $item['vat_classification_code'],
+            'Hodnota z API musí odpovídat tomu, co je v DB'
+        );
+    }
+}


### PR DESCRIPTION
## Problém

`InvoiceRepository::itemsFor()` vybírá ve `SELECT` všechny sloupce `invoice_items` **kromě `vat_classification_code`**. `GET /api/invoices/{id}` proto vrací klasifikaci plnění na hlavičce faktury, ale na položkách vždy `null` — přestože `replaceItems()` ji do DB ukládá (defaultuje podle sazby + reverse charge + země klienta přes `defaultSaleClassificationCode()`).

Důsledky:
- Konzument REST API (Make/Zapier/vlastní skripty) nevidí klasifikaci na řádcích.
- `GET → úprava → PUT` round-trip tiše zahodí ručně nastavenou klasifikaci řádku: čtení ji nevrátí, takže `PUT` ji přepíše defaultem.

## Reprodukce

Faktura, jejíž položky mají v DB `invoice_items.vat_classification_code` vyplněné (např. `3` pro tuzemské osvobozené plnění), vrací přes `GET /api/invoices/{id}` u položek `vat_classification_code: null`, zatímco hlavička má správně `3`.

## Oprava

- **`itemsFor()`** — doplněn `ii.vat_classification_code` do `SELECT`. `castItem()` vrací celý řádek, takže se pole propíše stejně jako ostatní sloupce — konzistentně s hlavičkou ve `find()`.
- **OpenAPI** — `vat_classification_code` doplněn do schématu `InvoiceItem` (čtení) i `InvoiceItemInput` (zápis; pole už `replaceItems()` akceptuje, jen nebylo dokumentované).
- **Test** — integrační regresní test `InvoiceItemVatClassificationTest` (skipuje se bez DB, stejně jako ostatní integration testy).

## Poznámka

Integrační testy jsem nespouštěl lokálně (nemám po ruce test DB), ale chování opravy je ověřené proti běžící instanci (hodnota v DB vs. odpověď API). `php -l` i validace `openapi.yaml` prošly.
