### PR TITLE
feat: dark mode with System / Light / Dark switcher

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,18 @@
     <meta name="theme-color" content="#3B2D83" />
     <meta name="robots" content="noindex, nofollow" />
     <title>MyInvoice.cz</title>
+    <script>
+      // Anti-FOUC: nastav .dark ještě před načtením appky, ať dark režim nebliká.
+      // Klíč musí sedět s composables/useTheme.ts (THEME_STORAGE_KEY).
+      (function () {
+        try {
+          var p = (localStorage.getItem('myinvoice-color-scheme') || 'auto').replace(/^"|"$/g, '');
+          if (p === 'dark' || (p !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches)) {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
 import Toaster from '@/components/Toaster.vue'
+import { useTheme } from '@/composables/useTheme'
+
+// Inicializace barevného režimu (System/Light/Dark) — aplikuje .dark na <html>.
+useTheme()
 </script>
 
 <template>

--- a/web/src/components/charts/AgingChart.vue
+++ b/web/src/components/charts/AgingChart.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { onMounted, onBeforeUnmount, ref, watch } from 'vue'
+import { onMounted, onBeforeUnmount, ref, watch, computed } from 'vue'
 import {
   Chart, BarController, BarElement, CategoryScale, LinearScale, Tooltip, Legend,
 } from 'chart.js'
+import { useChartColors, useTheme } from '@/composables/useTheme'
 
 Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip, Legend)
 
@@ -20,8 +21,14 @@ const props = defineProps<{
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+const colors = useChartColors()
+const { isDark } = useTheme()
 
-const palette = ['#4CAF7A', '#A99CD8', '#E8A547', '#D45B5B', '#7A2E2E']
+// Semantic gradient stáří pohledávek. V dark je nejtmavší maroon (90+) nahrazen
+// světlejší červenou, aby na tmavém pozadí nesplýval.
+const palette = computed(() => isDark.value
+  ? ['#4CAF7A', '#A99CD8', '#E8A547', '#D45B5B', '#E07A7A']
+  : ['#4CAF7A', '#A99CD8', '#E8A547', '#D45B5B', '#7A2E2E'])
 const bucketKeys = ['current', 'b1_30', 'b31_60', 'b61_90', 'b90_plus'] as const
 const bucketLabels = ['Aktuální', '1–30 dní', '31–60 dní', '61–90 dní', '90+ dní']
 
@@ -33,7 +40,7 @@ function build() {
   const datasets = bucketKeys.map((k, idx) => ({
     label: bucketLabels[idx],
     data: props.rows.map(r => r[k]),
-    backgroundColor: palette[idx],
+    backgroundColor: palette.value[idx],
     borderRadius: 2,
     stack: 'agg',
   }))
@@ -48,9 +55,9 @@ function build() {
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
-        legend: { position: 'bottom', labels: { boxWidth: 12, font: { size: 11 }, color: '#5A5470' } },
+        legend: { position: 'bottom', labels: { boxWidth: 12, font: { size: 11 }, color: colors.value.tick } },
         tooltip: {
-          backgroundColor: '#15131D',
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => {
               const cur = props.rows[ctx.dataIndex]?.currency ?? ''
@@ -60,8 +67,8 @@ function build() {
         },
       },
       scales: {
-        x: { stacked: true, beginAtZero: true, ticks: { color: '#7A748C', font: { size: 11 } }, grid: { color: '#E7E3EE' } },
-        y: { stacked: true, ticks: { color: '#7A748C', font: { size: 11 } }, grid: { display: false } },
+        x: { stacked: true, beginAtZero: true, ticks: { color: colors.value.tick, font: { size: 11 } }, grid: { color: colors.value.grid } },
+        y: { stacked: true, ticks: { color: colors.value.tick, font: { size: 11 } }, grid: { display: false } },
       },
     },
   })
@@ -70,6 +77,7 @@ function build() {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => props.rows, build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/CumulativeYtdChart.vue
+++ b/web/src/components/charts/CumulativeYtdChart.vue
@@ -12,6 +12,7 @@ import {
   Legend,
   Filler,
 } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(LineController, LineElement, PointElement, CategoryScale, LinearScale, Tooltip, Legend, Filler)
 
@@ -31,6 +32,7 @@ const props = defineProps<{
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
 const { locale, t } = useI18n()
+const colors = useChartColors()
 
 const seriesData = computed(() => {
   const now = new Date()
@@ -81,25 +83,25 @@ function build() {
         {
           label: `${thisYear}`,
           data: thisCum,
-          borderColor: '#5C45A0',
+          borderColor: colors.value.primary,
           backgroundColor: 'rgba(92, 69, 160, 0.15)',
           borderWidth: 2.5,
           tension: 0.3,
           pointRadius: 3,
-          pointBackgroundColor: '#5C45A0',
+          pointBackgroundColor: colors.value.primary,
           fill: true,
           spanGaps: false,
         },
         {
           label: `${prevYear}`,
           data: prevCum,
-          borderColor: '#A99CD8',
+          borderColor: colors.value.primarySoft,
           backgroundColor: 'transparent',
           borderWidth: 2,
           borderDash: [5, 4],
           tension: 0.3,
           pointRadius: 2,
-          pointBackgroundColor: '#A99CD8',
+          pointBackgroundColor: colors.value.primarySoft,
         },
       ],
     },
@@ -108,9 +110,9 @@ function build() {
       maintainAspectRatio: false,
       interaction: { mode: 'index', intersect: false },
       plugins: {
-        legend: { position: 'bottom', labels: { font: { size: 11 }, boxWidth: 12, color: '#5A5470' } },
+        legend: { position: 'bottom', labels: { font: { size: 11 }, boxWidth: 12, color: colors.value.tick } },
         tooltip: {
-          backgroundColor: '#15131D',
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => `${ctx.dataset.label}: ${formatVal(Number(ctx.parsed.y || 0))} ${props.currency}`,
           },
@@ -119,10 +121,10 @@ function build() {
       scales: {
         y: {
           beginAtZero: true,
-          ticks: { color: '#7A748C', font: { size: 11 }, callback: (v) => formatTick(Number(v)) },
-          grid: { color: '#E7E3EE' },
+          ticks: { color: colors.value.tick, font: { size: 11 }, callback: (v) => formatTick(Number(v)) },
+          grid: { color: colors.value.grid },
         },
-        x: { ticks: { color: '#7A748C', font: { size: 11 } }, grid: { display: false } },
+        x: { ticks: { color: colors.value.tick, font: { size: 11 } }, grid: { display: false } },
       },
     },
   })
@@ -131,6 +133,7 @@ function build() {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => [props.months, props.prevYear, props.currency, locale.value], build, { deep: true })
+watch(colors, build)
 // Použito jen pro odlišení od dashboard chartu — t() pro budoucí i18n hover labelů.
 void t
 </script>

--- a/web/src/components/charts/InvoiceSizeChart.vue
+++ b/web/src/components/charts/InvoiceSizeChart.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { onMounted, onBeforeUnmount, ref, watch } from 'vue'
+import { onMounted, onBeforeUnmount, ref, watch, computed } from 'vue'
 import {
   Chart, BarController, BarElement, CategoryScale, LinearScale, Tooltip,
 } from 'chart.js'
+import { useChartColors, useTheme } from '@/composables/useTheme'
 
 Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip)
 
@@ -12,8 +13,13 @@ const props = defineProps<{
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+const colors = useChartColors()
+const { isDark } = useTheme()
 
-const palette = ['#A99CD8', '#6753AE', '#3B2D83', '#15131D']
+// Gradient velikosti faktur; v dark posunutý do viditelného rozsahu (nejtmavší indigo splývá).
+const palette = computed(() => isDark.value
+  ? ['#6753AE', '#8675C5', '#A99CD8', '#C9C0E9']
+  : ['#A99CD8', '#6753AE', '#3B2D83', '#15131D'])
 
 function formatCzk(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M Kč'
@@ -31,7 +37,7 @@ function build() {
       labels: props.buckets.map(b => b.label),
       datasets: [{
         data: props.buckets.map(b => b.count),
-        backgroundColor: props.buckets.map((_, i) => palette[i] ?? '#5C45A0'),
+        backgroundColor: props.buckets.map((_, i) => palette.value[i] ?? '#5C45A0'),
         borderRadius: 4,
       }],
     },
@@ -41,7 +47,7 @@ function build() {
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: '#15131D',
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => {
               const b = props.buckets[ctx.dataIndex]
@@ -51,8 +57,8 @@ function build() {
         },
       },
       scales: {
-        y: { beginAtZero: true, ticks: { precision: 0, color: '#7A748C', font: { size: 11 } }, grid: { color: '#E7E3EE' } },
-        x: { ticks: { color: '#7A748C', font: { size: 11 } }, grid: { display: false } },
+        y: { beginAtZero: true, ticks: { precision: 0, color: colors.value.tick, font: { size: 11 } }, grid: { color: colors.value.grid } },
+        x: { ticks: { color: colors.value.tick, font: { size: 11 } }, grid: { display: false } },
       },
     },
   })
@@ -61,6 +67,7 @@ function build() {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => props.buckets, build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/MonthlyRevenueChart.vue
+++ b/web/src/components/charts/MonthlyRevenueChart.vue
@@ -8,6 +8,7 @@ import {
   LinearScale,
   Tooltip,
 } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip)
 
@@ -19,6 +20,7 @@ const props = defineProps<{
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+const colors = useChartColors()
 
 function build() {
   if (!canvas.value) return
@@ -31,7 +33,7 @@ function build() {
       datasets: [
         {
           data: props.values,
-          backgroundColor: '#5C45A0',
+          backgroundColor: colors.value.primary,
           borderRadius: 4,
         },
       ],
@@ -42,7 +44,7 @@ function build() {
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: '#15131D',
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => `${formatVal(ctx.parsed.y ?? 0)} ${props.currency}`,
           },
@@ -51,11 +53,11 @@ function build() {
       scales: {
         y: {
           beginAtZero: true,
-          ticks: { color: '#7A748C', font: { size: 11 }, callback: (v) => formatTick(Number(v)) },
-          grid: { color: '#E7E3EE' },
+          ticks: { color: colors.value.tick, font: { size: 11 }, callback: (v) => formatTick(Number(v)) },
+          grid: { color: colors.value.grid },
         },
         x: {
-          ticks: { color: '#7A748C', font: { size: 10 }, maxRotation: 45, minRotation: 45 },
+          ticks: { color: colors.value.tick, font: { size: 10 }, maxRotation: 45, minRotation: 45 },
           grid: { display: false },
         },
       },
@@ -76,6 +78,7 @@ function formatTick(n: number): string {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => [props.labels, props.values, props.currency], build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/PaymentDaysHistogramChart.vue
+++ b/web/src/components/charts/PaymentDaysHistogramChart.vue
@@ -3,6 +3,7 @@ import { onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import {
   Chart, BarController, BarElement, CategoryScale, LinearScale, Tooltip,
 } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip)
 
@@ -12,6 +13,7 @@ const props = defineProps<{
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+const colors = useChartColors()
 
 const palette = ['#4CAF7A', '#A99CD8', '#E8A547', '#D45B5B']
 
@@ -21,24 +23,24 @@ function build() {
 
   const labels = props.buckets.map(b => b.label)
   const data = props.buckets.map(b => b.count)
-  const colors = props.buckets.map((_, i) => palette[i] ?? '#5C45A0')
+  const barColors = props.buckets.map((_, i) => palette[i] ?? '#5C45A0')
 
   chart = new Chart(canvas.value, {
     type: 'bar',
-    data: { labels, datasets: [{ data, backgroundColor: colors, borderRadius: 4 }] },
+    data: { labels, datasets: [{ data, backgroundColor: barColors, borderRadius: 4 }] },
     options: {
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: '#15131D',
+          backgroundColor: colors.value.tooltipBg,
           callbacks: { label: (ctx) => ` ${ctx.parsed.y} faktur` },
         },
       },
       scales: {
-        y: { beginAtZero: true, ticks: { precision: 0, color: '#7A748C', font: { size: 11 } }, grid: { color: '#E7E3EE' } },
-        x: { ticks: { color: '#7A748C', font: { size: 11 } }, grid: { display: false } },
+        y: { beginAtZero: true, ticks: { precision: 0, color: colors.value.tick, font: { size: 11 } }, grid: { color: colors.value.grid } },
+        x: { ticks: { color: colors.value.tick, font: { size: 11 } }, grid: { display: false } },
       },
     },
   })
@@ -47,6 +49,7 @@ function build() {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => props.buckets, build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/ProjectStatusChart.vue
+++ b/web/src/components/charts/ProjectStatusChart.vue
@@ -2,6 +2,7 @@
 import { onMounted, onBeforeUnmount, ref, watch, computed } from 'vue'
 import { Chart, DoughnutController, ArcElement, Tooltip, Legend } from 'chart.js'
 import { useI18n } from 'vue-i18n'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(DoughnutController, ArcElement, Tooltip, Legend)
 
@@ -9,6 +10,7 @@ const { t } = useI18n()
 const props = defineProps<{ counts: Record<string, number> }>()
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+const colors = useChartColors()
 
 const palette: Record<string, string> = {
   active: '#4CAF7A',
@@ -40,13 +42,14 @@ function build() {
   const total = valueArr.reduce((s, v) => s + v, 0)
   chart = new Chart(canvas.value, {
     type: 'doughnut',
-    data: { labels: labelArr, datasets: [{ data: valueArr, backgroundColor: colorArr, borderWidth: 1, borderColor: '#FFFFFF' }] },
+    data: { labels: labelArr, datasets: [{ data: valueArr, backgroundColor: colorArr, borderWidth: 1, borderColor: colors.value.border }] },
     options: {
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
-        legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 } } },
+        legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 }, color: colors.value.tick } },
         tooltip: {
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => {
               const v = ctx.parsed as number
@@ -64,6 +67,7 @@ function build() {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => props.counts, build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/PurchaseStatusChart.vue
+++ b/web/src/components/charts/PurchaseStatusChart.vue
@@ -2,6 +2,7 @@
 import { onMounted, onBeforeUnmount, ref, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Chart, DoughnutController, ArcElement, Tooltip, Legend } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(DoughnutController, ArcElement, Tooltip, Legend)
 
@@ -13,6 +14,7 @@ const props = defineProps<{ counts: Record<string, number> }>()
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
 const { t, locale } = useI18n()
+const colors = useChartColors()
 
 const palette: Record<string, string> = {
   paid:      '#4CAF7A',
@@ -52,14 +54,15 @@ function build() {
     type: 'doughnut',
     data: {
       labels: labelArr,
-      datasets: [{ data: valueArr, backgroundColor: colorArr, borderWidth: 1, borderColor: '#FFFFFF' }],
+      datasets: [{ data: valueArr, backgroundColor: colorArr, borderWidth: 1, borderColor: colors.value.border }],
     },
     options: {
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
-        legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 } } },
+        legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 }, color: colors.value.tick } },
         tooltip: {
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => {
               const v = ctx.parsed as number
@@ -78,6 +81,7 @@ onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => props.counts, build, { deep: true })
 watch(() => locale.value, build)
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/RevenueChart.vue
+++ b/web/src/components/charts/RevenueChart.vue
@@ -13,6 +13,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(BarController, BarElement, LineController, LineElement, PointElement, CategoryScale, LinearScale, Tooltip, Legend)
 
@@ -26,6 +27,7 @@ const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
 
 const { locale } = useI18n()
+const colors = useChartColors()
 
 /** Label „04/2026" — měsíc/rok podle aktuální řady (months). */
 function labelFor(ym: string): string {
@@ -49,19 +51,19 @@ function build() {
         {
           label: `${props.currency}`,
           data,
-          backgroundColor: '#5C45A0',
+          backgroundColor: colors.value.primary,
           borderRadius: 4,
         },
         {
           label: `${props.currency} (-1y)`,
           data: prevData,
           type: 'line',
-          borderColor: '#A99CD8',
+          borderColor: colors.value.primarySoft,
           backgroundColor: 'transparent',
           borderWidth: 2,
           tension: 0.3,
           pointRadius: 3,
-          pointBackgroundColor: '#A99CD8',
+          pointBackgroundColor: colors.value.primarySoft,
         },
       ],
     },
@@ -72,10 +74,10 @@ function build() {
       plugins: {
         legend: {
           position: 'bottom',
-          labels: { font: { size: 11 }, boxWidth: 12, color: '#5A5470' },
+          labels: { font: { size: 11 }, boxWidth: 12, color: colors.value.tick },
         },
         tooltip: {
-          backgroundColor: '#15131D',
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             // Prev-year tooltip ukazuje, ze kterého měsíce předchozího roku hodnota pochází.
             title: (items) => {
@@ -92,11 +94,11 @@ function build() {
       scales: {
         y: {
           beginAtZero: true,
-          ticks: { color: '#7A748C', font: { size: 11 }, callback: (v) => formatTick(Number(v)) },
-          grid: { color: '#E7E3EE' },
+          ticks: { color: colors.value.tick, font: { size: 11 }, callback: (v) => formatTick(Number(v)) },
+          grid: { color: colors.value.grid },
         },
         x: {
-          ticks: { color: '#7A748C', font: { size: 11 } },
+          ticks: { color: colors.value.tick, font: { size: 11 } },
           grid: { display: false },
         },
       },
@@ -117,6 +119,7 @@ function formatTick(n: number): string {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => [props.months, props.prevYear, props.currency, locale.value], build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/SparklineChart.vue
+++ b/web/src/components/charts/SparklineChart.vue
@@ -3,6 +3,7 @@ import { onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import {
   Chart, BarController, BarElement, CategoryScale, LinearScale, Tooltip,
 } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip)
 
@@ -21,6 +22,7 @@ const props = defineProps<{
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+const colors = useChartColors()
 
 function build() {
   if (!canvas.value) return
@@ -33,7 +35,7 @@ function build() {
       labels: props.labels,
       datasets: [{
         data: props.values,
-        backgroundColor: props.color ?? '#5C45A0',
+        backgroundColor: props.color ?? colors.value.primary,
         borderRadius: 1.5,
         barPercentage: 0.85,
         categoryPercentage: 0.95,
@@ -45,7 +47,7 @@ function build() {
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: '#15131D',
+          backgroundColor: colors.value.tooltipBg,
           displayColors: false,
           callbacks: { label: (ctx) => ` ${ctx.label}: ${formatter(Number(ctx.parsed.y || 0))}` },
         },
@@ -61,6 +63,7 @@ function build() {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => [props.labels, props.values, props.color], build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/StatusDoughnutChart.vue
+++ b/web/src/components/charts/StatusDoughnutChart.vue
@@ -2,6 +2,7 @@
 import { onMounted, onBeforeUnmount, ref, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Chart, DoughnutController, ArcElement, Tooltip, Legend } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(DoughnutController, ArcElement, Tooltip, Legend)
 
@@ -9,6 +10,7 @@ const props = defineProps<{ counts: Record<string, number> }>()
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
 const { t, locale } = useI18n()
+const colors = useChartColors()
 
 const palette: Record<string, string> = {
   paid:      '#4CAF7A',
@@ -50,14 +52,15 @@ function build() {
     type: 'doughnut',
     data: {
       labels: labelArr,
-      datasets: [{ data: valueArr, backgroundColor: colorArr, borderWidth: 1, borderColor: '#FFFFFF' }],
+      datasets: [{ data: valueArr, backgroundColor: colorArr, borderWidth: 1, borderColor: colors.value.border }],
     },
     options: {
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
-        legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 } } },
+        legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 }, color: colors.value.tick } },
         tooltip: {
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => {
               const v = ctx.parsed as number
@@ -76,6 +79,7 @@ onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => props.counts, build, { deep: true })
 watch(() => locale.value, build)
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/TopClientsPieChart.vue
+++ b/web/src/components/charts/TopClientsPieChart.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { Chart, DoughnutController, ArcElement, Tooltip, Legend } from 'chart.js'
 import type { TopClient } from '@/api/dashboard'
 import { formatMoney } from '@/composables/useFormat'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(DoughnutController, ArcElement, Tooltip, Legend)
 
@@ -14,12 +15,7 @@ const props = defineProps<{ clients: TopClient[] }>()
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
 const { t, locale } = useI18n()
-
-// Indigo gradient palette
-const palette = [
-  '#3B2D83', '#5C45A0', '#6753AE', '#8675C5', '#A99CD8',
-  '#C9C0E9', '#E5E0F4', '#F4A261', '#E8A547', '#4CAF7A',
-]
+const colors = useChartColors()
 
 const sliceData = computed(() => {
   if (props.clients.length === 0) return { labels: [] as string[], values: [] as number[] }
@@ -47,9 +43,9 @@ function build() {
       labels,
       datasets: [{
         data: values,
-        backgroundColor: labels.map((_, i) => palette[i % palette.length]),
+        backgroundColor: labels.map((_, i) => colors.value.palette[i % colors.value.palette.length]),
         borderWidth: 1,
-        borderColor: '#FFFFFF',
+        borderColor: colors.value.border,
       }],
     },
     options: {
@@ -58,9 +54,10 @@ function build() {
       plugins: {
         legend: {
           position: 'right',
-          labels: { boxWidth: 12, font: { size: 11 } },
+          labels: { boxWidth: 12, font: { size: 11 }, color: colors.value.tick },
         },
         tooltip: {
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => {
               const v = ctx.parsed as number
@@ -79,6 +76,7 @@ onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => props.clients, build, { deep: true })
 watch(() => locale.value, build)
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/TopProjectsBarChart.vue
+++ b/web/src/components/charts/TopProjectsBarChart.vue
@@ -3,6 +3,7 @@ import { onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import {
   Chart, BarController, BarElement, CategoryScale, LinearScale, Tooltip,
 } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(BarController, BarElement, CategoryScale, LinearScale, Tooltip)
 
@@ -16,13 +17,14 @@ const props = defineProps<{
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+const colors = useChartColors()
 
 function build() {
   if (!canvas.value) return
   if (chart) chart.destroy()
 
   const greyed = new Set(props.greyedIndexes ?? [])
-  const colors = props.values.map((_, i) => greyed.has(i) ? '#A99CD8' : '#5C45A0')
+  const barColors = props.values.map((_, i) => greyed.has(i) ? colors.value.primarySoft : colors.value.primary)
 
   chart = new Chart(canvas.value, {
     type: 'bar',
@@ -30,7 +32,7 @@ function build() {
       labels: props.labels,
       datasets: [{
         data: props.values,
-        backgroundColor: colors,
+        backgroundColor: barColors,
         borderRadius: 4,
       }],
     },
@@ -41,7 +43,7 @@ function build() {
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: '#15131D',
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => `${formatVal(ctx.parsed.x ?? 0)} ${props.currency}`,
           },
@@ -50,11 +52,11 @@ function build() {
       scales: {
         x: {
           beginAtZero: true,
-          ticks: { color: '#7A748C', font: { size: 11 }, callback: (v) => formatTick(Number(v)) },
-          grid: { color: '#E7E3EE' },
+          ticks: { color: colors.value.tick, font: { size: 11 }, callback: (v) => formatTick(Number(v)) },
+          grid: { color: colors.value.grid },
         },
         y: {
-          ticks: { color: '#403B52', font: { size: 11 }, autoSkip: false },
+          ticks: { color: colors.value.tick, font: { size: 11 }, autoSkip: false },
           grid: { display: false },
         },
       },
@@ -74,6 +76,7 @@ function formatTick(n: number): string {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => [props.labels, props.values, props.currency], build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/charts/VatBreakdownChart.vue
+++ b/web/src/components/charts/VatBreakdownChart.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onBeforeUnmount, ref, watch, computed } from 'vue'
 import { Chart, DoughnutController, ArcElement, Tooltip, Legend } from 'chart.js'
+import { useChartColors } from '@/composables/useTheme'
 
 Chart.register(DoughnutController, ArcElement, Tooltip, Legend)
 
@@ -15,6 +16,7 @@ const props = defineProps<{
 
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
+const colors = useChartColors()
 
 // Barevné mapování podle obvyklých CZ sazeb (21 % red, 12 % blue, 0 % grey, RC purple).
 const palette: Record<string, string> = {
@@ -41,17 +43,18 @@ function build() {
   const total = items.reduce((s, i) => s + i.base, 0)
   const labels = items.map(i => i.label)
   const data = items.map(i => i.base)
-  const colors = items.map(i => palette[i.label] ?? '#5C45A0')
+  const segmentColors = items.map(i => palette[i.label] ?? '#5C45A0')
 
   chart = new Chart(canvas.value, {
     type: 'doughnut',
-    data: { labels, datasets: [{ data, backgroundColor: colors, borderWidth: 1, borderColor: '#FFFFFF' }] },
+    data: { labels, datasets: [{ data, backgroundColor: segmentColors, borderWidth: 1, borderColor: colors.value.border }] },
     options: {
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
-        legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 } } },
+        legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 }, color: colors.value.tick } },
         tooltip: {
+          backgroundColor: colors.value.tooltipBg,
           callbacks: {
             label: (ctx) => {
               const v = ctx.parsed as number
@@ -69,6 +72,7 @@ function build() {
 onMounted(build)
 onBeforeUnmount(() => chart?.destroy())
 watch(() => [props.items, props.currency], build, { deep: true })
+watch(colors, build)
 </script>
 
 <template>

--- a/web/src/components/documents/EntityLinkPicker.vue
+++ b/web/src/components/documents/EntityLinkPicker.vue
@@ -105,7 +105,7 @@ onBeforeUnmount(() => { if (debounce) clearTimeout(debounce) })
 
     <div
       v-if="open"
-      class="absolute z-30 mt-1 w-full bg-white border border-neutral-200 rounded-lg shadow-lg max-h-80 overflow-auto"
+      class="absolute z-30 mt-1 w-full bg-surface border border-neutral-200 rounded-lg shadow-lg max-h-80 overflow-auto"
     >
       <div v-if="query.trim().length < 2" class="px-3 py-3 text-sm text-neutral-400">
         {{ t('documents.search_hint') }}

--- a/web/src/components/documents/LinkedDocumentsPanel.vue
+++ b/web/src/components/documents/LinkedDocumentsPanel.vue
@@ -71,7 +71,7 @@ onMounted(load)
 </script>
 
 <template>
-  <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4">
+  <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4">
     <div class="flex items-center justify-between mb-3">
       <h3 class="text-sm font-medium text-neutral-700 flex items-center gap-2">
         <svg class="w-4 h-4 text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/web/src/components/documents/TagInput.vue
+++ b/web/src/components/documents/TagInput.vue
@@ -76,7 +76,7 @@ function onKeydown(e: KeyboardEvent) {
         @keydown="onKeydown"
       />
     </div>
-    <ul v-if="open && suggestions.length" class="absolute z-30 mt-1 w-full bg-white border border-neutral-200 rounded-lg shadow-lg max-h-56 overflow-auto py-1">
+    <ul v-if="open && suggestions.length" class="absolute z-30 mt-1 w-full bg-surface border border-neutral-200 rounded-lg shadow-lg max-h-56 overflow-auto py-1">
       <li
         v-for="(s, i) in suggestions"
         :key="s.id"

--- a/web/src/components/layout/AppLayout.vue
+++ b/web/src/components/layout/AppLayout.vue
@@ -7,6 +7,7 @@ import { useSupplierStore } from '@/stores/supplier'
 import { updateApi, type PublicVersion } from '@/api/update'
 import SupplierSwitcher from './SupplierSwitcher.vue'
 import GlobalSearch from './GlobalSearch.vue'
+import ThemeToggle from './ThemeToggle.vue'
 
 const { t, locale } = useI18n()
 function setLocale(l: 'cs' | 'en') {
@@ -249,7 +250,7 @@ onMounted(async () => {
   <div class="min-h-screen flex flex-col bg-neutral-50">
 
     <!-- ═════════════════════ TOPBAR ═════════════════════ -->
-    <header class="sticky top-0 z-30 bg-white border-b border-neutral-200">
+    <header class="sticky top-0 z-30 bg-surface border-b border-neutral-200">
       <div class="h-14 px-4 flex items-center justify-between gap-3">
         <!-- Logo -->
         <RouterLink to="/" class="flex items-center gap-2.5 shrink-0" @click="mobileOpen = false">
@@ -296,6 +297,9 @@ onMounted(async () => {
               </svg>
             </button>
           </div>
+
+          <!-- Přepínač motivu (System / Light / Dark) -->
+          <ThemeToggle />
 
           <!-- Nápověda -->
           <a
@@ -352,7 +356,7 @@ onMounted(async () => {
       <!-- Mobile backdrop -->
       <div
         v-if="mobileOpen" @click="mobileOpen = false"
-        class="lg:hidden fixed inset-0 bg-neutral-900/30 z-20"
+        class="lg:hidden fixed inset-0 bg-black/50 z-20"
         aria-hidden="true"
       ></div>
 
@@ -361,7 +365,7 @@ onMounted(async () => {
         :class="[
           'fixed lg:sticky top-14 z-30 lg:z-auto',
           'h-[calc(100vh-3.5rem)] w-60 shrink-0',
-          'bg-white border-r border-neutral-200',
+          'bg-surface border-r border-neutral-200',
           'flex flex-col',
           'transition-transform duration-200 ease-in-out',
           mobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
@@ -448,7 +452,7 @@ onMounted(async () => {
             </div>
             <a
               href="/manual" target="_blank" rel="noopener"
-              class="inline-flex w-9 h-9 items-center justify-center rounded-md text-neutral-600 hover:bg-white"
+              class="inline-flex w-9 h-9 items-center justify-center rounded-md text-neutral-600 hover:bg-surface"
               :title="t('nav.help')"
             >
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -457,7 +461,7 @@ onMounted(async () => {
             </a>
           </div>
           <div class="flex items-center justify-between gap-3">
-            <div class="inline-flex items-center border border-neutral-200 bg-white rounded-md overflow-hidden">
+            <div class="inline-flex items-center border border-neutral-200 bg-surface rounded-md overflow-hidden">
               <button
                 @click="setLocale('cs')" title="Čeština"
                 class="cursor-pointer h-9 px-3 inline-flex items-center"
@@ -486,7 +490,7 @@ onMounted(async () => {
             </div>
             <button
               @click="logout"
-              class="cursor-pointer px-4 h-9 text-sm border border-neutral-300 rounded-md text-neutral-700 hover:bg-white"
+              class="cursor-pointer px-4 h-9 text-sm border border-neutral-300 rounded-md text-neutral-700 hover:bg-surface"
             >{{ t('nav.logout') }}</button>
           </div>
         </div>

--- a/web/src/components/layout/AppShell.vue
+++ b/web/src/components/layout/AppShell.vue
@@ -6,7 +6,7 @@ const { t } = useI18n()
 
 <template>
   <div class="min-h-screen flex flex-col bg-neutral-50">
-    <header class="border-b border-neutral-200 bg-white">
+    <header class="border-b border-neutral-200 bg-surface">
       <div class="max-w-6xl mx-auto px-6 py-4 flex items-center gap-3">
         <img src="/styles/logo.svg" alt="MyInvoice" class="w-9 h-9" />
         <div>

--- a/web/src/components/layout/GlobalSearch.vue
+++ b/web/src/components/layout/GlobalSearch.vue
@@ -137,7 +137,7 @@ onBeforeUnmount(() => clearTimeout(debounceTimer))
         v-model="q"
         type="text"
         :placeholder="t('search.placeholder')"
-        class="w-full pl-8 pr-3 py-1.5 text-sm rounded-md border border-neutral-200 bg-neutral-50 focus:bg-white focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
+        class="w-full pl-8 pr-3 py-1.5 text-sm rounded-md border border-neutral-200 bg-neutral-50 focus:bg-surface focus:border-primary-400 focus:outline-none focus:ring-1 focus:ring-primary-200"
         autocomplete="off"
         spellcheck="false"
         @focus="open = q.trim().length > 0"
@@ -149,7 +149,7 @@ onBeforeUnmount(() => clearTimeout(debounceTimer))
     <!-- Dropdown výsledků -->
     <div
       v-if="showDropdown"
-      class="absolute left-0 right-0 mt-1 z-40 bg-white border border-neutral-200 rounded-md shadow-lg max-h-[70vh] overflow-y-auto"
+      class="absolute left-0 right-0 mt-1 z-40 bg-surface border border-neutral-200 rounded-md shadow-lg max-h-[70vh] overflow-y-auto"
     >
       <div v-if="loading && !hasResults" class="px-3 py-2 text-xs text-neutral-500">{{ t('common.loading') }}</div>
       <div v-else-if="!hasResults" class="px-3 py-2 text-xs text-neutral-500">{{ t('search.no_results') }}</div>

--- a/web/src/components/layout/SupplierSwitcher.vue
+++ b/web/src/components/layout/SupplierSwitcher.vue
@@ -47,7 +47,7 @@ function pick(id: number) {
       leave-from-class="opacity-100 scale-100"
       leave-to-class="opacity-0 scale-95"
     >
-      <div v-if="open" class="absolute right-0 mt-1 w-72 bg-white border border-neutral-200 rounded-lg shadow-lg py-1 z-40">
+      <div v-if="open" class="absolute right-0 mt-1 w-72 bg-surface border border-neutral-200 rounded-lg shadow-lg py-1 z-40">
         <button v-for="s in list" :key="s.id" type="button" @click="pick(s.id)"
           class="cursor-pointer w-full text-left px-3 py-2 text-sm hover:bg-neutral-50 flex items-start gap-2"
           :class="s.id === supplierStore.currentSupplierId ? 'bg-primary-50' : ''">

--- a/web/src/components/layout/ThemeToggle.vue
+++ b/web/src/components/layout/ThemeToggle.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { useTheme, type ThemePreference } from '@/composables/useTheme'
+
+const { t } = useI18n()
+const { preference } = useTheme()
+
+/** Heroicons outline (stroke 2, viewBox 24): monitor = System, slunce = Light, měsíc = Dark. */
+const OPTIONS: { value: ThemePreference; key: string; icon: string }[] = [
+  {
+    value: 'auto',
+    key: 'theme.system',
+    icon: 'M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25',
+  },
+  {
+    value: 'light',
+    key: 'theme.light',
+    icon: 'M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0z',
+  },
+  {
+    value: 'dark',
+    key: 'theme.dark',
+    icon: 'M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998z',
+  },
+]
+</script>
+
+<template>
+  <div
+    class="hidden sm:inline-flex items-center border border-neutral-200 rounded-md overflow-hidden"
+    role="group"
+    :aria-label="t('theme.label')"
+  >
+    <button
+      v-for="(opt, i) in OPTIONS"
+      :key="opt.value"
+      type="button"
+      @click="preference = opt.value"
+      :title="t(opt.key)"
+      :aria-label="t(opt.key)"
+      :aria-pressed="preference === opt.value"
+      class="cursor-pointer h-8 px-2 inline-flex items-center"
+      :class="[
+        i > 0 ? 'border-l border-neutral-200' : '',
+        preference === opt.value
+          ? 'bg-primary-50 text-primary-700'
+          : 'text-neutral-500 hover:bg-neutral-50 hover:text-neutral-700',
+      ]"
+    >
+      <svg class="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" :d="opt.icon" />
+      </svg>
+    </button>
+  </div>
+</template>

--- a/web/src/components/modals/WorkReportModal.vue
+++ b/web/src/components/modals/WorkReportModal.vue
@@ -207,8 +207,8 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="modelValue" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-start justify-center p-4 overflow-y-auto">
-    <div class="bg-white rounded-xl shadow-lg max-w-4xl w-full my-4">
+  <div v-if="modelValue" class="fixed inset-0 bg-black/40 z-50 flex items-start justify-center p-4 overflow-y-auto">
+    <div class="bg-surface rounded-xl shadow-lg max-w-4xl w-full my-4">
       <header class="px-5 py-4 border-b border-neutral-200 flex items-baseline justify-between gap-3">
         <h3 class="text-lg font-semibold">{{ t('invoice.work_report') }}</h3>
         <button @click="close" class="cursor-pointer text-neutral-400 hover:text-neutral-700 text-2xl leading-none">&times;</button>
@@ -267,7 +267,7 @@ onMounted(() => {
                 </td>
                 <td class="px-2 py-1.5 text-center">
                   <button type="button" @click="removeItem(i)" :title="t('common.delete')"
-                          class="cursor-pointer text-danger-500 hover:text-danger-700 text-lg leading-none">&times;</button>
+                          class="cursor-pointer text-danger-500 hover:text-danger-600 text-lg leading-none">&times;</button>
                 </td>
               </tr>
             </tbody>

--- a/web/src/components/purchase/ExchangeRateInput.vue
+++ b/web/src/components/purchase/ExchangeRateInput.vue
@@ -82,6 +82,6 @@ async function loadFromCnb() {
         {{ loading ? '…' : t('purchase_invoice.fields.exchange_rate_load_cnb') }}
       </button>
     </div>
-    <p v-if="errorMsg" class="text-xs text-red-600">{{ errorMsg }}</p>
+    <p v-if="errorMsg" class="text-xs text-danger-600">{{ errorMsg }}</p>
   </div>
 </template>

--- a/web/src/components/purchase/PaymentCurrencyBlock.vue
+++ b/web/src/components/purchase/PaymentCurrencyBlock.vue
@@ -100,7 +100,7 @@ const otherCurrencies = computed(() => {
           <select
             :value="paymentCurrencyId ?? ''"
             @change="emit('update:paymentCurrencyId', ($event.target as HTMLSelectElement).value ? Number(($event.target as HTMLSelectElement).value) : null)"
-            class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm"
+            class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm"
           >
             <option value="">—</option>
             <option v-for="c in otherCurrencies" :key="c.id" :value="c.id">{{ c.code }}</option>
@@ -161,7 +161,7 @@ const otherCurrencies = computed(() => {
             :value="exchangeDiffBase ?? ''"
             @input="emit('update:exchangeDiffBase', ($event.target as HTMLInputElement).value ? Number(($event.target as HTMLInputElement).value) : null)"
             class="w-full px-3 py-1.5 border border-neutral-300 rounded-md text-sm font-mono"
-            :class="exchangeDiffBase !== null && exchangeDiffBase < 0 ? 'text-red-700' : 'text-green-700'"
+            :class="exchangeDiffBase !== null && exchangeDiffBase < 0 ? 'text-danger-600' : 'text-success-600'"
           />
         </div>
       </div>

--- a/web/src/components/ui/Modal.vue
+++ b/web/src/components/ui/Modal.vue
@@ -35,9 +35,9 @@ void props
 
 <template>
   <Teleport to="body">
-    <div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-neutral-900/50"
+    <div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
       @click.self="emit('close')">
-      <div class="bg-white rounded-lg shadow-xl w-full flex flex-col max-h-[90vh]" :class="widthClass">
+      <div class="bg-surface rounded-lg shadow-xl w-full flex flex-col max-h-[90vh]" :class="widthClass">
         <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between shrink-0">
           <h2 class="text-lg font-semibold">{{ title }}</h2>
           <button type="button" @click="emit('close')" aria-label="Close"

--- a/web/src/components/ui/SearchableSelect.vue
+++ b/web/src/components/ui/SearchableSelect.vue
@@ -146,7 +146,7 @@ onUnmounted(() => {
         :disabled="disabled"
         autocomplete="off"
         :class="[
-          'w-full h-10 pl-3 pr-16 border border-neutral-300 rounded-md text-sm bg-white',
+          'w-full h-10 pl-3 pr-16 border border-neutral-300 rounded-md text-sm bg-surface',
           'focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none',
           'disabled:bg-neutral-50 disabled:text-neutral-400',
         ]"
@@ -168,7 +168,7 @@ onUnmounted(() => {
       ref="listbox"
       id="searchable-select-listbox"
       role="listbox"
-      class="absolute z-50 left-0 right-0 mt-1 bg-white border border-neutral-200 rounded-md shadow-lg max-h-72 overflow-y-auto"
+      class="absolute z-50 left-0 right-0 mt-1 bg-surface border border-neutral-200 rounded-md shadow-lg max-h-72 overflow-y-auto"
     >
       <div v-if="filtered.length === 0" class="px-3 py-2 text-sm text-neutral-400">
         {{ noResultsLabel }}

--- a/web/src/composables/useTheme.ts
+++ b/web/src/composables/useTheme.ts
@@ -1,0 +1,52 @@
+import { computed, watchEffect } from 'vue'
+import { useStorage, usePreferredDark } from '@vueuse/core'
+
+/**
+ * Barevný režim aplikace: System / Light / Dark.
+ *
+ * Why: `auto` respektuje OS (prefers-color-scheme), `light`/`dark` ho přebijí.
+ * Volba se ukládá do localStorage (klíč musí sedět s anti-FOUC scriptem v index.html).
+ * Reaktivně přepíná třídu `.dark` na <html>, na kterou je navázán dark scope v main.css.
+ *
+ * Stav je modul-level singleton, takže všechny komponenty sdílejí jednu instanci
+ * a watchEffect běží jen jednou.
+ */
+export type ThemePreference = 'auto' | 'light' | 'dark'
+
+export const THEME_STORAGE_KEY = 'myinvoice-color-scheme'
+
+const preference = useStorage<ThemePreference>(THEME_STORAGE_KEY, 'auto')
+const prefersDark = usePreferredDark()
+
+/** Co reálně svítí (auto → podle systému). */
+const isDark = computed(
+  () => preference.value === 'dark' || (preference.value === 'auto' && prefersDark.value),
+)
+
+watchEffect(() => {
+  document.documentElement.classList.toggle('dark', isDark.value)
+})
+
+export function useTheme() {
+  return { preference, isDark }
+}
+
+/**
+ * Barvy pro chart.js — ten nečte CSS proměnné, takže je tu zrcadlíme ručně podle režimu.
+ * POZOR: hodnoty musí odpovídat tokenům v styles/main.css (.dark scope) — při změně palety
+ * srovnej i tady. Sdílený singleton; v komponentě: const colors = useChartColors() + watch(colors, build).
+ */
+// Kategorická paleta pro grafy (rozlišení kategorií, ne sémantika). V dark posunutá do
+// světlejších indigo tónů, aby nejtmavší segmenty nesplývaly s tmavým pozadím.
+const CHART_PALETTE_LIGHT = ['#3B2D83', '#5C45A0', '#6753AE', '#8675C5', '#A99CD8', '#C9C0E9', '#E5E0F4', '#F4A261', '#E8A547', '#4CAF7A']
+const CHART_PALETTE_DARK = ['#A99CD8', '#7C68C4', '#C9C0E9', '#8B79C8', '#E5E0F4', '#6753AE', '#D8CEF0', '#F4A261', '#E8A547', '#5FBF8E']
+
+const chartColors = computed(() =>
+  isDark.value
+    ? { border: '#1E1B2B', tick: '#A8A1BE', grid: '#2C2840', tooltipBg: '#322C4A', primary: '#7C68C4', primarySoft: '#A99CD8', palette: CHART_PALETTE_DARK }
+    : { border: '#FFFFFF', tick: '#5A5470', grid: '#E7E3EE', tooltipBg: '#15131D', primary: '#5C45A0', primarySoft: '#A99CD8', palette: CHART_PALETTE_LIGHT },
+)
+
+export function useChartColors() {
+  return chartColors
+}

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -1,4 +1,5 @@
 {
+  "theme": { "label": "Motiv", "system": "Systém", "light": "Světlý", "dark": "Tmavý" },
   "app": { "title": "MyInvoice.cz", "subtitle": "Fakturační systém" },
   "documents": {
     "title": "Dokumenty",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -1,4 +1,5 @@
 {
+  "theme": { "label": "Theme", "system": "System", "light": "Light", "dark": "Dark" },
   "app": { "title": "MyInvoice.cz", "subtitle": "Invoicing system" },
   "documents": {
     "title": "Documents",

--- a/web/src/pages/ApiTokens.vue
+++ b/web/src/pages/ApiTokens.vue
@@ -153,7 +153,7 @@ onMounted(load)
       </button>
     </div>
 
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4 mb-4 text-sm text-neutral-700">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4 mb-4 text-sm text-neutral-700">
       <p>
         {{ t('api_tokens.intro') }}
         <a href="/api/docs" target="_blank" class="text-primary-600 hover:underline">{{ t('api_tokens.docs_link') }}</a>
@@ -164,7 +164,7 @@ onMounted(load)
       {{ error }}
     </div>
 
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <table class="w-full text-sm">
         <thead class="bg-neutral-50 text-neutral-600 text-xs uppercase">
           <tr>
@@ -203,7 +203,7 @@ onMounted(load)
               <button
                 v-if="!tk.is_revoked"
                 @click="revoke(tk.id, tk.name)"
-                class="cursor-pointer text-danger-500 hover:text-danger-700 text-sm"
+                class="cursor-pointer text-danger-500 hover:text-danger-600 text-sm"
               >
                 {{ t('api_tokens.revoke') }}
               </button>
@@ -215,7 +215,7 @@ onMounted(load)
 
     <!-- Create modal -->
     <div v-if="showCreate" class="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-      <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+      <div class="bg-surface rounded-lg shadow-xl max-w-md w-full p-6">
         <h2 class="text-xl font-semibold mb-4">{{ t('api_tokens.new') }}</h2>
 
         <div class="space-y-3">
@@ -229,7 +229,7 @@ onMounted(load)
           <label class="block text-sm">
             <span class="text-neutral-700 font-medium">{{ t('api_tokens.col_supplier') }}</span>
             <select v-model="form.supplier_id"
-              class="mt-1 w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+              class="mt-1 w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
               <option :value="null">{{ t('api_tokens.supplier_all') }}</option>
               <option v-for="s in suppliers.availableSuppliers" :key="s.id" :value="s.id">{{ s.company_name }}</option>
             </select>
@@ -291,7 +291,7 @@ onMounted(load)
 
     <!-- Reveal modal — plaintext shown ONCE -->
     <div v-if="revealed" class="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
-      <div class="bg-white rounded-lg shadow-xl max-w-lg w-full p-6">
+      <div class="bg-surface rounded-lg shadow-xl max-w-lg w-full p-6">
         <h2 class="text-xl font-semibold mb-2 text-success-600">{{ t('api_tokens.created_title') }}</h2>
         <p class="text-sm text-warning-600 font-medium mb-3">⚠ {{ t('api_tokens.created_warning') }}</p>
 
@@ -311,7 +311,7 @@ onMounted(load)
 
         <div class="mt-4 flex justify-end">
           <button @click="closeReveal" :disabled="!confirmCopied"
-            class="cursor-pointer h-10 px-4 bg-neutral-900 hover:bg-black disabled:bg-neutral-300 text-white font-medium rounded-md">
+            class="cursor-pointer h-10 px-4 bg-neutral-700 hover:bg-neutral-800 disabled:bg-neutral-300 text-neutral-50 font-medium rounded-md">
             {{ t('common.close') }}
           </button>
         </div>

--- a/web/src/pages/ApprovalPublic.vue
+++ b/web/src/pages/ApprovalPublic.vue
@@ -126,7 +126,7 @@ async function submit(decision: 'approve' | 'reject') {
 <template>
   <div class="min-h-screen bg-neutral-50 flex flex-col">
     <!-- Hlavička -->
-    <header class="bg-white border-b border-neutral-200 px-4 py-3">
+    <header class="bg-surface border-b border-neutral-200 px-4 py-3">
       <div class="max-w-2xl mx-auto flex items-center gap-3">
         <div class="w-8 h-8 bg-primary-600 rounded-md flex items-center justify-center text-white font-bold">M</div>
         <div class="text-sm">
@@ -145,7 +145,7 @@ async function submit(decision: 'approve' | 'reject') {
         </div>
 
         <!-- Token error -->
-        <div v-else-if="loadError" class="bg-white border border-danger-500/40 rounded-xl p-8 text-center shadow-sm">
+        <div v-else-if="loadError" class="bg-surface border border-danger-500/40 rounded-xl p-8 text-center shadow-sm">
           <div class="text-4xl mb-3">⚠</div>
           <h1 class="text-xl font-semibold mb-2">{{ tt('Odkaz není platný', 'Link not valid') }}</h1>
           <p class="text-neutral-600 text-sm">{{ loadError }}</p>
@@ -155,7 +155,7 @@ async function submit(decision: 'approve' | 'reject') {
         </div>
 
         <!-- Confirmation screen -->
-        <div v-else-if="mode === 'done' && result" class="bg-white border rounded-xl p-8 text-center shadow-sm"
+        <div v-else-if="mode === 'done' && result" class="bg-surface border rounded-xl p-8 text-center shadow-sm"
           :class="result.decision === 'approved' ? 'border-success-500/40' : 'border-warning-500/40'">
           <div class="text-5xl mb-3">{{ result.decision === 'approved' ? '✓' : '✕' }}</div>
           <h1 class="text-2xl font-semibold mb-3"
@@ -176,7 +176,7 @@ async function submit(decision: 'approve' | 'reject') {
         <!-- Review + actions -->
         <div v-else-if="data" class="space-y-4">
           <!-- Header card -->
-          <div class="bg-white border border-neutral-200 rounded-xl p-6 shadow-sm">
+          <div class="bg-surface border border-neutral-200 rounded-xl p-6 shadow-sm">
             <h1 class="text-xl font-semibold mb-2">
               {{ tt('Žádost o schválení výkazu práce', 'Work report approval request') }}
             </h1>
@@ -197,7 +197,7 @@ async function submit(decision: 'approve' | 'reject') {
           </div>
 
           <!-- Work report card -->
-          <div class="bg-white border border-neutral-200 rounded-xl shadow-sm overflow-hidden">
+          <div class="bg-surface border border-neutral-200 rounded-xl shadow-sm overflow-hidden">
             <header class="px-6 py-3 border-b border-neutral-200 flex items-baseline justify-between gap-3">
               <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
                 {{ tt('Výkaz', 'Report') }}
@@ -232,7 +232,7 @@ async function submit(decision: 'approve' | 'reject') {
           </div>
 
           <!-- Decided by email + actions -->
-          <div class="bg-white border border-neutral-200 rounded-xl p-6 shadow-sm">
+          <div class="bg-surface border border-neutral-200 rounded-xl p-6 shadow-sm">
             <p class="text-sm text-neutral-600 mb-4">
               {{ mode === 'reject_form'
                   ? tt('Uveďte prosím důvod zamítnutí. Dodavatel ho uvidí v systému.',
@@ -285,7 +285,7 @@ async function submit(decision: 'approve' | 'reject') {
             <!-- Akce: review -->
             <div v-if="mode === 'review'" class="flex flex-col gap-3">
               <button @click="approve" :disabled="submitting"
-                class="cursor-pointer w-full py-4 bg-emerald-700 hover:bg-emerald-800 disabled:bg-neutral-300 text-white text-lg font-bold rounded-lg shadow-sm transition">
+                class="cursor-pointer w-full py-4 bg-success-600 hover:bg-success-500 disabled:bg-neutral-300 text-white text-lg font-bold rounded-lg shadow-sm transition">
                 {{ submitting ? tt('Odesílám…', 'Submitting…') : tt('✓ Schválit vícepráce', '✓ Approve work report') }}
               </button>
               <button @click="startReject" :disabled="submitting"
@@ -310,7 +310,7 @@ async function submit(decision: 'approve' | 'reject') {
       </div>
     </main>
 
-    <footer class="border-t border-neutral-200 bg-white px-4 py-3 text-center text-xs text-neutral-500">
+    <footer class="border-t border-neutral-200 bg-surface px-4 py-3 text-center text-xs text-neutral-500">
       MyInvoice.cz · {{ tt('Automatizovaný systém schvalování', 'Automated approval system') }}
     </footer>
   </div>

--- a/web/src/pages/Dashboard.vue
+++ b/web/src/pages/Dashboard.vue
@@ -111,7 +111,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
           {{ t('invoice.new') }}
         </RouterLink>
         <RouterLink v-if="auth.canWrite" to="/clients/new"
-          class="inline-flex items-center h-9 px-4 border border-primary-500/40 bg-white hover:bg-primary-50 text-primary-700 text-sm font-medium rounded-md">
+          class="inline-flex items-center h-9 px-4 border border-primary-500/40 bg-surface hover:bg-primary-50 text-primary-700 text-sm font-medium rounded-md">
           {{ t('client.new') }}
         </RouterLink>
       </div>
@@ -123,7 +123,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
       {{ error }}
     </div>
 
-    <div v-else-if="!hasAnyData" class="bg-white border border-neutral-200 rounded-lg p-8 text-center">
+    <div v-else-if="!hasAnyData" class="bg-surface border border-neutral-200 rounded-lg p-8 text-center">
       <h2 class="text-lg font-semibold mb-2">{{ t('dashboard.welcome') }}</h2>
       <p class="text-neutral-500 mb-6">{{ t('common.no_data') }}</p>
       <div class="flex justify-center gap-3">
@@ -147,7 +147,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4" :class="singleCurrency ? 'lg:grid-cols-3' : 'lg:grid-cols-4'">
           <!-- Revenue card: 1 měna → vysoký vlevo (2 řádky); více měn → široký (2 sloupce) -->
           <div v-for="c in summary.kpi.per_currency" :key="c.currency"
-            class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm"
+            class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm"
             :class="singleCurrency ? 'lg:row-span-2 flex flex-col' : 'md:col-span-2'">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.revenue', { year: summary.year, currency: c.currency }) }}</div>
             <div class="text-2xl font-semibold text-neutral-900 font-mono">{{ formatMoney(c.this_year, c.currency) }}</div>
@@ -169,13 +169,13 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
           </div>
 
           <!-- 4 single-column boxes: issued count, overdue, upcoming, avg payment -->
-          <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.issued_count', { year: summary.year }) }}</div>
             <div class="text-2xl font-semibold text-neutral-900">{{ summary.kpi.issued_count_ytd }}</div>
             <div class="text-xs text-neutral-400 mt-1">{{ t('dashboard.invoices_unit') }}</div>
           </div>
 
-          <div class="bg-white border rounded-lg p-5 shadow-sm" :class="summary.kpi.overdue_count > 0 ? 'border-danger-500/40' : 'border-neutral-200'">
+          <div class="bg-surface border rounded-lg p-5 shadow-sm" :class="summary.kpi.overdue_count > 0 ? 'border-danger-500/40' : 'border-neutral-200'">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.overdue') }}</div>
             <div class="text-2xl font-semibold" :class="summary.kpi.overdue_count > 0 ? 'text-danger-500' : 'text-neutral-900'">
               {{ summary.kpi.overdue_count }}
@@ -186,7 +186,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
             </div>
           </div>
 
-          <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.upcoming') }}</div>
             <div class="text-2xl font-semibold text-neutral-900">{{ summary.unpaid_upcoming.length }}</div>
             <div class="text-xs mt-1 text-neutral-400 flex flex-wrap gap-x-3">
@@ -195,7 +195,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
             </div>
           </div>
 
-          <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.avg_payment') }}</div>
             <div class="text-2xl font-semibold text-neutral-900">
               {{ summary.kpi.avg_payment_days !== null ? summary.kpi.avg_payment_days + ' ' + t('dashboard.days') : '—' }}
@@ -214,14 +214,14 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
         </h2>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <!-- Costs YTD -->
-          <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.purchase_costs_ytd', { year: summary.year }) }}</div>
             <div class="text-2xl font-semibold text-neutral-900 font-mono">{{ formatMoney(summary.kpi.purchase_costs_ytd, 'CZK') }}</div>
             <div class="text-xs text-neutral-400 mt-1">{{ summary.kpi.purchase_count_ytd }} {{ t('dashboard.invoices_unit') }}</div>
           </div>
 
           <!-- Unpaid -->
-          <div class="bg-white border rounded-lg p-5 shadow-sm"
+          <div class="bg-surface border rounded-lg p-5 shadow-sm"
             :class="(summary.kpi.purchase_unpaid_count ?? 0) > 0 ? 'border-warning-500/40' : 'border-neutral-200'">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.purchase_unpaid') }}</div>
             <div class="text-2xl font-semibold"
@@ -235,7 +235,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
           </div>
 
           <!-- Overdue (vždy zobrazené pro grid alignment, červené pokud > 0) -->
-          <div class="bg-white border rounded-lg p-5 shadow-sm"
+          <div class="bg-surface border rounded-lg p-5 shadow-sm"
             :class="(summary.kpi.purchase_overdue_count ?? 0) > 0 ? 'border-danger-500/40' : 'border-neutral-200'">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.purchase_overdue') }}</div>
             <div class="text-2xl font-semibold"
@@ -254,7 +254,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
 
           <!-- 4. box: mini graf nákladů (12 měsíců, CZK) — odkaz do CRM analytics -->
           <RouterLink to="/crm"
-            class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm hover:bg-neutral-50 hover:border-primary-300 transition flex flex-col">
+            class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm hover:bg-neutral-50 hover:border-primary-300 transition flex flex-col">
             <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.costs_trend_12m') }}</div>
             <div v-if="hasCostsData" class="mt-1 flex-1 flex items-end">
               <SparklineChart class="w-full"
@@ -272,7 +272,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
         <RouterLink
           v-if="isAdmin && summary.pending_approvals && summary.pending_approvals.requested > 0"
           to="/admin/approvals"
-          class="bg-white border rounded-lg p-5 shadow-sm hover:bg-primary-50 transition cursor-pointer"
+          class="bg-surface border rounded-lg p-5 shadow-sm hover:bg-primary-50 transition cursor-pointer"
           :class="summary.pending_approvals.overdue > 0 ? 'border-warning-500/50' : 'border-primary-500/40'">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.pending_approvals') }}</div>
           <div class="text-2xl font-semibold"
@@ -299,7 +299,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
         </h2>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div v-for="b in summary.due_buckets" :key="`db-today-${b.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm"
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm"
           :class="{ 'border-warning-500/40 bg-warning-50/20': b.today_count > 0 }">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.due_today') }}</div>
           <div class="text-2xl font-semibold" :class="b.today_count > 0 ? 'text-warning-600' : 'text-neutral-300'">
@@ -310,13 +310,13 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
           </div>
         </div>
         <div v-for="b in summary.due_buckets" :key="`db-week-${b.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.due_this_week') }}</div>
           <div class="text-2xl font-semibold text-neutral-900">{{ b.week_count }}</div>
           <div class="text-xs mt-1 font-mono text-neutral-500">{{ formatMoney(b.week_total, b.currency) }}</div>
         </div>
         <div v-for="b in summary.due_buckets" :key="`db-month-${b.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.due_this_month') }}</div>
           <div class="text-2xl font-semibold text-neutral-900">{{ b.month_count }}</div>
           <div class="text-xs mt-1 font-mono text-neutral-500">{{ formatMoney(b.month_total, b.currency) }}</div>
@@ -325,7 +325,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
       </section>
 
       <!-- Cash-flow forecast 30 / 60 / 90 dní — kolik se očekává inkasovat -->
-      <div v-if="summary.cashflow_forecast.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-if="summary.cashflow_forecast.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-4">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('dashboard.cashflow_forecast') }}</h3>
           <span class="text-xs text-neutral-400">{{ t('dashboard.cashflow_forecast_hint') }}</span>
@@ -350,7 +350,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Po splatnosti -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
             <h3 class="font-semibold">{{ t('dashboard.overdue_table') }}</h3>
             <span v-if="summary.overdue.length" class="text-xs px-2 py-0.5 rounded bg-danger-50 text-danger-500">
@@ -403,7 +403,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
         </div>
 
         <!-- Nezaplacené -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
             <h3 class="font-semibold">{{ t('dashboard.unpaid_upcoming') }}</h3>
             <span v-if="summary.unpaid_upcoming.length" class="text-xs px-2 py-0.5 rounded bg-primary-100 text-primary-700">
@@ -452,7 +452,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
 
       <!-- Top klienti — posledních 12 měsíců: tabulka vlevo, koláč vpravo -->
       <div v-if="summary.top_clients_12m.length" class="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200">
           <h3 class="font-semibold">{{ t('dashboard.top_clients_12m') }}</h3>
         </header>
@@ -512,7 +512,7 @@ const hasCostsData = computed(() => (summary.value?.purchase_costs_by_month ?? [
       </div>
 
       <!-- Koláč Top klienti — totožná data, druhý úhel pohledu (vždy v CZK po přepočtu) -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-4">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('dashboard.top_clients_12m_share') }}</h3>
           <span class="text-xs font-mono text-neutral-500">CZK</span>

--- a/web/src/pages/ForcedTotpSetup.vue
+++ b/web/src/pages/ForcedTotpSetup.vue
@@ -58,14 +58,14 @@ onMounted(() => {
 <template>
   <AppShell :title="t('auth.totp_force_title')">
     <div class="w-full max-w-md">
-      <div class="bg-white border border-warning-300 rounded-lg shadow-sm p-6 space-y-5">
+      <div class="bg-surface border border-warning-300 rounded-lg shadow-sm p-6 space-y-5">
         <div class="flex items-start gap-3">
-          <svg class="w-6 h-6 text-warning-700 shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <svg class="w-6 h-6 text-warning-600 shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
           </svg>
           <div>
-            <h1 class="text-lg font-semibold text-warning-900">{{ t('auth.totp_force_title') }}</h1>
-            <p class="text-sm text-warning-800 mt-1">{{ t('auth.totp_force_intro') }}</p>
+            <h1 class="text-lg font-semibold text-warning-600">{{ t('auth.totp_force_title') }}</h1>
+            <p class="text-sm text-warning-600 mt-1">{{ t('auth.totp_force_intro') }}</p>
           </div>
         </div>
 

--- a/web/src/pages/ForgotPassword.vue
+++ b/web/src/pages/ForgotPassword.vue
@@ -60,7 +60,7 @@ async function submit() {
 <template>
   <AppShell :title="t('auth.reset_title')">
     <div class="w-full max-w-sm">
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-6">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-6">
         <h2 class="text-xl font-semibold mb-1">{{ t('auth.reset_title') }}</h2>
         <p class="text-sm text-neutral-500 mb-6">{{ t('auth.reset_send') }}</p>
 
@@ -80,7 +80,7 @@ async function submit() {
             <div ref="turnstileEl"></div>
           </div>
 
-          <div v-if="error" class="rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-700">
+          <div v-if="error" class="rounded-md bg-danger-50 border border-danger-500/40 p-3 text-sm text-danger-600">
             {{ error }}
           </div>
 

--- a/web/src/pages/Login.vue
+++ b/web/src/pages/Login.vue
@@ -167,7 +167,7 @@ async function resendCode() {
 <template>
   <AppShell :title="t('auth.login_title')">
     <div class="w-full max-w-sm">
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-6">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-6">
         <h2 class="text-xl font-semibold mb-1">{{ t('auth.login_title') }}</h2>
         <p class="text-sm text-neutral-500 mb-6">{{ t('auth.login_subtitle') }}</p>
 

--- a/web/src/pages/PasswordChange.vue
+++ b/web/src/pages/PasswordChange.vue
@@ -145,7 +145,7 @@ onMounted(() => {
 
     <!-- ── Heslo ── -->
     <form v-if="tab === 'password'" @submit.prevent="submitPw"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
       <div>
         <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('auth.current_password') }} *</label>
         <div class="flex gap-2">
@@ -210,7 +210,7 @@ onMounted(() => {
     </form>
 
     <!-- ── 2FA / TOTP ── -->
-    <div v-else class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
       <div v-if="totpStatus">
         <div v-if="totpStatus.enabled" class="flex items-center gap-2 text-success-600">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>

--- a/web/src/pages/PurchaseStats.vue
+++ b/web/src/pages/PurchaseStats.vue
@@ -158,7 +158,7 @@ const hasAnyData = computed(() =>
       {{ error }}
     </div>
 
-    <div v-else-if="!hasAnyData" class="bg-white border border-neutral-200 rounded-lg p-8 text-center">
+    <div v-else-if="!hasAnyData" class="bg-surface border border-neutral-200 rounded-lg p-8 text-center">
       <p class="text-neutral-500">{{ t('costs.no_data') }}</p>
     </div>
 
@@ -167,7 +167,7 @@ const hasAnyData = computed(() =>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <!-- Plovoucí 12měsíční náklady per měna -->
         <div v-for="r in summary.rolling_12m" :key="`r12-${r.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">
             {{ t('costs.rolling_12m', { currency: r.currency }) }}
           </div>
@@ -187,7 +187,7 @@ const hasAnyData = computed(() =>
 
         <!-- Náklady tento rok per měna -->
         <div v-for="r in costsThisYear" :key="`ty-${r.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">
             {{ t('costs.costs_this_year', { year: summary.year, currency: r.currency }) }}
           </div>
@@ -205,7 +205,7 @@ const hasAnyData = computed(() =>
 
         <!-- Forecast nákladů aktuálního roku per měna -->
         <div v-for="f in summary.costs_forecast" :key="`fc-${f.currency}`"
-          class="bg-white border border-primary-200 rounded-lg p-5 shadow-sm bg-primary-50/30">
+          class="bg-surface border border-primary-200 rounded-lg p-5 shadow-sm bg-primary-50/30">
           <div class="text-xs uppercase tracking-wide text-primary-700 mb-1">
             {{ t('costs.forecast_year', { year: summary.year, currency: f.currency }) }}
           </div>
@@ -228,7 +228,7 @@ const hasAnyData = computed(() =>
 
         <!-- Náklady minulý rok per měna -->
         <div v-for="r in costsPrevYear" :key="`py-${r.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">
             {{ t('costs.costs_prev_year', { year: summary.prev_year, currency: r.currency }) }}
           </div>
@@ -240,21 +240,21 @@ const hasAnyData = computed(() =>
         </div>
 
         <!-- Počet přijatých faktur YTD -->
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('costs.purchases_count_ytd', { year: summary.year }) }}</div>
           <div class="text-2xl font-semibold text-neutral-900">{{ summary.kpi.purchase_count_ytd }}</div>
           <div class="text-xs text-neutral-400 mt-1">{{ t('costs.invoices_unit') }}</div>
         </div>
 
         <!-- Aktivní dodavatelé -->
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('costs.active_vendors') }}</div>
           <div class="text-2xl font-semibold text-neutral-900">{{ summary.active_vendors_count }}</div>
           <div class="text-xs text-neutral-400 mt-1">{{ t('costs.active_vendors_hint') }}</div>
         </div>
 
         <!-- Ø doba úhrady dodavatelům -->
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('costs.avg_payment') }}</div>
           <div class="text-2xl font-semibold text-neutral-900">
             {{ summary.kpi.avg_payment_days !== null ? summary.kpi.avg_payment_days + ' ' + t('common.days') : '—' }}
@@ -264,7 +264,7 @@ const hasAnyData = computed(() =>
 
         <!-- Náklady posledních 30 dní per měna -->
         <div v-for="r in summary.costs_last_30d" :key="`c30-${r.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">
             {{ t('costs.costs_last_30d', { currency: r.currency }) }}
           </div>
@@ -275,7 +275,7 @@ const hasAnyData = computed(() =>
 
         <!-- Nezaplacené závazky -->
         <RouterLink to="/purchase-invoices"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm hover:bg-neutral-50 transition cursor-pointer block">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm hover:bg-neutral-50 transition cursor-pointer block">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('costs.unpaid_payables') }}</div>
           <div class="text-2xl font-semibold" :class="summary.kpi.overdue_count > 0 ? 'text-danger-500' : 'text-neutral-900'">
             {{ summary.kpi.unpaid_count }}
@@ -295,7 +295,7 @@ const hasAnyData = computed(() =>
       <!-- Měsíční náklady — bar + prev-year linka -->
       <div v-if="summary.costs_by_month.length" class="space-y-4">
         <div v-for="rev in summary.costs_by_month" :key="`m-${rev.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('costs.costs_last_12_months', { currency: rev.currency }) }}
           </h3>
@@ -306,7 +306,7 @@ const hasAnyData = computed(() =>
       <!-- Kumulativní cash-outflow YTD vs loni — per měna -->
       <div v-if="summary.cashflow_out_ytd.length" class="space-y-4">
         <div v-for="cf in summary.cashflow_out_ytd" :key="`cf-${cf.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('costs.cumulative_outflow', { currency: cf.currency }) }}
@@ -320,13 +320,13 @@ const hasAnyData = computed(() =>
       <!-- Top dodavatelé pie YTD + loni -->
       <div v-if="(summary.top_vendors_ytd.length + summary.top_vendors_prev_year.length) > 0"
         class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div v-if="summary.top_vendors_ytd.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="summary.top_vendors_ytd.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('costs.top_vendors_year', { year: summary.year }) }}
           </h3>
           <TopClientsPieChart :clients="vendorsToPie(summary.top_vendors_ytd)" />
         </div>
-        <div v-if="summary.top_vendors_prev_year.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="summary.top_vendors_prev_year.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('costs.top_vendors_year', { year: summary.prev_year }) }}
           </h3>
@@ -337,14 +337,14 @@ const hasAnyData = computed(() =>
       <!-- Status donut + rozpad DPH na vstupu -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div v-if="summary.kpi.status_counts_ytd && Object.keys(summary.kpi.status_counts_ytd).length"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('costs.status_purchases', { year: summary.year }) }}
           </h3>
           <PurchaseStatusChart :counts="summary.kpi.status_counts_ytd" />
         </div>
         <div v-if="isVatPayer && summary.vat_breakdown_12m.length"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('costs.vat_input_breakdown_title') }}</h3>
             <span class="text-xs font-mono text-neutral-500">{{ t('costs.last_12_months') }}</span>
@@ -356,7 +356,7 @@ const hasAnyData = computed(() =>
       <!-- Číselné tabulky: náklady po rocích + po měsících -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Náklady po rocích -->
-        <div v-if="summary.costs_by_year.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="summary.costs_by_year.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="font-semibold">{{ t('costs.costs_by_year_table') }}</h3>
           </header>
@@ -389,7 +389,7 @@ const hasAnyData = computed(() =>
         </div>
 
         <!-- Náklady po měsících -->
-        <div v-if="monthlyTable.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="monthlyTable.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="font-semibold">{{ t('costs.costs_by_month_table') }}</h3>
           </header>
@@ -418,7 +418,7 @@ const hasAnyData = computed(() =>
 
       <!-- Top 12 dodavatelů (12m) + rozpad nákladů po kategoriích -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div v-if="summary.top_vendors_12m.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="summary.top_vendors_12m.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="font-semibold">{{ t('costs.top_vendors_12m_table') }}</h3>
           </header>
@@ -450,7 +450,7 @@ const hasAnyData = computed(() =>
         </div>
 
         <!-- Rozpad nákladů po kategoriích -->
-        <div v-if="expenseRows.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="expenseRows.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="font-semibold">{{ t('costs.expense_breakdown_title') }}</h3>
           </header>
@@ -480,7 +480,7 @@ const hasAnyData = computed(() =>
       </div>
 
       <!-- Vendor concentration risk -->
-      <div v-if="concentration" class="bg-white border rounded-lg p-5 shadow-sm"
+      <div v-if="concentration" class="bg-surface border rounded-lg p-5 shadow-sm"
         :class="concentrationLevel === 'high' ? 'border-danger-500/40 bg-danger-50/30'
               : concentrationLevel === 'medium' ? 'border-warning-500/50 bg-warning-50/30'
               : 'border-neutral-200'">
@@ -527,7 +527,7 @@ const hasAnyData = computed(() =>
 
       <!-- Histogram doby úhrady + plán plateb dodavatelům -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div v-if="summary.payment_days_histogram.total > 0" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="summary.payment_days_histogram.total > 0" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('costs.payment_histogram_title') }}</h3>
             <span class="text-xs text-neutral-500">
@@ -538,7 +538,7 @@ const hasAnyData = computed(() =>
         </div>
 
         <!-- Plán plateb (cash-outflow 30/60/90) -->
-        <div v-if="outflowForecast.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="outflowForecast.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('costs.outflow_forecast_title') }}</h3>
             <span class="text-xs text-neutral-400">{{ t('costs.outflow_forecast_hint') }}</span>
@@ -569,7 +569,7 @@ const hasAnyData = computed(() =>
       </div>
 
       <!-- Aging report — stáří závazků -->
-      <div v-if="agingRows.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-if="agingRows.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('costs.aging_title') }}</h3>
           <span class="text-xs text-neutral-400">{{ t('costs.aging_hint') }}</span>
@@ -619,7 +619,7 @@ const hasAnyData = computed(() =>
 
       <!-- Distribuce velikosti přijatých faktur -->
       <div v-if="summary.invoice_size_histogram.total > 0"
-        class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('costs.invoice_size_title') }}</h3>
           <span class="text-xs text-neutral-400">{{ t('costs.invoice_size_hint', { n: summary.invoice_size_histogram.total }) }}</span>

--- a/web/src/pages/ResetPassword.vue
+++ b/web/src/pages/ResetPassword.vue
@@ -43,7 +43,7 @@ async function submit() {
 <template>
   <AppShell :title="t('auth.reset_title')">
     <div class="w-full max-w-sm">
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-6">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-6">
         <h2 class="text-xl font-semibold mb-1">{{ t('auth.reset_title') }}</h2>
 
         <div v-if="success" class="rounded-md bg-primary-50 border border-primary-200 p-4 text-sm text-primary-800 mt-4">

--- a/web/src/pages/Setup.vue
+++ b/web/src/pages/Setup.vue
@@ -202,7 +202,7 @@ async function submit() {
 <template>
   <AppShell :title="t('setup.title')">
     <div class="w-full max-w-xl">
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-6">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-6">
         <!-- Progress -->
         <div class="flex items-center mb-6 text-sm">
           <span :class="step >= 1 ? 'text-primary-600 font-medium' : 'text-neutral-400'">1. {{ t('setup.step_admin') }}</span>
@@ -293,7 +293,7 @@ async function submit() {
               <div v-if="aresMessage" class="mt-2 text-xs px-2 py-1 rounded"
                 :class="aresMessage.type === 'success' ? 'bg-success-50 text-success-600' : 'bg-danger-50 text-danger-500'">
                 {{ aresMessage.text }}
-                <span v-if="aresMessage.type === 'success' && !supplier.email" class="block mt-0.5 text-warning-700">
+                <span v-if="aresMessage.type === 'success' && !supplier.email" class="block mt-0.5 text-warning-600">
                   {{ t('supplier.ares_loaded_email_hint') }}
                 </span>
               </div>
@@ -336,7 +336,7 @@ async function submit() {
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('common.currency') }}</label>
-                  <select v-model="supplier.bank_currency" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+                  <select v-model="supplier.bank_currency" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
                     <option value="CZK">CZK</option>
                     <option value="EUR">EUR</option>
                   </select>
@@ -402,7 +402,7 @@ async function submit() {
           <h2 class="text-xl font-semibold mb-2">{{ t('common.success') }}</h2>
           <p class="text-neutral-500 mb-2">{{ locale === 'cs' ? 'Admin účet byl vytvořen a jste přihlášen.' : 'Admin account created and you are signed in.' }}</p>
 
-          <div v-if="requireTotp" class="mb-6 inline-block bg-warning-50 border border-warning-500/40 rounded-md px-4 py-2 text-sm text-warning-700 text-left">
+          <div v-if="requireTotp" class="mb-6 inline-block bg-warning-50 border border-warning-500/40 rounded-md px-4 py-2 text-sm text-warning-600 text-left">
             {{ locale === 'cs'
               ? 'Vynucení 2FA je aktivní. Po pokračování budeš přesměrován na nastavení TOTP.'
               : '2FA enforcement is active. You will be redirected to TOTP setup next.' }}

--- a/web/src/pages/Stats.vue
+++ b/web/src/pages/Stats.vue
@@ -191,7 +191,7 @@ const hasAnyData = computed(() =>
       {{ error }}
     </div>
 
-    <div v-else-if="!hasAnyData" class="bg-white border border-neutral-200 rounded-lg p-8 text-center">
+    <div v-else-if="!hasAnyData" class="bg-surface border border-neutral-200 rounded-lg p-8 text-center">
       <p class="text-neutral-500">{{ t('stats.no_data') }}</p>
     </div>
 
@@ -199,7 +199,7 @@ const hasAnyData = computed(() =>
       <!-- Plovoucí 12měsíční obrat — KPI tiles per měna -->
       <div v-if="summary.rolling_12m.length" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <div v-for="r in summary.rolling_12m" :key="`r12-${r.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">
             {{ t('stats.rolling_12m', { currency: r.currency }) }}
           </div>
@@ -222,7 +222,7 @@ const hasAnyData = computed(() =>
 
         <!-- Obrat pro registraci DPH (kalendářní rok) — relevantní pro neplátce -->
         <div v-if="!isVatPayer && obratCzkThisYear !== null"
-          class="bg-white border rounded-lg p-5 shadow-sm"
+          class="bg-surface border rounded-lg p-5 shadow-sm"
           :class="obratCzkThisYear >= VAT_REG_THRESHOLD ? 'border-danger-500/40 bg-danger-50/30'
                 : obratCzkThisYear >= VAT_REG_NEAR ? 'border-warning-500/50 bg-warning-50/30'
                 : 'border-neutral-200'">
@@ -247,7 +247,7 @@ const hasAnyData = computed(() =>
 
         <!-- Paušální daň — limit příjmů pro zvolené pásmo (§ 7a ZDP) -->
         <div v-if="summary.flat_tax_threshold && summary.flat_tax_threshold.applicable && summary.flat_tax_threshold.limit_czk"
-          class="bg-white border rounded-lg p-5 shadow-sm"
+          class="bg-surface border rounded-lg p-5 shadow-sm"
           :class="summary.flat_tax_threshold.status === 'danger' ? 'border-danger-500/40 bg-danger-50/30'
                 : summary.flat_tax_threshold.status === 'warning' ? 'border-warning-500/50 bg-warning-50/30'
                 : 'border-neutral-200'">
@@ -278,7 +278,7 @@ const hasAnyData = computed(() =>
 
         <!-- Obrat tento rok per měna -->
         <div v-for="r in revenueThisYear" :key="`ty-${r.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">
             {{ t('stats.revenue_this_year', { year: summary.year, currency: r.currency }) }}
           </div>
@@ -297,7 +297,7 @@ const hasAnyData = computed(() =>
 
         <!-- Forecast aktuálního roku per měna — growth-adjusted seasonality -->
         <div v-for="f in summary.revenue_forecast" :key="`fc-${f.currency}`"
-          class="bg-white border border-primary-200 rounded-lg p-5 shadow-sm bg-primary-50/30">
+          class="bg-surface border border-primary-200 rounded-lg p-5 shadow-sm bg-primary-50/30">
           <div class="text-xs uppercase tracking-wide text-primary-700 mb-1">
             {{ t('stats.forecast_year', { year: summary.year, currency: f.currency }) }}
           </div>
@@ -320,7 +320,7 @@ const hasAnyData = computed(() =>
 
         <!-- Obrat minulý rok per měna -->
         <div v-for="r in revenuePrevYear" :key="`py-${r.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">
             {{ t('stats.revenue_prev_year', { year: summary.prev_year, currency: r.currency }) }}
           </div>
@@ -333,21 +333,21 @@ const hasAnyData = computed(() =>
         </div>
 
         <!-- Počet vystavených faktur YTD -->
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('stats.invoices_count_ytd', { year: summary.year }) }}</div>
           <div class="text-2xl font-semibold text-neutral-900">{{ summary.kpi.issued_count_ytd }}</div>
           <div class="text-xs text-neutral-400 mt-1">{{ t('dashboard.invoices_unit') }}</div>
         </div>
 
         <!-- Počet aktivních klientů -->
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('stats.active_clients') }}</div>
           <div class="text-2xl font-semibold text-neutral-900">{{ summary.active_clients_count }}</div>
           <div class="text-xs text-neutral-400 mt-1">{{ t('stats.active_clients_hint') }}</div>
         </div>
 
         <!-- Ø doba úhrady -->
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('dashboard.avg_payment') }}</div>
           <div class="text-2xl font-semibold text-neutral-900">
             {{ summary.kpi.avg_payment_days !== null ? summary.kpi.avg_payment_days + ' ' + t('dashboard.days') : '—' }}
@@ -357,7 +357,7 @@ const hasAnyData = computed(() =>
 
         <!-- Obrat posledních 30 dní per měna -->
         <div v-for="r in summary.revenue_last_30d" :key="`r30-${r.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">
             {{ t('stats.revenue_last_30d', { currency: r.currency }) }}
           </div>
@@ -368,7 +368,7 @@ const hasAnyData = computed(() =>
 
         <!-- Aktivní pravidelné fakturace -->
         <RouterLink to="/recurring"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm hover:bg-neutral-50 transition cursor-pointer block">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm hover:bg-neutral-50 transition cursor-pointer block">
           <div class="text-xs uppercase tracking-wide text-neutral-500 mb-1">{{ t('stats.active_recurring') }}</div>
           <div class="text-2xl font-semibold text-neutral-900">{{ summary.active_recurring_count }}</div>
           <div class="text-[11px] text-neutral-400 mt-2">{{ t('stats.active_recurring_hint') }}</div>
@@ -378,7 +378,7 @@ const hasAnyData = computed(() =>
       <!-- Měsíční obrat — bar + prev-year linka -->
       <div v-if="summary.revenue_by_month.length" class="space-y-4">
         <div v-for="rev in summary.revenue_by_month" :key="`m-${rev.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('stats.revenue_last_12_months', { currency: rev.currency }) }}
           </h3>
@@ -389,7 +389,7 @@ const hasAnyData = computed(() =>
       <!-- Kumulativní YTD vs loni — per měna -->
       <div v-if="summary.revenue_by_month.length" class="space-y-4">
         <div v-for="rev in summary.revenue_by_month" :key="`c-${rev.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('stats.cumulative_ytd', { currency: rev.currency }) }}
@@ -403,13 +403,13 @@ const hasAnyData = computed(() =>
       <!-- Top klienti pie YTD + loni -->
       <div v-if="(summary.top_clients_ytd.length + summary.top_clients_prev_year.length) > 0"
         class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div v-if="summary.top_clients_ytd.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="summary.top_clients_ytd.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('stats.top_clients_year', { year: summary.year }) }}
           </h3>
           <TopClientsPieChart :clients="summary.top_clients_ytd" />
         </div>
-        <div v-if="summary.top_clients_prev_year.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="summary.top_clients_prev_year.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('stats.top_clients_year', { year: summary.prev_year }) }}
           </h3>
@@ -420,7 +420,7 @@ const hasAnyData = computed(() =>
       <!-- Top zakázky bar YTD + loni -->
       <div v-if="projectStats && (projectStats.top_this_year.top.length + projectStats.top_prev_year.top.length) > 0"
         class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div v-if="projectStats.top_this_year.top.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="projectStats.top_this_year.top.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('stats.top_projects_year', { year: projectStats.this_year }) }}
@@ -433,7 +433,7 @@ const hasAnyData = computed(() =>
             :greyed-indexes="topProjectChart('this').greyed"
             :currency="'CZK'" />
         </div>
-        <div v-if="projectStats.top_prev_year.top.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="projectStats.top_prev_year.top.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('stats.top_projects_year', { year: projectStats.prev_year }) }}
@@ -451,14 +451,14 @@ const hasAnyData = computed(() =>
       <!-- Status donuty (faktury + zakázky) -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div v-if="summary.kpi.status_counts_ytd && Object.keys(summary.kpi.status_counts_ytd).length"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('stats.status_invoices', { year: summary.year }) }}
           </h3>
           <StatusDoughnutChart :counts="summary.kpi.status_counts_ytd" />
         </div>
         <div v-if="projectStats && projectStats.status_breakdown.length"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">
             {{ t('stats.status_projects') }}
           </h3>
@@ -469,7 +469,7 @@ const hasAnyData = computed(() =>
       <!-- Číselné tabulky pod grafy -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Obrat po rocích -->
-        <div v-if="summary.revenue_by_year.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="summary.revenue_by_year.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="font-semibold">{{ t('stats.revenue_by_year_table') }}</h3>
           </header>
@@ -506,7 +506,7 @@ const hasAnyData = computed(() =>
         </div>
 
         <!-- Obrat po měsících (12 měsíců) -->
-        <div v-if="monthlyTable.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="monthlyTable.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="font-semibold">{{ t('stats.revenue_by_month_table') }}</h3>
           </header>
@@ -535,7 +535,7 @@ const hasAnyData = computed(() =>
 
       <!-- Top 12 klientů + Top 12 zakázek za rolling 12 měsíců (smart mix — pie nahoře YTD/loni, tabulky 12m) -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div v-if="summary.top_clients_12m.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="summary.top_clients_12m.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="font-semibold">{{ t('stats.top_clients_12m_table') }}</h3>
           </header>
@@ -567,7 +567,7 @@ const hasAnyData = computed(() =>
         </div>
 
         <div v-if="projectStats && projectStats.top_12m.top.length"
-          class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+          class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="font-semibold">{{ t('stats.top_projects_12m_table') }}</h3>
           </header>
@@ -600,7 +600,7 @@ const hasAnyData = computed(() =>
       </div>
 
       <!-- Concentration risk — % obratu z TOP3/TOP5 klientů (rolling 12m) -->
-      <div v-if="concentration" class="bg-white border rounded-lg p-5 shadow-sm"
+      <div v-if="concentration" class="bg-surface border rounded-lg p-5 shadow-sm"
         :class="concentrationLevel === 'high' ? 'border-danger-500/40 bg-danger-50/30'
               : concentrationLevel === 'medium' ? 'border-warning-500/50 bg-warning-50/30'
               : 'border-neutral-200'">
@@ -655,7 +655,7 @@ const hasAnyData = computed(() =>
 
       <!-- Histogram doby úhrady + DPH rozpad (vedle sebe) -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div v-if="summary.payment_days_histogram.total > 0" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div v-if="summary.payment_days_histogram.total > 0" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('stats.payment_histogram_title') }}</h3>
             <span class="text-xs text-neutral-500">
@@ -666,7 +666,7 @@ const hasAnyData = computed(() =>
         </div>
 
         <div v-if="isVatPayer && summary.vat_breakdown_12m.length"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('stats.vat_breakdown_title') }}</h3>
             <span class="text-xs font-mono text-neutral-500">{{ primaryCurrency }} · {{ t('stats.last_12_months') }}</span>
@@ -678,7 +678,7 @@ const hasAnyData = computed(() =>
       <!-- Cash-flow YTD — kumulativní křivka inkasovaných plateb -->
       <div v-if="summary.cashflow_ytd.length" class="space-y-4">
         <div v-for="cf in summary.cashflow_ytd" :key="`cf-${cf.currency}`"
-          class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <div class="flex items-baseline justify-between mb-3">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('stats.cashflow_title', { currency: cf.currency }) }}</h3>
             <span class="text-xs text-neutral-400">{{ t('stats.cashflow_hint') }}</span>
@@ -688,7 +688,7 @@ const hasAnyData = computed(() =>
       </div>
 
       <!-- Aging report — stáří pohledávek -->
-      <div v-if="agingRows.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-if="agingRows.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('stats.aging_title') }}</h3>
           <span class="text-xs text-neutral-400">{{ t('stats.aging_hint') }}</span>
@@ -739,7 +739,7 @@ const hasAnyData = computed(() =>
 
       <!-- Distribuce velikosti faktur -->
       <div v-if="summary.invoice_size_histogram.total > 0"
-        class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('stats.invoice_size_title') }}</h3>
           <span class="text-xs text-neutral-400">{{ t('stats.invoice_size_hint', { n: summary.invoice_size_histogram.total }) }}</span>

--- a/web/src/pages/TotpSetup.vue
+++ b/web/src/pages/TotpSetup.vue
@@ -62,7 +62,7 @@ onMounted(loadStatus)
       </RouterLink>
     </div>
 
-    <div class="bg-white border border-neutral-200 rounded-lg p-6 shadow-sm space-y-4">
+    <div class="bg-surface border border-neutral-200 rounded-lg p-6 shadow-sm space-y-4">
       <div v-if="status">
         <div v-if="status.enabled" class="flex items-center gap-2 text-success-600">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>

--- a/web/src/pages/admin/ActivityLog.vue
+++ b/web/src/pages/admin/ActivityLog.vue
@@ -69,12 +69,12 @@ function goPage(delta: number) {
     </div>
 
     <!-- Filtry -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm mb-4 p-3 flex flex-wrap gap-2 items-center">
-      <select v-model="filter.action" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm mb-4 p-3 flex flex-wrap gap-2 items-center">
+      <select v-model="filter.action" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
         <option value="">{{ t('activity_log.all_actions') }}</option>
         <option v-for="a in actions" :key="a.action" :value="a.action">{{ a.action }} ({{ a.cnt }})</option>
       </select>
-      <select v-model="filter.entity_type" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+      <select v-model="filter.entity_type" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
         <option value="">{{ t('activity_log.all_entities') }}</option>
         <option value="invoice">invoice</option>
         <option value="user">user</option>
@@ -90,11 +90,11 @@ function goPage(delta: number) {
 
     <div v-if="loading" class="text-center text-neutral-500 py-12 text-sm">{{ t('common.loading') }}</div>
 
-    <div v-else-if="!entries.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-12 text-center text-neutral-500">
+    <div v-else-if="!entries.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-12 text-center text-neutral-500">
       {{ t('activity_log.no_records') }}
     </div>
 
-    <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <!-- Desktop: tabulka -->
       <div class="hidden md:block overflow-x-auto">
       <table class="w-full text-sm table-sticky-first">

--- a/web/src/pages/admin/Approvals.vue
+++ b/web/src/pages/admin/Approvals.vue
@@ -97,13 +97,13 @@ function daysSince(date: string | null): number | null {
     </div>
 
     <!-- Filtry -->
-    <div class="bg-white border border-neutral-200 rounded-lg p-3 mb-4 flex flex-wrap items-center gap-2">
+    <div class="bg-surface border border-neutral-200 rounded-lg p-3 mb-4 flex flex-wrap items-center gap-2">
       <button v-for="opt in (['requested','approved','rejected','all'] as const)" :key="opt"
         @click="statusFilter = opt"
         class="cursor-pointer px-3 h-8 text-xs rounded-md font-medium border inline-flex items-center gap-1.5"
         :class="statusFilter === opt
           ? 'bg-primary-600 text-white border-primary-600'
-          : 'bg-white text-neutral-700 border-neutral-300 hover:bg-neutral-50'">
+          : 'bg-surface text-neutral-700 border-neutral-300 hover:bg-neutral-50'">
         {{ t('approval_inbox.filter_' + opt) }}
         <span class="text-xs opacity-80">({{ counts[opt] }})</span>
       </button>
@@ -118,11 +118,11 @@ function daysSince(date: string | null): number | null {
     <div v-if="loading" class="text-center text-neutral-500 py-12 text-sm">{{ t('common.loading') }}</div>
 
     <div v-else-if="filteredItems.length === 0"
-      class="bg-white border border-neutral-200 rounded-lg p-12 text-center text-sm text-neutral-500">
+      class="bg-surface border border-neutral-200 rounded-lg p-12 text-center text-sm text-neutral-500">
       {{ t('approval_inbox.empty') }}
     </div>
 
-    <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <!-- Desktop: tabulka -->
       <div class="hidden md:block overflow-x-auto">
       <table class="w-full text-sm table-sticky-first">

--- a/web/src/pages/admin/Codebooks.vue
+++ b/web/src/pages/admin/Codebooks.vue
@@ -510,7 +510,7 @@ watch(tab, (newTab) => {
       </div>
 
       <!-- Desktop tabulka -->
-      <div class="hidden md:block bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="hidden md:block bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <div class="overflow-x-auto">
           <table class="w-full text-sm table-sticky-first">
             <thead class="bg-neutral-50 text-xs text-neutral-500 uppercase tracking-wide">
@@ -557,7 +557,7 @@ watch(tab, (newTab) => {
       </div>
 
       <!-- Mobile karty -->
-      <div class="md:hidden bg-white border border-neutral-200 rounded-lg shadow-sm divide-y divide-neutral-100 overflow-hidden">
+      <div class="md:hidden bg-surface border border-neutral-200 rounded-lg shadow-sm divide-y divide-neutral-100 overflow-hidden">
         <div v-for="s in suppliers" :key="`m-${s.id}`" class="px-4 py-3">
           <div class="flex items-baseline justify-between gap-2">
             <div class="font-medium text-neutral-900 flex items-center gap-1.5 min-w-0 truncate">
@@ -595,7 +595,7 @@ watch(tab, (newTab) => {
           {{ t('codebooks.new_currency') }}
         </button>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <!-- Desktop: tabulka -->
         <div class="hidden md:block overflow-x-auto">
         <table class="w-full text-sm table-sticky-first">
@@ -687,7 +687,7 @@ watch(tab, (newTab) => {
           {{ t('codebooks.new_vat') }}
         </button>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <!-- Desktop: tabulka -->
         <div class="hidden md:block overflow-x-auto">
         <table class="w-full text-sm table-sticky-first">
@@ -766,7 +766,7 @@ watch(tab, (newTab) => {
           {{ t('codebooks.new_country') }}
         </button>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <!-- Desktop: tabulka -->
         <div class="hidden md:block overflow-x-auto">
         <table class="w-full text-sm table-sticky-first">
@@ -836,7 +836,7 @@ watch(tab, (newTab) => {
           {{ t('codebooks.new_unit') }}
         </button>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <!-- Desktop: tabulka -->
         <div class="hidden md:block overflow-x-auto">
         <table class="w-full text-sm table-sticky-first">
@@ -905,11 +905,11 @@ watch(tab, (newTab) => {
         </button>
       </div>
 
-      <div v-if="expenseCategories.length === 0" class="bg-white border border-dashed border-neutral-300 rounded-lg p-8 text-center text-sm text-neutral-500">
+      <div v-if="expenseCategories.length === 0" class="bg-surface border border-dashed border-neutral-300 rounded-lg p-8 text-center text-sm text-neutral-500">
         {{ t('expense_categories.empty') }}
       </div>
 
-      <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <table class="w-full text-sm">
           <thead class="bg-neutral-50 text-xs text-neutral-500 uppercase tracking-wide">
             <tr>
@@ -958,11 +958,11 @@ watch(tab, (newTab) => {
         </button>
       </div>
 
-      <div v-if="vatClassifications.length === 0" class="bg-white border border-dashed border-neutral-300 rounded-lg p-8 text-center text-sm text-neutral-500">
+      <div v-if="vatClassifications.length === 0" class="bg-surface border border-dashed border-neutral-300 rounded-lg p-8 text-center text-sm text-neutral-500">
         {{ t('vat_classifications.empty') }}
       </div>
 
-      <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <table class="w-full text-sm">
           <thead class="bg-neutral-50 text-xs text-neutral-500 uppercase tracking-wide">
             <tr>
@@ -1015,8 +1015,8 @@ watch(tab, (newTab) => {
     <!-- ====== Modals ====== -->
 
     <!-- VAT classification modal -->
-    <div v-if="vatClsOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-xl w-full p-5">
+    <div v-if="vatClsOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-xl w-full p-5">
         <h3 class="text-lg font-semibold mb-3">
           {{ vatClsEditMode === 'edit' ? t('vat_classifications.edit_title') : t('vat_classifications.new_title') }}
         </h3>
@@ -1030,7 +1030,7 @@ watch(tab, (newTab) => {
             </div>
             <div>
               <label class="block text-xs font-medium text-neutral-700 mb-1">{{ t('vat_classifications.direction') }}</label>
-              <select v-model="vatClsDraft.direction" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+              <select v-model="vatClsDraft.direction" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
                 <option value="sale">{{ t('vat_classifications.direction_sale') }}</option>
                 <option value="purchase">{{ t('vat_classifications.direction_purchase') }}</option>
                 <option value="both">{{ t('vat_classifications.direction_both') }}</option>
@@ -1081,8 +1081,8 @@ watch(tab, (newTab) => {
     </div>
 
     <!-- Expense category modal -->
-    <div v-if="expenseOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="expenseOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">
           {{ expenseDraft.id ? t('expense_categories.edit_title') : t('expense_categories.new_title') }}
         </h3>
@@ -1100,7 +1100,7 @@ watch(tab, (newTab) => {
           </div>
           <div>
             <label class="block text-xs font-medium text-neutral-700 mb-1">{{ t('expense_categories.fixed_or_var') }}</label>
-            <select v-model="expenseDraft.fixed_or_var" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="expenseDraft.fixed_or_var" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
               <option value="variable">{{ t('expense_categories.variable') }}</option>
               <option value="fixed">{{ t('expense_categories.fixed') }}</option>
             </select>
@@ -1123,8 +1123,8 @@ watch(tab, (newTab) => {
     </div>
 
     <!-- Supplier create modal (multi-tenant firma) -->
-    <div v-if="supplierCreateOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-xl w-full p-5">
+    <div v-if="supplierCreateOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-xl w-full p-5">
         <h3 class="text-lg font-semibold mb-1">{{ t('supplier.create_title') }}</h3>
         <p class="text-xs text-neutral-500 mb-4">{{ t('supplier.create_hint') }}</p>
         <form @submit.prevent="saveSupplier">
@@ -1183,8 +1183,8 @@ watch(tab, (newTab) => {
       </div>
     </div>
 
-    <div v-if="currencyOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="currencyOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ currencyDraft._new ? t('codebooks.new_currency') : t('settings.edit_currency', { code: currencyDraft.code }) }}</h3>
         <div class="space-y-3">
           <div class="grid grid-cols-3 gap-3" v-if="currencyDraft._new">
@@ -1232,8 +1232,8 @@ watch(tab, (newTab) => {
       </div>
     </div>
 
-    <div v-if="vatOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="vatOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ vatDraft._new ? t('codebooks.new_vat') : vatDraft.code }}</h3>
         <div class="space-y-3">
           <div class="grid grid-cols-3 gap-3">
@@ -1270,8 +1270,8 @@ watch(tab, (newTab) => {
       </div>
     </div>
 
-    <div v-if="unitOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="unitOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ unitDraft._new ? t('codebooks.new_unit') : unitDraft.code }}</h3>
         <div class="space-y-3">
           <div>
@@ -1301,8 +1301,8 @@ watch(tab, (newTab) => {
       </div>
     </div>
 
-    <div v-if="countryOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="countryOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ countryDraft._new ? t('codebooks.new_country') : countryDraft.iso2 }}</h3>
         <div class="space-y-3">
           <div class="grid grid-cols-2 gap-3">

--- a/web/src/pages/admin/CronJobs.vue
+++ b/web/src/pages/admin/CronJobs.vue
@@ -148,7 +148,7 @@ const hasProblems = computed(() => jobs.value.some(j => j.health !== 'ok'))
 
     <div v-if="loading && !jobs.length" class="text-center text-neutral-500 py-12 text-sm">{{ t('common.loading') }}</div>
 
-    <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <!-- Desktop tabulka -->
       <div class="hidden md:block overflow-x-auto">
         <table class="w-full text-sm">
@@ -199,7 +199,7 @@ const hasProblems = computed(() => jobs.value.some(j => j.health !== 'ok'))
                 <td class="px-3 py-2 text-right whitespace-nowrap" @click.stop>
                   <button
                     type="button"
-                    class="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-neutral-200 bg-white hover:bg-neutral-50 text-neutral-700 disabled:opacity-50 disabled:cursor-wait"
+                    class="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-neutral-200 bg-surface hover:bg-neutral-50 text-neutral-700 disabled:opacity-50 disabled:cursor-wait"
                     :disabled="running[j.script]"
                     @click="runNow(j.script)"
                   >
@@ -297,7 +297,7 @@ const hasProblems = computed(() => jobs.value.some(j => j.health !== 'ok'))
           <div class="pt-1">
             <button
               type="button"
-              class="text-xs px-2 py-1 rounded border border-neutral-200 bg-white hover:bg-neutral-50 text-neutral-700 disabled:opacity-50 disabled:cursor-wait"
+              class="text-xs px-2 py-1 rounded border border-neutral-200 bg-surface hover:bg-neutral-50 text-neutral-700 disabled:opacity-50 disabled:cursor-wait"
               :disabled="running[j.script]"
               @click="runNow(j.script)"
             >

--- a/web/src/pages/admin/EmailTemplates.vue
+++ b/web/src/pages/admin/EmailTemplates.vue
@@ -69,7 +69,7 @@ function codeLabel(code: string): string {
 
     <div v-if="loading" class="text-center text-neutral-500 py-12 text-sm">{{ t('common.loading') }}</div>
 
-    <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <!-- Desktop: tabulka -->
       <div class="hidden md:block overflow-x-auto">
       <table class="w-full text-sm table-sticky-first">
@@ -115,8 +115,8 @@ function codeLabel(code: string): string {
     </div>
 
     <!-- Editor modal -->
-    <div v-if="editing" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto p-5">
+    <div v-if="editing" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-4xl w-full max-h-[90vh] overflow-y-auto p-5">
         <h3 class="text-lg font-semibold mb-3">{{ codeLabel(editing.code) }} <span class="text-xs font-mono uppercase text-neutral-500 ml-1">{{ editing.locale }}</span></h3>
 
         <div class="space-y-3">

--- a/web/src/pages/admin/Export.vue
+++ b/web/src/pages/admin/Export.vue
@@ -68,7 +68,7 @@ const monthLabel = (m: string): string => {
       <p class="text-sm text-neutral-500 mt-0.5">{{ t('export.subtitle') }}</p>
     </div>
 
-    <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm max-w-md">
+    <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm max-w-md">
       <div class="space-y-4">
         <div>
           <label class="block text-sm font-medium text-neutral-700 mb-2">{{ t('export.format') }} *</label>
@@ -132,7 +132,7 @@ const monthLabel = (m: string): string => {
         </div>
         <div>
           <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('export.type_optional') }}</label>
-          <select v-model="type" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+          <select v-model="type" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
             <option value="">{{ t('export.type_all') }}</option>
             <option value="invoice">{{ t('export.type_invoice_only') }}</option>
             <option value="proforma">{{ t('export.type_proforma_only') }}</option>

--- a/web/src/pages/admin/Imports.vue
+++ b/web/src/pages/admin/Imports.vue
@@ -121,7 +121,7 @@ async function runScan() {
     </div>
 
     <!-- Tabs: Vystavené / Přijaté -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm max-w-3xl">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm max-w-3xl">
       <div class="px-4 pt-2 border-b border-neutral-100 flex items-center gap-1">
         <button
           type="button"
@@ -327,7 +327,7 @@ async function runScan() {
         </div>
 
         <!-- Scan result -->
-        <div v-if="scanResult" class="mt-4 bg-white border border-neutral-200 rounded-lg p-4">
+        <div v-if="scanResult" class="mt-4 bg-surface border border-neutral-200 rounded-lg p-4">
           <div class="flex flex-wrap items-center gap-4 mb-3 text-sm">
             <div><span class="font-semibold text-success-600">{{ scanResult.created }}</span> {{ t('imports.summary_created') }}</div>
             <div><span class="font-semibold text-warning-600">{{ scanResult.skipped }}</span> {{ t('imports.summary_skipped') }}</div>
@@ -369,7 +369,7 @@ async function runScan() {
     </div>
 
     <!-- Report — pro oba tabs (issued / purchase) -->
-    <div v-if="report" class="mt-6 bg-white border border-neutral-200 rounded-lg p-5 shadow-sm max-w-3xl">
+    <div v-if="report" class="mt-6 bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm max-w-3xl">
       <div class="flex items-center gap-4 mb-4 text-sm">
         <div><span class="font-semibold text-success-600">{{ report.summary.created }}</span> {{ t('imports.summary_created') }}</div>
         <div><span class="font-semibold text-warning-600">{{ report.summary.skipped }}</span> {{ t('imports.summary_skipped') }}</div>

--- a/web/src/pages/admin/Integrations.vue
+++ b/web/src/pages/admin/Integrations.vue
@@ -477,7 +477,7 @@ onUnmounted(() => {
     <!-- ════ iDoklad tab ════ -->
     <div v-if="tab === 'idoklad'" class="space-y-4">
       <!-- Box: credentials -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-2">{{ t('integrations.idoklad.credentials_title') }}</h2>
         <p class="text-xs text-neutral-500 mb-4">{{ t('integrations.idoklad.credentials_hint') }}</p>
 
@@ -537,7 +537,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Box: import controls -->
-      <div v-if="idokladStatus?.configured" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-if="idokladStatus?.configured" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-3">{{ t('integrations.idoklad.run_title') }}</h2>
 
         <div v-if="!isJobRunning" class="space-y-3">
@@ -643,7 +643,7 @@ onUnmounted(() => {
 
     <!-- ════ Fakturoid tab ════ -->
     <div v-else-if="tab === 'fakturoid'" class="space-y-4">
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-2">{{ t('integrations.fakturoid.credentials_title') }}</h2>
         <p class="text-xs text-neutral-500 mb-4">{{ t('integrations.fakturoid.credentials_hint') }}</p>
 
@@ -661,14 +661,14 @@ onUnmounted(() => {
                     class="cursor-pointer px-3 py-1.5 text-xs rounded-md border transition"
                     :class="fakAuthMode === 'oauth2'
                       ? 'bg-primary-600 text-white border-primary-600 font-medium'
-                      : 'bg-white text-neutral-700 border-neutral-300 hover:border-neutral-400'">
+                      : 'bg-surface text-neutral-700 border-neutral-300 hover:border-neutral-400'">
               {{ t('integrations.fakturoid.mode_oauth') }}
             </button>
             <button type="button" @click="fakAuthMode = 'basic'"
                     class="cursor-pointer px-3 py-1.5 text-xs rounded-md border transition"
                     :class="fakAuthMode === 'basic'
                       ? 'bg-primary-600 text-white border-primary-600 font-medium'
-                      : 'bg-white text-neutral-700 border-neutral-300 hover:border-neutral-400'">
+                      : 'bg-surface text-neutral-700 border-neutral-300 hover:border-neutral-400'">
               {{ t('integrations.fakturoid.mode_basic') }}
             </button>
           </div>
@@ -755,7 +755,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Box: import controls -->
-      <div v-if="fakStatus?.configured" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-if="fakStatus?.configured" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-3">{{ t('integrations.idoklad.run_title') }}</h2>
 
         <div v-if="!isJobRunning" class="space-y-3">
@@ -863,7 +863,7 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-2">{{ t('integrations.ai.credentials_title') }}</h2>
         <p class="text-xs text-neutral-500 mb-4">{{ t('integrations.ai.credentials_hint') }}</p>
 
@@ -890,7 +890,7 @@ onUnmounted(() => {
           </div>
           <div>
             <label class="block text-sm text-neutral-700 mb-1">{{ t('integrations.ai.default_model') }}</label>
-            <select v-model="aiModel" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="aiModel" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
               <option v-for="m in (aiStatus?.allowed_models || ['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-7'])" :key="m" :value="m">
                 {{ m }} —
                 {{ m.includes('haiku') ? t('integrations.ai.cost_haiku')
@@ -920,7 +920,7 @@ onUnmounted(() => {
       </div>
 
       <!-- AI PDF extract -->
-      <div v-if="aiStatus?.configured" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-if="aiStatus?.configured" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-2">{{ t('integrations.ai.extract_title') }}</h2>
         <p class="text-xs text-neutral-500 mb-4">{{ t('integrations.ai.extract_hint') }}</p>
 
@@ -942,7 +942,7 @@ onUnmounted(() => {
 
           <div class="flex items-center gap-2">
             <label class="text-sm text-neutral-700">{{ t('integrations.ai.model_override') }}</label>
-            <select v-model="aiPerRequestModel" class="h-9 px-2 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="aiPerRequestModel" class="h-9 px-2 border border-neutral-300 rounded-md bg-surface text-sm">
               <option value="">{{ t('integrations.ai.use_default') }} ({{ aiStatus.default_model }})</option>
               <option v-for="m in aiStatus.allowed_models" :key="m" :value="m">{{ m }}</option>
             </select>
@@ -1017,7 +1017,7 @@ onUnmounted(() => {
     </div>
 
     <!-- Fallback (žádný tab nevyhovuje) -->
-    <div v-else class="bg-white border border-neutral-200 rounded-lg p-8 shadow-sm text-center text-neutral-500 text-sm">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg p-8 shadow-sm text-center text-neutral-500 text-sm">
       —
     </div>
   </div>

--- a/web/src/pages/admin/Settings.vue
+++ b/web/src/pages/admin/Settings.vue
@@ -310,7 +310,7 @@ async function removeCurrency(c: CurrencyAccount) {
 
     <div v-else-if="supplier" class="space-y-6">
       <!-- Supplier -->
-      <section class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <section class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">{{ t('settings.supplier') }}</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
@@ -376,7 +376,7 @@ async function removeCurrency(c: CurrencyAccount) {
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('settings.default_due_label') }}</label>
             <div class="flex gap-2">
-              <select v-model="dueSelectValue" class="h-10 px-2 border border-neutral-300 rounded-md text-sm bg-white" :class="dueSelectValue === 'custom' ? 'w-40' : 'w-full'">
+              <select v-model="dueSelectValue" class="h-10 px-2 border border-neutral-300 rounded-md text-sm bg-surface" :class="dueSelectValue === 'custom' ? 'w-40' : 'w-full'">
                 <option value="7">{{ t('settings.default_due_preset_7') }}</option>
                 <option value="14">{{ t('settings.default_due_preset_14') }}</option>
                 <option value="month">{{ t('settings.default_due_preset_month') }}</option>
@@ -419,7 +419,7 @@ async function removeCurrency(c: CurrencyAccount) {
       </section>
 
       <!-- Číslování faktur — samostatný box -->
-      <section class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <section class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">{{ t('settings.numbering_section') }}</h2>
         <div>
           <h3 class="sr-only">{{ t('settings.numbering_section') }}</h3>
@@ -482,7 +482,7 @@ async function removeCurrency(c: CurrencyAccount) {
       </section>
 
       <!-- Daňové nastavení (EPO výkazy DPH/KH/DPFO/DPPO) — samostatný box -->
-      <section class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <section class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">{{ t('settings.tax_section') }}</h2>
         <div>
           <h3 class="sr-only">{{ t('settings.tax_section') }}</h3>
@@ -490,7 +490,7 @@ async function removeCurrency(c: CurrencyAccount) {
           <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
               <label class="block text-xs font-medium text-neutral-700 mb-1">{{ t('settings.taxpayer_type') }}</label>
-              <select v-model="supplier.taxpayer_type" class="w-full h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+              <select v-model="supplier.taxpayer_type" class="w-full h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
                 <option :value="null">— {{ t('common.unset') }} —</option>
                 <option value="fo">{{ t('settings.taxpayer_fo') }}</option>
                 <option value="po">{{ t('settings.taxpayer_po') }}</option>
@@ -498,7 +498,7 @@ async function removeCurrency(c: CurrencyAccount) {
             </div>
             <div>
               <label class="block text-xs font-medium text-neutral-700 mb-1">{{ t('settings.vat_period') }}</label>
-              <select v-model="supplier.vat_period" class="w-full h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+              <select v-model="supplier.vat_period" class="w-full h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
                 <option :value="null">— {{ t('common.unset') }} —</option>
                 <option value="monthly">{{ t('settings.vat_monthly') }}</option>
                 <option value="quarterly">{{ t('settings.vat_quarterly') }}</option>
@@ -507,7 +507,7 @@ async function removeCurrency(c: CurrencyAccount) {
             </div>
             <div v-if="!supplier.is_vat_payer">
               <label class="block text-xs font-medium text-neutral-700 mb-1">{{ t('settings.flat_tax_band') }}</label>
-              <select v-model="(supplier as any).flat_tax_band" class="w-full h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+              <select v-model="(supplier as any).flat_tax_band" class="w-full h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
                 <option value="none">{{ t('settings.flat_tax_none') }}</option>
                 <option value="band1">{{ t('settings.flat_tax_band1') }}</option>
                 <option value="band2">{{ t('settings.flat_tax_band2') }}</option>
@@ -606,7 +606,7 @@ async function removeCurrency(c: CurrencyAccount) {
       </section>
 
       <!-- Pohoda XML export config (volitelné) — samostatný box -->
-      <section class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <section class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-4">{{ t('settings.pohoda_section') }}</h2>
         <div>
           <h3 class="sr-only">{{ t('settings.pohoda_section') }}</h3>
@@ -639,7 +639,7 @@ async function removeCurrency(c: CurrencyAccount) {
       </section>
 
       <!-- Email branding (M16) -->
-      <section class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <section class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-center justify-between mb-1">
           <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('settings.branding_title') }}</h2>
           <label class="inline-flex items-center gap-2 cursor-pointer">
@@ -733,7 +733,7 @@ async function removeCurrency(c: CurrencyAccount) {
       </section>
 
       <!-- Currencies / Bank accounts -->
-      <section class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <section class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200">
           <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('settings.currencies_banks') }}</h2>
         </header>
@@ -781,7 +781,7 @@ async function removeCurrency(c: CurrencyAccount) {
           <span>{{ t('settings.add_another_account') }}</span>
           <button v-for="code in [...new Set(currencies.map(c => c.code))]" :key="code"
             @click="addCurrencyAccount(code)"
-            class="cursor-pointer px-2 h-7 border border-neutral-300 rounded text-xs hover:bg-white">
+            class="cursor-pointer px-2 h-7 border border-neutral-300 rounded text-xs hover:bg-surface">
             + {{ code }}
           </button>
         </div>
@@ -789,8 +789,8 @@ async function removeCurrency(c: CurrencyAccount) {
     </div>
 
     <!-- Modal — currency edit -->
-    <div v-if="editingCurrency" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="editingCurrency" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ t('settings.edit_currency_label_full', { label: editingCurrencyLabel }) }}</h3>
         <div class="space-y-3">
           <div>

--- a/web/src/pages/admin/Update.vue
+++ b/web/src/pages/admin/Update.vue
@@ -291,7 +291,7 @@ function fmtDate(s?: string | null): string {
         class="rounded-lg border p-5"
         :class="status.has_update
           ? 'border-primary-300 bg-primary-50/40'
-          : 'border-neutral-200 bg-white'"
+          : 'border-neutral-200 bg-surface'"
       >
         <div class="flex flex-wrap items-baseline justify-between gap-4">
           <div>
@@ -330,7 +330,7 @@ function fmtDate(s?: string | null): string {
         </div>
 
         <div v-if="status.last_check_error"
-          class="mt-3 rounded-md bg-error-50 border border-error-200 p-3 text-xs text-error-700">
+          class="mt-3 rounded-md bg-danger-50 border border-danger-500/40 p-3 text-xs text-danger-600">
           {{ t('updates.last_check_error') }}: <span class="font-mono">{{ status.last_check_error }}</span>
         </div>
 
@@ -339,7 +339,7 @@ function fmtDate(s?: string | null): string {
             type="button"
             @click="refresh"
             :disabled="checking"
-            class="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50 disabled:opacity-60 disabled:cursor-not-allowed"
+            class="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-surface px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50 disabled:opacity-60 disabled:cursor-not-allowed"
           >
             <svg class="w-4 h-4" :class="{ 'animate-spin': checking }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 0 0 4.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 0 1-15.357-2m15.357 2H15"/></svg>
             {{ checking ? t('updates.checking') : t('updates.check_now') }}
@@ -355,7 +355,7 @@ function fmtDate(s?: string | null): string {
             {{ triggering ? t('updates.triggering') : t('updates.trigger_update', { version: status.latest }) }}
           </button>
           <a v-if="status.release_url" :href="status.release_url" target="_blank" rel="noopener"
-            class="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50">
+            class="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-surface px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3"/></svg>
             {{ t('updates.release_on_github') }}
           </a>
@@ -368,7 +368,7 @@ function fmtDate(s?: string | null): string {
           ? 'border-primary-300 bg-primary-50/40'
           : triggerResult.status === 'manual_required'
             ? 'border-neutral-300 bg-neutral-50'
-            : 'border-error-300 bg-error-50/40'">
+            : 'border-danger-500/40 bg-danger-50/40'">
         <h2 class="text-lg font-semibold text-neutral-900">
           <template v-if="triggerResult.status === 'queued'">{{ t('updates.queued_title') }}</template>
           <template v-else-if="triggerResult.status === 'manual_required'">{{ t('updates.manual_required_title') }}</template>
@@ -391,7 +391,7 @@ function fmtDate(s?: string | null): string {
         <p class="text-sm text-neutral-600 mt-1.5">{{ t('updates.in_progress_desc') }}</p>
         <div class="mt-3 pt-3 border-t border-primary-200/60 flex items-center gap-3 flex-wrap">
           <button type="button" @click="cancelStuckUpgrade" :disabled="cancelling"
-            class="cursor-pointer h-8 px-3 text-sm border border-neutral-300 bg-white hover:bg-neutral-50 rounded-md inline-flex items-center gap-1.5 disabled:opacity-50">
+            class="cursor-pointer h-8 px-3 text-sm border border-neutral-300 bg-surface hover:bg-neutral-50 rounded-md inline-flex items-center gap-1.5 disabled:opacity-50">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
             {{ cancelling ? '…' : t('updates.cancel_stuck') }}
           </button>
@@ -405,7 +405,7 @@ function fmtDate(s?: string | null): string {
         :class="['applied','success'].includes(status.last_upgrade_result.status)
           ? 'border-success-300 bg-success-50/40'
           : status.last_upgrade_result.status === 'failed'
-            ? 'border-error-300 bg-error-50/40'
+            ? 'border-danger-500/40 bg-danger-50/40'
             : 'border-warning-300 bg-warning-50/40'">
         <h2 class="text-lg font-semibold text-neutral-900">
           {{ ['applied','success'].includes(status.last_upgrade_result.status)
@@ -431,13 +431,13 @@ function fmtDate(s?: string | null): string {
 
       <!-- Release notes -->
       <section v-if="status.release_notes_md"
-        class="rounded-lg border border-neutral-200 bg-white p-5">
+        class="rounded-lg border border-neutral-200 bg-surface p-5">
         <h2 class="text-lg font-semibold text-neutral-900 mb-3">{{ t('updates.release_notes') }} (v{{ status.latest }})</h2>
         <div class="release-notes prose prose-sm max-w-none" v-html="renderedNotes"></div>
       </section>
 
       <!-- How upgrade works — vždy viditelné, environment-specific instrukce -->
-      <section class="rounded-lg border border-neutral-200 bg-white p-5">
+      <section class="rounded-lg border border-neutral-200 bg-surface p-5">
         <h2 class="text-lg font-semibold text-neutral-900 mb-3">{{ t('updates.how_it_works') }}</h2>
 
         <template v-if="status.environment === 'docker'">
@@ -488,7 +488,7 @@ php api/bin/migrate.php</code></pre>
       </section>
     </div>
 
-    <div v-if="errorMsg" class="rounded-md bg-error-50 border border-error-200 p-4 text-sm text-error-700">
+    <div v-if="errorMsg" class="rounded-md bg-danger-50 border border-danger-500/40 p-4 text-sm text-danger-600">
       {{ errorMsg }}
     </div>
   </div>
@@ -500,24 +500,24 @@ php api/bin/migrate.php</code></pre>
 .release-notes :deep(h2),
 .release-notes :deep(h3) {
   font-weight: 600;
-  color: #1f2937;
+  color: var(--color-neutral-900);
   margin: 1em 0 0.4em;
   line-height: 1.3;
 }
 .release-notes :deep(h1) { font-size: 1.25rem; }
 .release-notes :deep(h2) { font-size: 1.1rem; }
 .release-notes :deep(h3) { font-size: 1rem; }
-.release-notes :deep(p) { margin: 0.4em 0; line-height: 1.55; color: #374151; }
+.release-notes :deep(p) { margin: 0.4em 0; line-height: 1.55; color: var(--color-neutral-700); }
 .release-notes :deep(ul),
 .release-notes :deep(ol) {
   margin: 0.4em 0;
   padding-left: 1.5em;
-  color: #374151;
+  color: var(--color-neutral-700);
 }
 .release-notes :deep(li) { margin: 0.15em 0; }
 .release-notes :deep(code) {
-  background: #f3f4f6;
-  color: #c0392b;
+  background: var(--color-neutral-100);
+  color: var(--color-danger-600);
   padding: 0 4px;
   border-radius: 3px;
   font-size: 0.85em;
@@ -534,8 +534,8 @@ php api/bin/migrate.php</code></pre>
   line-height: 1.5;
 }
 .release-notes :deep(pre code) { background: transparent; color: inherit; padding: 0; }
-.release-notes :deep(strong) { font-weight: 600; color: #1f2937; }
+.release-notes :deep(strong) { font-weight: 600; color: var(--color-neutral-900); }
 .release-notes :deep(em) { font-style: italic; }
-.release-notes :deep(a) { color: #6c5ce7; text-decoration: underline; }
-.release-notes :deep(a:hover) { color: #4c1d95; }
+.release-notes :deep(a) { color: var(--color-primary-600); text-decoration: underline; }
+.release-notes :deep(a:hover) { color: var(--color-primary-700); }
 </style>

--- a/web/src/pages/admin/Users.vue
+++ b/web/src/pages/admin/Users.vue
@@ -118,7 +118,7 @@ function roleBadge(role: string): string {
 
     <div v-if="loading" class="text-center text-neutral-500 py-12 text-sm">{{ t('common.loading') }}</div>
 
-    <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <!-- Desktop: tabulka -->
       <div class="hidden md:block overflow-x-auto">
       <table class="w-full text-sm table-sticky-first">
@@ -206,8 +206,8 @@ function roleBadge(role: string): string {
     </div>
 
     <!-- Modal -->
-    <div v-if="showForm" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="showForm" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ form.id === null ? t('users.new_title') : t('users.edit_title', { email: form.email }) }}</h3>
         <div class="space-y-3">
           <div v-if="form.id === null">
@@ -221,7 +221,7 @@ function roleBadge(role: string): string {
           <div class="grid grid-cols-2 gap-3">
             <div>
               <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('users.role') }}</label>
-              <select v-model="form.role" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm bg-white">
+              <select v-model="form.role" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm bg-surface">
                 <option value="admin">admin</option>
                 <option value="accountant">accountant</option>
                 <option value="readonly">readonly</option>
@@ -229,7 +229,7 @@ function roleBadge(role: string): string {
             </div>
             <div>
               <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('common.language') }}</label>
-              <select v-model="form.locale" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm bg-white">
+              <select v-model="form.locale" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm bg-surface">
                 <option value="cs">cs</option>
                 <option value="en">en</option>
               </select>

--- a/web/src/pages/bank/StatementDetail.vue
+++ b/web/src/pages/bank/StatementDetail.vue
@@ -218,25 +218,25 @@ async function rematchStatement() {
     </p>
 
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mt-4 mb-4">
-      <div class="bg-white border border-neutral-200 rounded-lg p-4 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-4 shadow-sm">
         <div class="text-xs text-neutral-500 uppercase">{{ t('bank.prev_balance') }}</div>
         <div class="text-lg font-mono">{{ formatMoney(statement.prev_balance, statement.currency ?? 'CZK') }}</div>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-4 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-4 shadow-sm">
         <div class="text-xs text-neutral-500 uppercase">{{ t('bank.curr_balance') }}</div>
         <div class="text-lg font-mono font-semibold">{{ formatMoney(statement.curr_balance, statement.currency ?? 'CZK') }}</div>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-4 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-4 shadow-sm">
         <div class="text-xs text-neutral-500 uppercase">{{ t('bank.credit_total') }}</div>
         <div class="text-lg font-mono text-success-600">+{{ formatMoney(statement.credit_total, statement.currency ?? 'CZK') }}</div>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-4 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-4 shadow-sm">
         <div class="text-xs text-neutral-500 uppercase">{{ t('bank.debit_total') }}</div>
         <div class="text-lg font-mono text-danger-500">−{{ formatMoney(statement.debit_total, statement.currency ?? 'CZK') }}</div>
       </div>
     </div>
 
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between gap-3">
         <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
           {{ t('bank.transactions') }}
@@ -245,7 +245,7 @@ async function rematchStatement() {
         <div class="flex items-center gap-2">
           <select v-model="statusFilter"
             :title="t('bank.filter_status')"
-            class="h-8 px-2 text-xs border border-neutral-300 rounded-md text-neutral-700 bg-white">
+            class="h-8 px-2 text-xs border border-neutral-300 rounded-md text-neutral-700 bg-surface">
             <option value="">{{ t('bank.filter_all') }}</option>
             <option v-for="s in STATUS_OPTIONS" :key="s" :value="s">{{ statusLabel(s) }}</option>
           </select>
@@ -419,8 +419,8 @@ async function rematchStatement() {
     </div>
 
     <!-- Manual match modal — návrhy dle částky + ruční VS jako druhá možnost -->
-    <div v-if="matchingTx" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="matchingTx" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-1">{{ t('bank.manual_match_title') }}</h3>
         <p v-if="matchCtx" class="text-xs text-neutral-500 mb-3 font-mono">
           {{ matchCtx.amount > 0 ? '+' : '' }}{{ formatMoney(matchCtx.amount, matchCtx.currency ?? statement.currency ?? 'CZK') }}
@@ -484,8 +484,8 @@ async function rematchStatement() {
     </div>
 
     <!-- Vytvoření konceptu přijaté faktury z odchozí platby — výběr dodavatele -->
-    <div v-if="createTx" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="createTx" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-1">{{ t('bank.create_purchase_title') }}</h3>
         <p class="text-xs text-neutral-500 mb-3">
           {{ formatMoney(Math.abs(createTx.amount), createTx.currency ?? 'CZK') }} ·

--- a/web/src/pages/bank/StatementList.vue
+++ b/web/src/pages/bank/StatementList.vue
@@ -160,11 +160,11 @@ async function onFileSelected(e: Event) {
 
     <div v-if="loading" class="text-center text-neutral-500 py-12 text-sm">{{ t('common.loading') }}</div>
 
-    <div v-else-if="!statements.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-12 text-center text-neutral-500">
+    <div v-else-if="!statements.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-12 text-center text-neutral-500">
       {{ t('bank.no_data') }}
     </div>
 
-    <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <!-- Desktop: tabulka -->
       <div class="hidden md:block overflow-x-auto">
       <table class="w-full text-sm table-sticky-first">

--- a/web/src/pages/clients/ClientDetail.vue
+++ b/web/src/pages/clients/ClientDetail.vue
@@ -332,7 +332,7 @@ async function deleteClient() {
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <!-- Kontakt -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('client.section_contact') }}</h3>
         <dl class="space-y-2 text-sm">
           <div>
@@ -347,7 +347,7 @@ async function deleteClient() {
       </div>
 
       <!-- Adresa -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('client.section_address') }}</h3>
         <div class="text-sm text-neutral-900 leading-relaxed">
           {{ client.street }}<br />
@@ -357,7 +357,7 @@ async function deleteClient() {
       </div>
 
       <!-- Nastavení -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('nav.settings') }}</h3>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-500">{{ t('client.language_label') }}</dt><dd class="font-mono">{{ client.language.toUpperCase() }}</dd></div>
@@ -371,7 +371,7 @@ async function deleteClient() {
 
     <!-- KPI: nezaplaceno + po splatnosti -->
     <div v-if="(client.unpaid_summary?.length ?? 0) > 0" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('client.unpaid') }}</h3>
         <div class="space-y-1">
           <div v-for="u in client.unpaid_summary || []" :key="`u-${u.currency}`" class="flex items-baseline justify-between">
@@ -380,7 +380,7 @@ async function deleteClient() {
           </div>
         </div>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm" :class="overdueAny ? 'border-danger-500/40' : ''">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm" :class="overdueAny ? 'border-danger-500/40' : ''">
         <h3 class="text-sm font-semibold uppercase tracking-wide mb-3" :class="overdueAny ? 'text-danger-500' : 'text-neutral-500'">{{ t('client.overdue') }}</h3>
         <div class="space-y-1">
           <div v-for="u in client.unpaid_summary || []" :key="`o-${u.currency}`" class="flex items-baseline justify-between">
@@ -393,14 +393,14 @@ async function deleteClient() {
 
     <!-- Obrat: graf po měsících + sumace po letech -->
     <div v-if="(client.revenue_by_month?.length ?? 0) > 0" class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="md:col-span-2 bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="md:col-span-2 bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('client.revenue_by_month') }}</h3>
           <span class="text-xs font-mono text-neutral-500">{{ primaryCurrency }}<span v-if="revenueIsMultiCurrency" class="ml-1 text-neutral-400 normal-case">({{ t('client.converted_from', { ccys: revenueCurrencies.join(', ') }) }})</span></span>
         </div>
         <MonthlyRevenueChart :labels="monthlyChart.labels" :values="monthlyChart.values" :currency="primaryCurrency" />
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('client.revenue_by_year') }}</h3>
         <div class="overflow-x-auto">
         <table class="w-full text-sm">
@@ -418,14 +418,14 @@ async function deleteClient() {
 
     <!-- Náklady (přijaté faktury) — graf po měsících + sumace po letech -->
     <div v-if="purchaseByMonth.length > 0" class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="md:col-span-2 bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="md:col-span-2 bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('client.costs_by_month') }}</h3>
           <span class="text-xs font-mono text-neutral-500">{{ purchaseDisplayCurrency }}<span v-if="purchaseIsMultiCurrency" class="ml-1 text-neutral-400 normal-case">({{ t('client.converted_from', { ccys: purchaseCurrencies.join(', ') }) }})</span></span>
         </div>
         <MonthlyRevenueChart :labels="purchaseMonthlyChart.labels" :values="purchaseMonthlyChart.values" :currency="purchaseDisplayCurrency" />
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('client.costs_by_year') }}</h3>
         <div class="overflow-x-auto">
         <table class="w-full text-sm">
@@ -448,14 +448,14 @@ async function deleteClient() {
 
     <!-- Obrat podle zakázek — graf + tabulka -->
     <div v-if="projectsTable.length > 0" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('client.revenue_by_project') }}</h3>
           <span class="text-xs font-mono text-neutral-500">{{ primaryCurrency }}</span>
         </div>
         <TopProjectsBarChart :labels="projectsChart.labels" :values="projectsChart.values" :currency="primaryCurrency" />
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('client.revenue_by_project_table') }}</h3>
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
@@ -485,7 +485,7 @@ async function deleteClient() {
 
     <!-- Zakázky — visible pokud is_customer NEBO existují zakázky -->
     <div v-if="client.is_customer !== false || (client.projects?.length ?? 0) > 0"
-         class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+         class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <div class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
         <h3 class="font-semibold">{{ t('client.projects') }}</h3>
         <RouterLink v-if="auth.canWrite" :to="`/projects/new?client_id=${client.id}`"
@@ -514,8 +514,8 @@ async function deleteClient() {
             <td class="px-4 py-3">
               <span class="text-xs px-2 py-0.5 rounded"
                 :class="{
-                  'bg-emerald-50 text-emerald-700': p.status === 'active',
-                  'bg-amber-50 text-amber-700': p.status === 'paused',
+                  'bg-success-50 text-success-600': p.status === 'active',
+                  'bg-warning-50 text-warning-600': p.status === 'paused',
                   'bg-neutral-100 text-neutral-600': p.status === 'closed',
                 }">{{ p.status }}</span>
             </td>
@@ -547,8 +547,8 @@ async function deleteClient() {
             <div class="font-medium text-neutral-900 truncate">{{ p.name }}</div>
             <span class="text-xs px-2 py-0.5 rounded whitespace-nowrap"
               :class="{
-                'bg-emerald-50 text-emerald-700': p.status === 'active',
-                'bg-amber-50 text-amber-700': p.status === 'paused',
+                'bg-success-50 text-success-600': p.status === 'active',
+                'bg-warning-50 text-warning-600': p.status === 'paused',
                 'bg-neutral-100 text-neutral-600': p.status === 'closed',
               }">{{ p.status }}</span>
           </div>
@@ -565,7 +565,7 @@ async function deleteClient() {
     </div>
 
     <!-- Vystavené faktury — visible pokud is_customer NEBO existují vystavené faktury -->
-    <div v-if="client.is_customer !== false || invoices.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div v-if="client.is_customer !== false || invoices.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <div class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
         <h3 class="font-semibold">{{ t('client.issued_invoices') }} <span v-if="invoicesTotal" class="text-neutral-400 font-normal">({{ invoicesTotal }})</span></h3>
         <RouterLink v-if="auth.canWrite" :to="`/invoices/new?client_id=${client.id}`"
@@ -654,7 +654,7 @@ async function deleteClient() {
     </div>
 
     <!-- Přijaté faktury — visible pokud is_vendor NEBO existují přijaté faktury -->
-    <div v-if="client.is_vendor === true || purchaseInvoices.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div v-if="client.is_vendor === true || purchaseInvoices.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <div class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
         <h3 class="font-semibold">{{ t('client.received_invoices') }} <span v-if="purchaseInvoices.length" class="text-neutral-400 font-normal">({{ purchaseInvoices.length }})</span></h3>
         <RouterLink v-if="auth.canWrite" :to="`/purchase-invoices/new?vendor_id=${client.id}`"
@@ -696,7 +696,7 @@ async function deleteClient() {
 
     <!-- Pravidelné fakturace — visible pokud is_customer NEBO existují recurring -->
     <div v-if="client.is_customer !== false || recurringTemplates.length > 0"
-         class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+         class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <div class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
         <h3 class="font-semibold">
           {{ t('recurring.title') }}

--- a/web/src/pages/clients/ClientForm.vue
+++ b/web/src/pages/clients/ClientForm.vue
@@ -295,7 +295,7 @@ async function submit() {
       <RouterLink to="/clients" class="text-sm text-neutral-600 hover:text-neutral-900">{{ t('client.back_to_list') }}</RouterLink>
     </div>
 
-    <form @submit.prevent="submit" autocomplete="off" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <form @submit.prevent="submit" autocomplete="off" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <div class="p-5 space-y-4">
         <!-- Lookup helpers -->
         <div class="bg-primary-50 border border-primary-200 rounded-md p-3">
@@ -308,11 +308,11 @@ async function submit() {
                   @blur="checkDuplicateIc"
                   class="flex-1 h-9 px-3 border border-neutral-300 rounded-md font-mono text-sm focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none" />
                 <button type="button" @click="loadFromAres" :disabled="!form.ic || aresLoading"
-                  class="px-3 h-9 text-sm bg-white border border-primary-300 text-primary-700 rounded-md hover:bg-primary-100 disabled:opacity-50">
+                  class="px-3 h-9 text-sm bg-surface border border-primary-300 text-primary-700 rounded-md hover:bg-primary-100 disabled:opacity-50">
                   {{ aresLoading ? '…' : 'ARES' }}
                 </button>
               </div>
-              <p v-if="duplicateIc" class="text-xs text-amber-700 mt-1">
+              <p v-if="duplicateIc" class="text-xs text-warning-600 mt-1">
                 ⚠ {{ t('client.duplicate_ic') }} <strong>{{ duplicateIc.name }}</strong>
                 <RouterLink :to="`/clients/${duplicateIc.id}`" class="text-primary-700 hover:underline ml-1">{{ t('client.open_existing') }} →</RouterLink>
               </p>
@@ -324,11 +324,11 @@ async function submit() {
                   @blur="checkDuplicateDic"
                   class="flex-1 h-9 px-3 border border-neutral-300 rounded-md font-mono text-sm focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none" />
                 <button type="button" @click="checkVies" :disabled="!form.dic || viesLoading"
-                  class="px-3 h-9 text-sm bg-white border border-primary-300 text-primary-700 rounded-md hover:bg-primary-100 disabled:opacity-50">
+                  class="px-3 h-9 text-sm bg-surface border border-primary-300 text-primary-700 rounded-md hover:bg-primary-100 disabled:opacity-50">
                   {{ viesLoading ? '…' : 'VIES' }}
                 </button>
               </div>
-              <p v-if="duplicateDic" class="text-xs text-amber-700 mt-1">
+              <p v-if="duplicateDic" class="text-xs text-warning-600 mt-1">
                 ⚠ {{ t('client.duplicate_dic') }} <strong>{{ duplicateDic.name }}</strong>
                 <RouterLink :to="`/clients/${duplicateDic.id}`" class="text-primary-700 hover:underline ml-1">{{ t('client.open_existing') }} →</RouterLink>
               </p>
@@ -384,7 +384,7 @@ async function submit() {
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('client.country') }}</label>
             <select v-model="form.country_iso2"
-              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
               <option v-for="c in countries" :key="c.iso2" :value="c.iso2">{{ locale === 'en' ? c.name_en : c.name_cs }}</option>
             </select>
           </div>
@@ -394,7 +394,7 @@ async function submit() {
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('client.language') }}</label>
             <select v-model="form.language"
-              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
               <option value="cs">Čeština</option>
               <option value="en">English</option>
             </select>
@@ -403,7 +403,7 @@ async function submit() {
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('client.payment_due_label') }}</label>
             <div class="flex gap-2 items-center">
               <select v-model="clientDuePreset"
-                class="flex-1 min-w-0 h-10 px-2 border border-neutral-300 rounded-md text-sm bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+                class="flex-1 min-w-0 h-10 px-2 border border-neutral-300 rounded-md text-sm bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
                 <option value="inherit">{{ t('client.payment_due_inherit', { default: supplierDueLabel }) }}</option>
                 <option value="7">{{ t('client.payment_due_preset_7') }}</option>
                 <option value="14">{{ t('client.payment_due_preset_14') }}</option>
@@ -424,7 +424,7 @@ async function submit() {
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('client.currency_default') }}</label>
             <select v-model.number="form.currency_default_id"
-              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
               <option v-for="c in currencies" :key="c.id" :value="c.id">{{ c.label }}</option>
             </select>
           </div>
@@ -480,7 +480,7 @@ async function submit() {
               </span>
             </label>
           </div>
-          <p v-if="!form.is_customer && !form.is_vendor" class="text-xs text-red-600 mt-1">
+          <p v-if="!form.is_customer && !form.is_vendor" class="text-xs text-danger-600 mt-1">
             {{ t('client.roles_required') }}
           </p>
         </div>
@@ -489,7 +489,7 @@ async function submit() {
         <div v-if="form.is_vendor" class="pt-3 border-t border-neutral-100">
           <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('client.default_expense_category') }}</label>
           <select v-model="form.default_expense_category_id"
-            class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+            class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
             <option :value="null">— {{ t('client.default_expense_category_none') }} —</option>
             <option v-for="c in expenseCategories" :key="c.id" :value="c.id">
               {{ c.label }} ({{ c.code }})
@@ -529,7 +529,7 @@ async function submit() {
             <div>
               <label class="block text-xs font-medium text-neutral-700 mb-1">{{ t('client.invoice_number_period') }}</label>
               <select v-model="form.invoice_number_period"
-                class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+                class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
                 <option :value="null">{{ t('client.numbering_period_inherit') }}</option>
                 <option value="year">{{ t('client.numbering_period_year') }}</option>
                 <option value="month">{{ t('client.numbering_period_month') }}</option>
@@ -547,8 +547,8 @@ async function submit() {
 
       <div class="px-5 py-3 border-t border-neutral-200 bg-neutral-50 flex justify-end gap-3 rounded-b-lg">
         <button v-if="embedded" type="button" @click="emit('cancel')"
-          class="px-4 h-10 border border-neutral-300 rounded-md text-neutral-700 hover:bg-white text-sm font-medium">{{ t('common.cancel') }}</button>
-        <RouterLink v-else to="/clients" class="px-4 h-10 leading-10 border border-neutral-300 rounded-md text-neutral-700 hover:bg-white text-sm font-medium">{{ t('common.cancel') }}</RouterLink>
+          class="px-4 h-10 border border-neutral-300 rounded-md text-neutral-700 hover:bg-surface text-sm font-medium">{{ t('common.cancel') }}</button>
+        <RouterLink v-else to="/clients" class="px-4 h-10 leading-10 border border-neutral-300 rounded-md text-neutral-700 hover:bg-surface text-sm font-medium">{{ t('common.cancel') }}</RouterLink>
         <button type="submit" :disabled="submitting"
           class="px-5 h-10 bg-primary-600 hover:bg-primary-700 disabled:bg-neutral-300 text-white text-sm font-medium rounded-md">
           {{ submitting ? t('common.saving') : (isEdit ? t('common.save') : t('common.create')) }}

--- a/web/src/pages/clients/ClientList.vue
+++ b/web/src/pages/clients/ClientList.vue
@@ -114,7 +114,7 @@ function openClient(c: Client) {
       </RouterLink>
     </div>
 
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <!-- Tabs: Klienti / Dodavatelé / Vše -->
       <div class="px-4 pt-2 border-b border-neutral-100 flex items-center gap-1">
         <button
@@ -148,12 +148,12 @@ function openClient(c: Client) {
           {{ t('client.show_archived') }}
         </label>
         <select v-if="roleFilter === 'vendors'" v-model.number="categoryFilter"
-          class="h-9 px-3 border border-neutral-300 rounded-md text-sm bg-white"
+          class="h-9 px-3 border border-neutral-300 rounded-md text-sm bg-surface"
           :title="t('client.default_expense_category')">
           <option :value="null">{{ t('client.filter_category_all') }}</option>
           <option v-for="c in expenseCategories" :key="c.id" :value="c.id">{{ c.label }} ({{ c.code }})</option>
         </select>
-        <select v-model="sort" class="h-9 px-3 border border-neutral-300 rounded-md text-sm bg-white"
+        <select v-model="sort" class="h-9 px-3 border border-neutral-300 rounded-md text-sm bg-surface"
           :title="t('common.sort_by')">
           <option value="name">{{ t('common.sort_name') }}</option>
           <option value="revenue">{{ t('common.sort_revenue') }}</option>
@@ -192,10 +192,10 @@ function openClient(c: Client) {
               <div class="flex items-center gap-2">
                 <div class="font-medium text-neutral-900">{{ c.company_name }}</div>
                 <span v-if="c.is_customer !== false && c.is_vendor === true"
-                      class="inline-block px-1.5 py-0 text-[10px] bg-purple-100 text-purple-700 rounded font-medium uppercase tracking-wide"
+                      class="inline-block px-1.5 py-0 text-[10px] bg-primary-100 text-primary-700 rounded font-medium uppercase tracking-wide"
                       :title="t('client.dual_role_tooltip')">K+D</span>
                 <span v-else-if="c.is_vendor === true"
-                      class="inline-block px-1.5 py-0 text-[10px] bg-amber-100 text-amber-700 rounded font-medium uppercase tracking-wide">{{ t('client.vendor_badge') }}</span>
+                      class="inline-block px-1.5 py-0 text-[10px] bg-warning-50 text-warning-600 rounded font-medium uppercase tracking-wide">{{ t('client.vendor_badge') }}</span>
               </div>
               <div v-if="c.archived_at" class="text-xs text-neutral-400 mt-0.5">{{ t('common.archived') }}</div>
             </td>

--- a/web/src/pages/crm/CrmDashboard.vue
+++ b/web/src/pages/crm/CrmDashboard.vue
@@ -243,7 +243,7 @@ onMounted(loadAll)
         <p class="text-sm text-neutral-500 mt-0.5">{{ t('crm.subtitle') }}</p>
       </div>
       <div class="flex items-center gap-2 flex-wrap">
-        <select v-if="availableCurrencies.length > 1" v-model="currencyFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-if="availableCurrencies.length > 1" v-model="currencyFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="c in availableCurrencies" :key="c" :value="c">{{ c }}</option>
         </select>
         <button
@@ -259,11 +259,11 @@ onMounted(loadAll)
       </div>
     </div>
 
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">
       {{ t('common.loading') }}…
     </div>
 
-    <div v-else-if="!overview || overview.currencies.length === 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-8 text-center">
+    <div v-else-if="!overview || overview.currencies.length === 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-8 text-center">
       <p class="text-neutral-600 mb-2">{{ t('crm.no_data') }}</p>
       <p class="text-sm text-neutral-500 mb-4">{{ t('crm.no_data_hint') }}</p>
       <button v-if="auth.user?.role === 'admin'" type="button" @click="recompute" :disabled="recomputing"
@@ -274,7 +274,7 @@ onMounted(loadAll)
 
     <div v-else class="space-y-4">
       <!-- ═══ Action items widget (daily TODO) ═══ -->
-      <div v-if="actionItems && actionItems.total > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+      <div v-if="actionItems && actionItems.total > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
         <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between bg-gradient-to-r from-primary-50 to-white rounded-t-lg">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-primary-700">
             ⚡ {{ t('crm.action_items.title') }}
@@ -307,7 +307,7 @@ onMounted(loadAll)
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 7a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0 7a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/></svg>
               </button>
               <div v-if="(openMenuIdx === idx) && auth.canWrite"
-                class="absolute right-3 top-12 z-20 bg-white border border-neutral-200 rounded-md shadow-lg py-1 w-[280px]"
+                class="absolute right-3 top-12 z-20 bg-surface border border-neutral-200 rounded-md shadow-lg py-1 w-[280px]"
                 @click.stop>
                 <div class="px-3 py-1.5 text-xs uppercase tracking-wide text-neutral-500 font-semibold border-b border-neutral-100">
                   {{ t('crm.action_items.dismiss_title') }}
@@ -355,7 +355,7 @@ onMounted(loadAll)
         <h2 class="text-sm font-semibold uppercase tracking-wide text-neutral-600 mb-2">{{ t('crm.kpi_section') }}</h2>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <!-- Revenue -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="flex items-center justify-between mb-1">
             <span class="text-xs uppercase tracking-wide text-neutral-500 font-medium">{{ t('crm.kpi.revenue') }}</span>
             <svg class="w-5 h-5 text-success-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -380,7 +380,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Costs -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="flex items-center justify-between mb-1">
             <span class="text-xs uppercase tracking-wide text-neutral-500 font-medium">{{ t('crm.kpi.costs') }}</span>
             <svg class="w-5 h-5 text-danger-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -405,7 +405,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Profit -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="flex items-center justify-between mb-1">
             <span class="text-xs uppercase tracking-wide text-neutral-500 font-medium">{{ t('crm.kpi.profit') }}</span>
             <svg class="w-5 h-5 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -437,7 +437,7 @@ onMounted(loadAll)
         </div>
         <label class="flex items-center gap-2 text-sm shrink-0">
           <span class="text-neutral-500">{{ t('crm.period_label') }}</span>
-          <select v-model.number="periodMonths" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+          <select v-model.number="periodMonths" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
             <option :value="3">{{ t('crm.last_n_months', { n: 3 }) }}</option>
             <option :value="6">{{ t('crm.last_n_months', { n: 6 }) }}</option>
             <option :value="12">{{ t('crm.last_n_months', { n: 12 }) }}</option>
@@ -447,7 +447,7 @@ onMounted(loadAll)
       </div>
 
       <!-- ═══ Monthly trend chart (HTML/CSS bars — no chart.js dependency) ═══ -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
         <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
             {{ t('crm.monthly_trend') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ periodChip }})</span>
@@ -490,7 +490,7 @@ onMounted(loadAll)
       <!-- ═══ Top klienti + Top vendoři side by side ═══ -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Top clients -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('crm.top_clients') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ periodChip }})</span>
@@ -521,7 +521,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Top vendors -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('crm.top_vendors') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ periodChip }})</span>
@@ -555,7 +555,7 @@ onMounted(loadAll)
       <!-- ═══ Aging buckets (pohledávky + závazky) ═══ -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Receivables -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('crm.aging.receivables_title') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ t('crm.snapshot_now') }})</span>
@@ -583,7 +583,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Payables -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('crm.aging.payables_title') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ t('crm.snapshot_now') }})</span>
@@ -614,7 +614,7 @@ onMounted(loadAll)
       <!-- ═══ Health metrics row: DSO + Punctuality + Concentration ═══ -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <!-- DSO -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">
             {{ t('crm.dso.title') }} <span class="normal-case font-normal text-neutral-400">· {{ periodChip }}</span>
           </div>
@@ -625,7 +625,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Punctuality -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">
             {{ t('crm.punctuality.title') }} <span class="normal-case font-normal text-neutral-400">· {{ periodChip }}</span>
           </div>
@@ -639,7 +639,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Concentration risk -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">
             {{ t('crm.concentration.title') }} <span class="normal-case font-normal text-neutral-400">· {{ periodChip }}</span>
           </div>
@@ -659,7 +659,7 @@ onMounted(loadAll)
       <!-- ═══ Health metrics row 2: DPO + Vendor concentration + Working capital cycle ═══ -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <!-- DPO -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">
             {{ t('crm.dpo.title') }} <span class="normal-case font-normal text-neutral-400">· {{ periodChip }}</span>
           </div>
@@ -670,7 +670,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Vendor concentration risk -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">
             {{ t('crm.vendor_concentration.title') }} <span class="normal-case font-normal text-neutral-400">· {{ periodChip }}</span>
           </div>
@@ -687,7 +687,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Working capital cycle (DSO − DPO) -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">
             {{ t('crm.wc_cycle.title') }}
           </div>
@@ -707,7 +707,7 @@ onMounted(loadAll)
       <!-- ═══ Expense breakdown + Churn risk side-by-side ═══ -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Expense breakdown -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('crm.expense_breakdown.title') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ periodChip }})</span>
@@ -742,7 +742,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Churn risk -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               {{ t('crm.churn.title') }}
@@ -778,7 +778,7 @@ onMounted(loadAll)
       <!-- ═══ Náklady po rocích + Náklady po měsících (obdoba Stats) ═══ -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Náklady po rocích -->
-        <div v-if="yearly.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="yearly.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               📅 {{ t('crm.costs_by_year_table') }}
@@ -805,7 +805,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Náklady po měsících (posledních N podle periodMonths) -->
-        <div v-if="monthly.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="monthly.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               📊 {{ t('crm.costs_by_month_table') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ periodChip }})</span>
@@ -833,7 +833,7 @@ onMounted(loadAll)
       </div>
 
       <!-- ═══ Cash flow forecast (4 týdny) ═══ -->
-      <div v-if="cashFlow && cashFlow.weeks.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div v-if="cashFlow && cashFlow.weeks.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
             💰 {{ t('crm.cash_flow.title') }} ({{ cashFlow.currency }})
@@ -884,7 +884,7 @@ onMounted(loadAll)
       <!-- ═══ Late payment risk + Payment time histogram side-by-side ═══ -->
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <!-- Late risk -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               ⚠️ {{ t('crm.late_risk.title') }}
@@ -925,7 +925,7 @@ onMounted(loadAll)
         </div>
 
         <!-- Payment time histogram -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
             <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
               ⏱️ {{ t('crm.payment_time.title') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ periodChip }})</span>
@@ -957,7 +957,7 @@ onMounted(loadAll)
       </div>
 
       <!-- ═══ Reminder effectiveness funnel ═══ -->
-      <div v-if="reminderEff && reminderEff.total_paid > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div v-if="reminderEff && reminderEff.total_paid > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
             📧 {{ t('crm.reminder.title') }} <span class="normal-case font-normal text-[10px] text-neutral-400">({{ periodChip }})</span>

--- a/web/src/pages/documents/DocumentDetail.vue
+++ b/web/src/pages/documents/DocumentDetail.vue
@@ -175,7 +175,7 @@ onMounted(load)
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
       <!-- Left: preview -->
       <div class="lg:col-span-2 space-y-4">
-        <div v-if="previewTarget" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        <div v-if="previewTarget" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
           <div class="flex items-center justify-between px-4 py-2 border-b border-neutral-100">
             <span class="text-sm font-medium text-neutral-600">
               {{ t('documents.preview') }}
@@ -199,7 +199,7 @@ onMounted(load)
         </div>
 
         <!-- DMS message panel (ZFO) -->
-        <div v-if="doc.dms_message" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4">
+        <div v-if="doc.dms_message" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4">
           <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('documents.dms.title') }}</h3>
           <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
             <div><dt class="text-neutral-400 text-xs">{{ t('documents.dms.message_id') }}</dt><dd class="text-neutral-800">{{ doc.dms_message.dm_id || '—' }}</dd></div>
@@ -213,14 +213,14 @@ onMounted(load)
         </div>
 
         <!-- Attachments (ZFO children) -->
-        <div v-if="doc.attachments && doc.attachments.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4">
+        <div v-if="doc.attachments && doc.attachments.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4">
           <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('documents.attachments') }} ({{ doc.attachments.length }})</h3>
           <ul class="space-y-1">
             <li v-for="a in doc.attachments" :key="a.id" :class="['flex items-center gap-3 px-2 py-1.5 rounded', previewTarget && previewTarget.id === a.id ? 'bg-primary-50' : 'hover:bg-neutral-50']">
               <span :class="['shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold', docTypeBadge(a.doc_type).class]">{{ docTypeBadge(a.doc_type).label }}</span>
               <button type="button" class="min-w-0 flex-1 text-left text-sm text-neutral-700 truncate hover:text-primary-600" @click="router.push({ name: 'document-detail', params: { id: a.id } })">{{ a.title }}</button>
               <span class="text-xs text-neutral-400">{{ formatBytes(a.size_bytes) }}</span>
-              <button v-if="canInline(a.doc_type)" type="button" class="cursor-pointer inline-flex items-center gap-1 h-7 px-2 text-xs rounded-md border border-neutral-300 text-neutral-600 hover:bg-white" @click="showPreview(a)">
+              <button v-if="canInline(a.doc_type)" type="button" class="cursor-pointer inline-flex items-center gap-1 h-7 px-2 text-xs rounded-md border border-neutral-300 text-neutral-600 hover:bg-surface" @click="showPreview(a)">
                 <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5s8.268 2.943 9.542 7c-1.274 4.057-5.065 7-9.542 7s-8.268-2.943-9.542-7z" /><circle cx="12" cy="12" r="3" /></svg>
                 {{ t('documents.show') }}
               </button>
@@ -235,7 +235,7 @@ onMounted(load)
       <!-- Right: metadata + links -->
       <div class="space-y-4">
         <!-- Metadata -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4 space-y-3">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4 space-y-3">
           <h3 class="text-sm font-medium text-neutral-700">{{ t('documents.metadata') }}</h3>
           <div>
             <label class="block text-xs text-neutral-400 mb-1">{{ t('documents.name') }}</label>
@@ -264,7 +264,7 @@ onMounted(load)
         </div>
 
         <!-- Links (oboustranné párování) -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4 space-y-3">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4 space-y-3">
           <h3 class="text-sm font-medium text-neutral-700">{{ t('documents.linked_to') }}</h3>
           <ul v-if="doc.links && doc.links.length" class="space-y-1">
             <li v-for="l in doc.links" :key="l.entity_type + '-' + l.entity_id" class="flex items-start gap-2 text-sm">

--- a/web/src/pages/documents/DocumentsBrowser.vue
+++ b/web/src/pages/documents/DocumentsBrowser.vue
@@ -527,7 +527,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
     </div>
 
     <!-- Toolbar: search + view -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm mb-4 p-3">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm mb-4 p-3">
       <div class="flex flex-wrap items-center gap-2">
         <div class="relative flex-1 min-w-48">
           <input
@@ -541,7 +541,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
         <select
           v-if="availableTags.length"
           :value="tagFilter"
-          class="cursor-pointer h-9 px-2 border border-neutral-300 rounded-md bg-white text-sm max-w-44"
+          class="cursor-pointer h-9 px-2 border border-neutral-300 rounded-md bg-surface text-sm max-w-44"
           @change="setTagFilter(($event.target as HTMLSelectElement).value)"
         >
           <option value="">{{ t('documents.all_tags') }}</option>
@@ -580,7 +580,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
 
     <!-- Background jobs (ZIP import / export) -->
     <div v-if="jobs.length" class="mb-4 space-y-2">
-      <div v-for="j in jobs" :key="j.id" class="bg-white border border-neutral-200 rounded-lg p-3">
+      <div v-for="j in jobs" :key="j.id" class="bg-surface border border-neutral-200 rounded-lg p-3">
         <div class="flex items-center gap-2 text-sm flex-wrap">
           <svg class="w-4 h-4 text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path v-if="j.source === 'document_zip_import'" stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2M12 4v12m-4-8l4-4 4 4" />
@@ -623,7 +623,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
       </div>
       <p v-if="!trashDocs.length && !trashFolders.length" class="text-sm text-neutral-400">{{ t('documents.trash_is_empty') }}</p>
       <ul class="space-y-1">
-        <li v-for="f in trashFolders" :key="'tf' + f.id" class="flex items-center gap-3 px-3 py-2 bg-white border border-neutral-200 rounded-lg">
+        <li v-for="f in trashFolders" :key="'tf' + f.id" class="flex items-center gap-3 px-3 py-2 bg-surface border border-neutral-200 rounded-lg">
           <svg class="w-5 h-5 text-warning-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" /></svg>
           <span class="flex-1 text-sm text-neutral-700">{{ f.name }}</span>
           <button v-if="auth.canWrite" type="button" class="cursor-pointer inline-flex items-center gap-1 h-8 px-2.5 text-sm rounded-md border border-neutral-300 text-neutral-600 hover:bg-neutral-50" @click="restoreFolder(f)">
@@ -631,7 +631,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
             {{ t('documents.restore') }}
           </button>
         </li>
-        <li v-for="d in trashDocs" :key="'td' + d.id" class="flex items-center gap-3 px-3 py-2 bg-white border border-neutral-200 rounded-lg">
+        <li v-for="d in trashDocs" :key="'td' + d.id" class="flex items-center gap-3 px-3 py-2 bg-surface border border-neutral-200 rounded-lg">
           <span :class="['shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold', docTypeBadge(d.doc_type).class]">{{ docTypeBadge(d.doc_type).label }}</span>
           <span class="flex-1 text-sm text-neutral-700 truncate">{{ d.title }}</span>
           <button v-if="auth.canWrite" type="button" class="cursor-pointer inline-flex items-center gap-1 h-8 px-2.5 text-sm rounded-md border border-neutral-300 text-neutral-600 hover:bg-neutral-50" @click="restoreDoc(d)">
@@ -646,7 +646,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
     <div v-else-if="searchActive">
       <p v-if="!searching && searchResults.length === 0" class="text-sm text-neutral-400">{{ t('documents.search_no_results') }}</p>
       <ul class="space-y-1">
-        <li v-for="d in searchResults" :key="d.id" class="flex items-center gap-3 px-3 py-2 bg-white border border-neutral-200 rounded-lg hover:border-primary-300 cursor-pointer" @click="openDoc(d)">
+        <li v-for="d in searchResults" :key="d.id" class="flex items-center gap-3 px-3 py-2 bg-surface border border-neutral-200 rounded-lg hover:border-primary-300 cursor-pointer" @click="openDoc(d)">
           <span :class="['shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold', docTypeBadge(d.doc_type).class]">{{ docTypeBadge(d.doc_type).label }}</span>
           <span class="flex-1 min-w-0"><span class="block text-sm text-neutral-800 truncate">{{ d.title }}</span><span class="block text-xs text-neutral-400">{{ formatBytes(d.size_bytes) }} · {{ d.created_at.slice(0, 10) }}</span></span>
         </li>
@@ -689,19 +689,19 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
       <div v-if="selCount > 0" class="flex items-center gap-2 mb-3 px-3 py-2 bg-primary-50 border border-primary-200 rounded-lg text-sm flex-wrap">
         <span class="font-medium text-primary-700">{{ t('documents.selected', { n: selCount }) }}</span>
         <div class="flex-1"></div>
-        <button v-if="auth.canWrite" type="button" class="cursor-pointer inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-md border border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-50" @click="openMove">
+        <button v-if="auth.canWrite" type="button" class="cursor-pointer inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-md border border-neutral-300 bg-surface text-neutral-700 hover:bg-neutral-50" @click="openMove">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2zM13 13l3-3m0 0l-3-3m3 3H8" /></svg>
           {{ t('documents.bulk_move') }}
         </button>
-        <button v-if="auth.canWrite && selDocCount > 0" type="button" class="cursor-pointer inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-md border border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-50" @click="bulkTag">
+        <button v-if="auth.canWrite && selDocCount > 0" type="button" class="cursor-pointer inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-md border border-neutral-300 bg-surface text-neutral-700 hover:bg-neutral-50" @click="bulkTag">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5a2 2 0 0 1 1.414.586l7 7a2 2 0 0 1 0 2.828l-5 5a2 2 0 0 1-2.828 0l-7-7A2 2 0 0 1 5 8V5a2 2 0 0 1 2-2z" /></svg>
           {{ t('documents.bulk_tag') }}
         </button>
-        <button type="button" class="cursor-pointer inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-md border border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-50" @click="bulkDownload">
+        <button type="button" class="cursor-pointer inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-md border border-neutral-300 bg-surface text-neutral-700 hover:bg-neutral-50" @click="bulkDownload">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2M7 10l5 5 5-5M12 15V3" /></svg>
           {{ t('documents.bulk_download') }}
         </button>
-        <button v-if="auth.canWrite" type="button" class="cursor-pointer inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-md border border-danger-300 bg-white text-danger-500 hover:bg-danger-50" @click="bulkDelete">
+        <button v-if="auth.canWrite" type="button" class="cursor-pointer inline-flex items-center gap-1.5 h-8 px-2.5 text-sm font-medium rounded-md border border-danger-300 bg-surface text-danger-500 hover:bg-danger-50" @click="bulkDelete">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0 1 16.138 21H7.862a2 2 0 0 1-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3" /></svg>
           {{ t('documents.bulk_delete') }}
         </button>
@@ -717,7 +717,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
           <div
             v-for="f in folders"
             :key="f.id"
-            :class="['group flex items-center gap-2 px-3 py-2.5 bg-white border rounded-lg cursor-pointer', selectedFolders.has(f.id) ? 'border-primary-400 ring-2 ring-primary-100' : 'border-neutral-200 hover:border-primary-300']"
+            :class="['group flex items-center gap-2 px-3 py-2.5 bg-surface border rounded-lg cursor-pointer', selectedFolders.has(f.id) ? 'border-primary-400 ring-2 ring-primary-100' : 'border-neutral-200 hover:border-primary-300']"
             @click="openFolder(f.id)"
           >
             <input type="checkbox" class="shrink-0 cursor-pointer" :checked="selectedFolders.has(f.id)" @click.stop="toggleFolderSel(f.id)" />
@@ -754,7 +754,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
           <div
             v-for="d in sortedDocuments"
             :key="d.id"
-            :class="['relative group bg-white border rounded-lg overflow-hidden cursor-pointer', selected.has(d.id) ? 'border-primary-400 ring-2 ring-primary-100' : 'border-neutral-200 hover:border-primary-300']"
+            :class="['relative group bg-surface border rounded-lg overflow-hidden cursor-pointer', selected.has(d.id) ? 'border-primary-400 ring-2 ring-primary-100' : 'border-neutral-200 hover:border-primary-300']"
             @click="openDoc(d)"
           >
             <input type="checkbox" class="absolute top-2 left-2 z-10" :checked="selected.has(d.id)" @click.stop="toggleSel(d.id)" />
@@ -808,12 +808,12 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
 
     <!-- Drag overlay -->
     <div v-if="dragOver && auth.canWrite" class="fixed inset-0 z-40 bg-primary-500/10 border-4 border-dashed border-primary-400 flex items-center justify-center pointer-events-none">
-      <span class="px-4 py-2 bg-white rounded-lg shadow text-primary-700 font-medium">{{ t('documents.drop_here') }}</span>
+      <span class="px-4 py-2 bg-surface rounded-lg shadow text-primary-700 font-medium">{{ t('documents.drop_here') }}</span>
     </div>
 
     <!-- Move modal -->
     <div v-if="moveOpen" class="fixed inset-0 z-50 bg-black/30 flex items-center justify-center p-4" @click.self="moveOpen = false">
-      <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-4 max-h-[70vh] overflow-auto">
+      <div class="bg-surface rounded-lg shadow-xl max-w-md w-full p-4 max-h-[70vh] overflow-auto">
         <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('documents.bulk_move') }} · {{ t('documents.selected', { n: selCount }) }}</h3>
         <ul class="space-y-0.5">
           <li>
@@ -840,7 +840,7 @@ onUnmounted(() => { if (jobTimer) clearInterval(jobTimer) })
 
     <!-- Bulk tag modal (našeptávání tagů) -->
     <div v-if="tagModalOpen" class="fixed inset-0 z-50 bg-black/30 flex items-center justify-center p-4" @click.self="tagModalOpen = false">
-      <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-4">
+      <div class="bg-surface rounded-lg shadow-xl max-w-md w-full p-4">
         <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('documents.bulk_tag') }} · {{ t('documents.selected', { n: selDocCount }) }}</h3>
         <TagInput v-model="bulkTags" :autofocus="true" />
         <div class="flex justify-end gap-2 mt-4">

--- a/web/src/pages/invoices/InvoiceDetail.vue
+++ b/web/src/pages/invoices/InvoiceDetail.vue
@@ -772,8 +772,8 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Mark paid modal -->
-    <div v-if="markPaidOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-sm w-full p-5">
+    <div v-if="markPaidOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-sm w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ t('invoice.modals.mark_paid_title') }}</h3>
         <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.modals.mark_paid_date') }}</label>
         <input v-model="paidAtInput" type="date" class="w-full h-10 px-3 border border-neutral-300 rounded-md mb-4" />
@@ -788,8 +788,8 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Cancel modal -->
-    <div v-if="cancelOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="cancelOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ isCreditNoteSource ? t('invoice.modals.cancel_title_cn') : t('invoice.modals.cancel_title') }}</h3>
         <p class="text-sm text-neutral-600 mb-3">{{ t('invoice.modals.cancel_choose') }}</p>
         <div class="space-y-2 mb-4">
@@ -840,8 +840,8 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Send modal -->
-    <div v-if="sendOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="sendOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ t('invoice.modals.send_title') }}</h3>
         <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.modals.send_recipients') }}</label>
         <input v-model="sendTo" type="text" class="w-full h-10 px-3 border border-neutral-300 rounded-md mb-2 text-sm" />
@@ -862,8 +862,8 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Reminder modal -->
-    <div v-if="reminderOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="reminderOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-1">{{ t('invoice.modals.reminder_title') }}</h3>
         <p class="text-sm text-warning-600 font-medium mb-3">{{ t('invoice.modals.reminder_overdue', { days: daysOverdue }) }}</p>
         <p class="text-sm text-neutral-600 mb-3">{{ t('invoice.modals.reminder_body') }}</p>
@@ -888,7 +888,7 @@ async function updateApprovalStatus() {
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">
           {{ t('invoice.issue_date') }}
           <template v-if="!isProforma"> / {{ t('invoice.tax_date') }}</template>
@@ -902,7 +902,7 @@ async function updateApprovalStatus() {
         </dl>
       </div>
 
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('common.currency') }} &amp; {{ t('invoice.totals.vat') }}</h3>
         <dl class="space-y-1.5 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-500">{{ t('common.currency') }}</dt><dd class="font-mono">{{ invoice.currency }}</dd></div>
@@ -915,7 +915,7 @@ async function updateApprovalStatus() {
         </dl>
       </div>
 
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('settings.account_cz') }}</h3>
         <dl v-if="(invoice.payment_method ?? 'bank_transfer') === 'bank_transfer'" class="space-y-1 text-sm">
           <div v-if="invoice.bank_account_number" class="font-mono text-xs">
@@ -934,7 +934,7 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Položky -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <div class="px-5 py-3 border-b border-neutral-200">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.items') }}</h3>
       </div>
@@ -991,7 +991,7 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Sumace -->
-    <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('invoice.summary') }}</h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <dl class="space-y-1 text-sm">
@@ -1039,7 +1039,7 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- CZK přepočet pro faktury v cizí měně -->
-    <div v-if="invoice.czk_recap" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div v-if="invoice.czk_recap" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">
         {{ t('invoice.czk_recap.title') }}
       </h3>
@@ -1081,14 +1081,14 @@ async function updateApprovalStatus() {
       </div>
     </div>
 
-    <div v-if="invoice.note_below_items" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div v-if="invoice.note_below_items" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-2">{{ t('invoice.note') }}</h3>
       <p class="text-sm text-neutral-700 whitespace-pre-wrap">{{ invoice.note_below_items }}</p>
     </div>
 
 
     <!-- Výkaz víceprací -->
-    <div v-if="workReport" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-if="workReport" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <header class="px-5 py-3 border-b border-neutral-200 flex items-baseline justify-between gap-3">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.work_report') }}</h3>
         <span class="text-sm text-neutral-700">{{ workReport.title }}</span>
@@ -1147,7 +1147,7 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Stav schválení výkazu — viditelné jen pokud projekt vyžaduje + výkaz existuje -->
-    <div v-if="requiresApproval" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div v-if="requiresApproval" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <header class="px-5 py-3 border-b border-neutral-200">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.approval.section_title') }}</h3>
       </header>
@@ -1212,8 +1212,8 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Approval status modal (admin) -->
-    <div v-if="approvalStatusOpen" class="fixed inset-0 bg-neutral-900/40 z-50 flex items-center justify-center p-4">
-      <div class="bg-white rounded-xl shadow-lg max-w-md w-full p-5">
+    <div v-if="approvalStatusOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-md w-full p-5">
         <h3 class="text-lg font-semibold mb-3">{{ t('invoice.approval.modal_title') }}</h3>
         <p class="text-sm text-neutral-600 mb-3">{{ t('invoice.approval.modal_hint') }}</p>
         <div class="space-y-2 mb-4">
@@ -1252,7 +1252,7 @@ async function updateApprovalStatus() {
 
     <!-- Přílohy emailu (PDF/Office/obrázky se přibalí při odeslání faktury) -->
     <div v-if="invoice && attachmentsAvailable(invoice)"
-         class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+         class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
         <div>
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">
@@ -1323,7 +1323,7 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Historie PDF -->
-    <div v-if="pdfHistory.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-if="pdfHistory.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.pdf_history.title') }}</h3>
         <span class="text-xs text-neutral-400">{{ pdfHistory.length }}</span>
@@ -1354,7 +1354,7 @@ async function updateApprovalStatus() {
     </div>
 
     <!-- Aktivita -->
-    <div v-if="activity.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-if="activity.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <header class="px-5 py-3 border-b border-neutral-200">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.activity') }}</h3>
       </header>
@@ -1381,7 +1381,7 @@ async function updateApprovalStatus() {
     <!-- Sekundární akce — pod fakturou (Test odeslání + admin/destrukční).
          Pro draft zobrazujeme kvůli „Test odeslání" + odkazu na klienta;
          vnitřní tlačítka mají vlastní v-if podmínky. -->
-    <div v-if="invoice" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div v-if="invoice" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-xs font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('invoice.more_actions') }}</h3>
       <div class="flex flex-wrap gap-2">
         <RouterLink :to="`/clients/${invoice.client_id}`"

--- a/web/src/pages/invoices/InvoiceEditor.vue
+++ b/web/src/pages/invoices/InvoiceEditor.vue
@@ -923,12 +923,12 @@ async function deleteDraft() {
     <form @submit.prevent="submit" class="space-y-4">
       <!-- Klient + zakázka + datumy -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('invoice.client') }} &amp; {{ t('invoice.project') }}</h3>
           <div class="space-y-3">
             <div>
               <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.doc_type') }} *</label>
-              <select v-model="form.invoice_type" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+              <select v-model="form.invoice_type" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
                 <option value="invoice">{{ t('invoice.doc_invoice') }}</option>
                 <option value="proforma">{{ t('invoice.doc_proforma') }}</option>
                 <option value="credit_note">{{ t('invoice.doc_credit_note') }}</option>
@@ -1005,13 +1005,13 @@ async function deleteDraft() {
               <div>
                 <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.currency') }}</label>
                 <select v-model.number="form.currency_id" @change="onCurrencyChange"
-                  class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+                  class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
                   <option v-for="c in currencies" :key="c.id" :value="c.id">{{ c.label }}</option>
                 </select>
               </div>
               <div>
                 <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.language') }}</label>
-                <select v-model="form.language" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+                <select v-model="form.language" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
                   <option value="cs">CZ</option>
                   <option value="en">EN</option>
                 </select>
@@ -1019,7 +1019,7 @@ async function deleteDraft() {
             </div>
             <div>
               <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('payment_method.label') }}</label>
-              <select v-model="form.payment_method" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+              <select v-model="form.payment_method" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
                 <option value="bank_transfer">{{ t('payment_method.bank_transfer') }}</option>
                 <option value="card">{{ t('payment_method.card') }}</option>
                 <option value="cash">{{ t('payment_method.cash') }}</option>
@@ -1036,7 +1036,7 @@ async function deleteDraft() {
           </div>
         </div>
 
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('invoice.dates_section') }}</h3>
           <div class="space-y-3">
             <!-- Ruční override čísla faktury — jen u draftu; prázdné = vygeneruje se při Vystavení.
@@ -1086,7 +1086,7 @@ async function deleteDraft() {
       </div>
 
       <!-- Položky -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
         <div class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.items') }}</h3>
           <button type="button" @click="addItem" class="px-3 h-8 text-sm bg-primary-600 hover:bg-primary-700 text-white rounded-md">
@@ -1126,7 +1126,7 @@ async function deleteDraft() {
                   :class="['w-full h-9 px-2 border rounded text-right font-mono text-sm', itemHasBothNegative(item) ? 'border-danger-400' : 'border-neutral-200']" />
               </td>
               <td class="px-3 py-2">
-                <select v-model="item.unit" class="w-full h-9 px-1 border border-neutral-200 rounded text-sm bg-white">
+                <select v-model="item.unit" class="w-full h-9 px-1 border border-neutral-200 rounded text-sm bg-surface">
                   <option v-for="u in units" :key="u.id" :value="u.code">{{ u.code }}</option>
                   <option v-if="item.unit && !units.some(u => u.code === item.unit)" :value="item.unit">{{ item.unit }}</option>
                 </select>
@@ -1136,7 +1136,7 @@ async function deleteDraft() {
                   :class="['w-full h-9 px-2 border rounded text-right font-mono text-sm', itemHasBothNegative(item) ? 'border-danger-400' : 'border-neutral-200']" />
               </td>
               <td v-if="supplierIsVatPayer" class="px-3 py-2">
-                <select v-model.number="item.vat_rate_id" class="w-full h-9 px-1 border border-neutral-200 rounded text-sm bg-white">
+                <select v-model.number="item.vat_rate_id" class="w-full h-9 px-1 border border-neutral-200 rounded text-sm bg-surface">
                   <option v-for="r in vatRates" :key="r.id" :value="r.id">{{ vatRateLabel(r) }}</option>
                 </select>
               </td>
@@ -1185,7 +1185,7 @@ async function deleteDraft() {
               </div>
               <div>
                 <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.items_table.unit') }}</label>
-                <select v-model="item.unit" class="w-full h-10 px-2 border border-neutral-200 rounded text-sm bg-white">
+                <select v-model="item.unit" class="w-full h-10 px-2 border border-neutral-200 rounded text-sm bg-surface">
                   <option v-for="u in units" :key="u.id" :value="u.code">{{ u.code }}</option>
                   <option v-if="item.unit && !units.some(u => u.code === item.unit)" :value="item.unit">{{ item.unit }}</option>
                 </select>
@@ -1199,7 +1199,7 @@ async function deleteDraft() {
               </div>
               <div v-if="supplierIsVatPayer">
                 <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.totals.vat') }}</label>
-                <select v-model.number="item.vat_rate_id" class="w-full h-10 px-2 border border-neutral-200 rounded text-sm bg-white">
+                <select v-model.number="item.vat_rate_id" class="w-full h-10 px-2 border border-neutral-200 rounded text-sm bg-surface">
                   <option v-for="r in vatRates" :key="r.id" :value="r.id">{{ vatRateLabel(r) }}</option>
                 </select>
               </div>
@@ -1215,12 +1215,12 @@ async function deleteDraft() {
       </div>
 
       <!-- Klasifikace (VAT pro DPH přiznání + volitelný revenue tag) -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-3">{{ t('invoice.classification.title') }}</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label class="block text-xs text-neutral-500 mb-1">{{ t('invoice.classification.vat_classification') }}</label>
-            <select v-model="form.vat_classification_code" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="form.vat_classification_code" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
               <option :value="null">— {{ t('invoice.classification.no_vat_class') }} —</option>
               <option v-for="vc in vatClassifications" :key="vc.id" :value="vc.code">
                 {{ vc.code }} — {{ vc.label.length > 60 ? vc.label.slice(0, 60) + '…' : vc.label }}
@@ -1241,17 +1241,17 @@ async function deleteDraft() {
       <!-- Sumace + poznámky -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div class="md:col-span-2 space-y-4">
-          <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.note_above') }}</label>
             <textarea v-model="form.note_above_items" rows="2" class="w-full px-3 py-2 border border-neutral-300 rounded-md text-sm"></textarea>
           </div>
-          <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+          <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.note_below') }}</label>
             <textarea v-model="form.note_below_items" rows="2" class="w-full px-3 py-2 border border-neutral-300 rounded-md text-sm"></textarea>
           </div>
         </div>
 
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('invoice.summary') }}</h3>
           <div class="flex items-center justify-between gap-3 mb-3 pb-3 border-b border-neutral-100">
             <label for="discount_percent" class="text-sm text-neutral-700">{{ t('invoice.discount.label') }}</label>
@@ -1311,7 +1311,7 @@ async function deleteDraft() {
       </div>
 
       <!-- Výkaz víceprací -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.work_report') }}</h3>
           <div class="flex items-center gap-2">
@@ -1321,7 +1321,7 @@ async function deleteDraft() {
               {{ t('invoice.wr_add') }}
             </button>
             <button v-if="wrOpen && wrItems.length > 0" type="button" @click="pushWrToInvoiceItem"
-              class="cursor-pointer px-4 h-9 text-sm bg-emerald-700 hover:bg-emerald-800 text-white font-semibold rounded-md inline-flex items-center gap-1.5 shadow-sm">
+              class="cursor-pointer px-4 h-9 text-sm bg-success-600 hover:bg-success-600 text-white font-semibold rounded-md inline-flex items-center gap-1.5 shadow-sm">
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/></svg>
               {{ t('invoice.wr_push_to_item') }}
             </button>
@@ -1424,22 +1424,22 @@ async function deleteDraft() {
               </div>
               <div>
                 <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.wr_description') }}</label>
-                <input v-model="it.description" type="text" class="w-full h-10 px-3 border border-neutral-200 rounded text-sm bg-white" />
+                <input v-model="it.description" type="text" class="w-full h-10 px-3 border border-neutral-200 rounded text-sm bg-surface" />
               </div>
               <div class="grid grid-cols-2 gap-2">
                 <div>
                   <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.wr_date') }}</label>
-                  <input v-model="it.work_date" type="date" class="w-full h-10 px-3 border border-neutral-200 rounded text-sm font-mono bg-white" />
+                  <input v-model="it.work_date" type="date" class="w-full h-10 px-3 border border-neutral-200 rounded text-sm font-mono bg-surface" />
                 </div>
                 <div>
                   <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.wr_hours') }}</label>
-                  <input v-model.number="it.hours" type="number" inputmode="decimal" step="0.25" min="0" class="w-full h-10 px-3 border border-neutral-200 rounded text-right font-mono text-sm bg-white" />
+                  <input v-model.number="it.hours" type="number" inputmode="decimal" step="0.25" min="0" class="w-full h-10 px-3 border border-neutral-200 rounded text-right font-mono text-sm bg-surface" />
                 </div>
               </div>
               <div class="grid grid-cols-2 gap-2 items-end">
                 <div>
                   <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.wr_rate') }}</label>
-                  <input v-model.number="it.rate" type="number" inputmode="decimal" step="1" min="0" class="w-full h-10 px-3 border border-neutral-200 rounded text-right font-mono text-sm bg-white" />
+                  <input v-model.number="it.rate" type="number" inputmode="decimal" step="1" min="0" class="w-full h-10 px-3 border border-neutral-200 rounded text-right font-mono text-sm bg-surface" />
                 </div>
                 <div class="text-right pb-2">
                   <div class="text-xs font-medium text-neutral-500 uppercase tracking-wide">{{ t('invoice.wr_total') }}</div>
@@ -1471,7 +1471,7 @@ async function deleteDraft() {
       </div>
 
       <!-- Action bar -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-4 flex justify-between items-center sticky bottom-3 shadow-md">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-4 flex justify-between items-center sticky bottom-3 shadow-md">
         <RouterLink to="/invoices" class="text-sm text-neutral-600 hover:text-neutral-900">{{ t('common.cancel') }}</RouterLink>
         <button type="submit" :disabled="submitting"
           class="px-5 h-10 bg-primary-600 hover:bg-primary-700 disabled:bg-neutral-300 text-white text-sm font-medium rounded-md">

--- a/web/src/pages/invoices/InvoiceList.vue
+++ b/web/src/pages/invoices/InvoiceList.vue
@@ -496,7 +496,7 @@ const monthOptions = computed(() => (tm('common.months_short') as unknown as str
     </div>
 
     <!-- Filtry -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm mb-4 p-3">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm mb-4 p-3">
       <div class="flex flex-wrap items-center gap-2">
         <input
           v-model="search"
@@ -504,7 +504,7 @@ const monthOptions = computed(() => (tm('common.months_short') as unknown as str
           :placeholder="t('invoice.search_placeholder')"
           class="flex-1 min-w-48 h-9 px-3 border border-neutral-300 rounded-md text-sm focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none"
         />
-        <select v-model="statusFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model="statusFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option value="">{{ t('invoice.all_statuses') }}</option>
           <option value="draft">{{ t('status.draft') }}</option>
           <option value="issued">{{ t('status.issued') }}</option>
@@ -513,7 +513,7 @@ const monthOptions = computed(() => (tm('common.months_short') as unknown as str
           <option value="paid">{{ t('status.paid') }}</option>
           <option value="cancelled">{{ t('status.cancelled') }}</option>
         </select>
-        <select v-model="typeFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model="typeFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option value="">{{ t('invoice.all_types') }}</option>
           <option value="invoice">{{ t('type.invoice') }}</option>
           <option value="proforma">{{ t('type.proforma') }}</option>
@@ -527,17 +527,17 @@ const monthOptions = computed(() => (tm('common.months_short') as unknown as str
             :placeholder="t('project.all_clients')"
           />
         </div>
-        <select v-model="currencyFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model="currencyFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option value="">{{ t('invoice.all_currencies') }}</option>
           <option v-for="c in currencies" :key="c.id" :value="c.code">{{ c.code }}</option>
         </select>
         <select v-model="yearFilter" :disabled="!!dateFrom || !!dateTo"
-          class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm disabled:opacity-50">
+          class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm disabled:opacity-50">
           <option value="">{{ t('invoice.all_years') }}</option>
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
         </select>
         <select v-model="monthFilter" :disabled="!!dateFrom || !!dateTo || yearFilter === ''"
-          class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm disabled:opacity-50"
+          class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm disabled:opacity-50"
           :title="t('invoice.month_filter')">
           <option :value="''">{{ t('invoice.all_months') }}</option>
           <option v-for="(label, i) in monthOptions" :key="i + 1" :value="i + 1">{{ label }}</option>
@@ -564,11 +564,11 @@ const monthOptions = computed(() => (tm('common.months_short') as unknown as str
       </div>
     </div>
 
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <TableSkeleton :rows="8" :cols="7" />
     </div>
 
-    <div v-else-if="!groups.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div v-else-if="!groups.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <EmptyState :title="t('invoice.no_data')" :cta="t('invoice.issue_first')" to="/invoices/new" />
     </div>
 
@@ -594,7 +594,7 @@ const monthOptions = computed(() => (tm('common.months_short') as unknown as str
         </header>
 
         <!-- Desktop: tabulka -->
-        <div class="hidden md:block bg-white border border-t-0 border-neutral-200 rounded-b-lg overflow-hidden">
+        <div class="hidden md:block bg-surface border border-t-0 border-neutral-200 rounded-b-lg overflow-hidden">
           <div class="overflow-x-auto">
           <table class="w-full text-sm table-sticky-first">
             <thead class="bg-neutral-50 text-neutral-500 text-xs uppercase tracking-wide">
@@ -670,7 +670,7 @@ const monthOptions = computed(() => (tm('common.months_short') as unknown as str
         </div>
 
         <!-- Mobile: karty -->
-        <div class="md:hidden bg-white border border-t-0 border-neutral-200 rounded-b-lg divide-y divide-neutral-100 overflow-hidden">
+        <div class="md:hidden bg-surface border border-t-0 border-neutral-200 rounded-b-lg divide-y divide-neutral-100 overflow-hidden">
           <div
             v-for="inv in g.invoices"
             :key="`m-${inv.id}`"

--- a/web/src/pages/projects/ProjectDetail.vue
+++ b/web/src/pages/projects/ProjectDetail.vue
@@ -125,8 +125,8 @@ async function deleteProject() {
         <div class="text-sm text-neutral-500 mt-1 flex items-center gap-2 flex-wrap">
           <span class="text-xs px-2 py-0.5 rounded"
             :class="{
-              'bg-emerald-50 text-emerald-700': project.status === 'active',
-              'bg-amber-50 text-amber-700': project.status === 'paused',
+              'bg-success-50 text-success-600': project.status === 'active',
+              'bg-warning-50 text-warning-600': project.status === 'paused',
               'bg-neutral-100 text-neutral-600': project.status === 'closed',
             }">{{ project.status }}</span>
           <span v-if="project.project_number" class="font-mono text-xs">{{ project.project_number }}</span>
@@ -168,7 +168,7 @@ async function deleteProject() {
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('project.rates_due_section') }}</h3>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-500">{{ t('project.hourly_rate') }}</dt><dd class="font-mono">{{ project.hourly_rate.toLocaleString('cs') }} {{ project.currency }}</dd></div>
@@ -177,7 +177,7 @@ async function deleteProject() {
         </dl>
       </div>
 
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('common.budgets') }}</h3>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-500">{{ t('project.budget_total_short') }}</dt><dd class="font-mono">{{ project.budget_total?.toLocaleString('cs') ?? '—' }}</dd></div>
@@ -186,7 +186,7 @@ async function deleteProject() {
         </dl>
       </div>
 
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('project.reference_section') }}</h3>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-500">{{ t('project.project_number') }}</dt><dd class="font-mono">{{ project.project_number || '—' }}</dd></div>
@@ -195,7 +195,7 @@ async function deleteProject() {
       </div>
     </div>
 
-    <div v-if="project.billing_emails.length" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div v-if="project.billing_emails.length" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('project.billing_emails') }}</h3>
       <ul class="space-y-1.5 text-sm">
         <li v-for="b in project.billing_emails" :key="b.position" class="flex items-center justify-between border-b border-neutral-100 pb-1.5 last:border-b-0">
@@ -206,14 +206,14 @@ async function deleteProject() {
       <p class="text-xs text-neutral-400 mt-2">{{ t('project.client_main_email_note', { email: project.client_main_email }) }}</p>
     </div>
 
-    <div v-if="project.note" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div v-if="project.note" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-2">{{ t('project.note') }}</h3>
       <p class="text-sm text-neutral-700 whitespace-pre-wrap">{{ project.note }}</p>
     </div>
 
     <!-- KPI: nezaplaceno + po splatnosti -->
     <div v-if="(project.unpaid_summary?.length ?? 0) > 0" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('client.unpaid') }}</h3>
         <div class="space-y-1">
           <div v-for="u in project.unpaid_summary || []" :key="`u-${u.currency}`" class="flex items-baseline justify-between">
@@ -222,7 +222,7 @@ async function deleteProject() {
           </div>
         </div>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm" :class="overdueAny ? 'border-danger-500/40' : ''">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm" :class="overdueAny ? 'border-danger-500/40' : ''">
         <h3 class="text-sm font-semibold uppercase tracking-wide mb-3" :class="overdueAny ? 'text-danger-500' : 'text-neutral-500'">{{ t('client.overdue') }}</h3>
         <div class="space-y-1">
           <div v-for="u in project.unpaid_summary || []" :key="`o-${u.currency}`" class="flex items-baseline justify-between">
@@ -235,14 +235,14 @@ async function deleteProject() {
 
     <!-- Obrat: graf po měsících + sumace po letech -->
     <div v-if="(project.revenue_by_month?.length ?? 0) > 0" class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="md:col-span-2 bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="md:col-span-2 bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-baseline justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('client.revenue_by_month') }}</h3>
           <span class="text-xs font-mono text-neutral-500">{{ primaryCurrency }}</span>
         </div>
         <MonthlyRevenueChart :labels="monthlyChart.labels" :values="monthlyChart.values" :currency="primaryCurrency" />
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('client.revenue_by_year') }}</h3>
         <div class="overflow-x-auto">
         <table class="w-full text-sm">
@@ -259,7 +259,7 @@ async function deleteProject() {
     </div>
 
     <!-- Faktury -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <div class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
         <h3 class="font-semibold">{{ t('nav.invoices') }} <span v-if="invoicesTotal" class="text-neutral-400 font-normal">({{ invoicesTotal }})</span></h3>
         <RouterLink v-if="(project.status === 'active') && auth.canWrite"

--- a/web/src/pages/projects/ProjectForm.vue
+++ b/web/src/pages/projects/ProjectForm.vue
@@ -192,7 +192,7 @@ async function submit() {
       {{ t('invoice.client') }}: <span class="font-medium text-neutral-900">{{ client.company_name }}</span>
     </div>
 
-    <form @submit.prevent="submit" autocomplete="off" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <form @submit.prevent="submit" autocomplete="off" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <div class="p-5 space-y-4">
         <div>
           <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('project.name') }} *</label>
@@ -205,7 +205,7 @@ async function submit() {
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('project.payment_due_label') }} *</label>
             <div class="flex gap-2 items-center">
               <select v-model="projectDuePreset"
-                class="flex-1 min-w-0 h-10 px-2 border border-neutral-300 rounded-md text-sm bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+                class="flex-1 min-w-0 h-10 px-2 border border-neutral-300 rounded-md text-sm bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
                 <option value="7">{{ t('project.payment_due_preset_7') }}</option>
                 <option value="14">{{ t('project.payment_due_preset_14') }}</option>
                 <option value="month">{{ t('project.payment_due_preset_month') }}</option>
@@ -227,14 +227,14 @@ async function submit() {
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('project.currency') }}</label>
             <select v-model.number="form.currency_id"
-              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
               <option v-for="c in currencies" :key="c.id" :value="c.id">{{ c.label }}</option>
             </select>
           </div>
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('project.status') }}</label>
             <select v-model="form.status"
-              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
+              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none">
               <option value="active">{{ t('common.active') }}</option>
               <option value="paused">{{ t('project.status_paused') }}</option>
               <option value="closed">{{ t('project.status_closed') }}</option>
@@ -315,7 +315,7 @@ async function submit() {
       </div>
 
       <div class="px-5 py-3 border-t border-neutral-200 bg-neutral-50 flex justify-end gap-3 rounded-b-lg">
-        <button type="button" @click="embedded ? emit('cancel') : router.back()" class="px-4 h-10 border border-neutral-300 rounded-md text-neutral-700 hover:bg-white text-sm font-medium">{{ t('common.cancel') }}</button>
+        <button type="button" @click="embedded ? emit('cancel') : router.back()" class="px-4 h-10 border border-neutral-300 rounded-md text-neutral-700 hover:bg-surface text-sm font-medium">{{ t('common.cancel') }}</button>
         <button type="submit" :disabled="submitting"
           class="px-5 h-10 bg-primary-600 hover:bg-primary-700 disabled:bg-neutral-300 text-white text-sm font-medium rounded-md">
           {{ submitting ? t('common.saving') : (isEdit ? t('common.save') : t('common.create')) }}

--- a/web/src/pages/projects/ProjectList.vue
+++ b/web/src/pages/projects/ProjectList.vue
@@ -85,10 +85,10 @@ watch([status, clientId, sort], () => load(true))
       </i18n-t>
     </div>
 
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <div class="px-4 py-3 border-b border-neutral-200 flex flex-wrap items-center gap-2">
         <select v-model="status"
-          class="h-9 px-3 border border-neutral-300 rounded-md text-sm bg-white">
+          class="h-9 px-3 border border-neutral-300 rounded-md text-sm bg-surface">
           <option value="">{{ t('invoice.all_statuses') }}</option>
           <option value="active">{{ t('common.active') }}</option>
           <option value="paused">{{ t('project.status_paused') }}</option>
@@ -102,7 +102,7 @@ watch([status, clientId, sort], () => load(true))
             :placeholder="t('project.all_clients')"
           />
         </div>
-        <select v-model="sort" class="h-9 px-3 border border-neutral-300 rounded-md text-sm bg-white ml-auto"
+        <select v-model="sort" class="h-9 px-3 border border-neutral-300 rounded-md text-sm bg-surface ml-auto"
           :title="t('common.sort_by')">
           <option value="name">{{ t('common.sort_name') }}</option>
           <option value="client">{{ t('common.sort_client') }}</option>
@@ -140,8 +140,8 @@ watch([status, clientId, sort], () => load(true))
             <td class="px-4 py-3">
               <span class="text-xs px-2 py-0.5 rounded"
                 :class="{
-                  'bg-emerald-50 text-emerald-700': p.status === 'active',
-                  'bg-amber-50 text-amber-700': p.status === 'paused',
+                  'bg-success-50 text-success-600': p.status === 'active',
+                  'bg-warning-50 text-warning-600': p.status === 'paused',
                   'bg-neutral-100 text-neutral-600': p.status === 'closed',
                 }">
                 {{ p.status === 'active' ? t('common.active') : p.status === 'paused' ? t('project.status_paused') : t('project.status_closed') }}
@@ -179,8 +179,8 @@ watch([status, clientId, sort], () => load(true))
           <div class="flex items-center justify-between gap-2 mt-2 text-xs">
             <span class="px-2 py-0.5 rounded"
               :class="{
-                'bg-emerald-50 text-emerald-700': p.status === 'active',
-                'bg-amber-50 text-amber-700': p.status === 'paused',
+                'bg-success-50 text-success-600': p.status === 'active',
+                'bg-warning-50 text-warning-600': p.status === 'paused',
                 'bg-neutral-100 text-neutral-600': p.status === 'closed',
               }">
               {{ p.status === 'active' ? t('common.active') : p.status === 'paused' ? t('project.status_paused') : t('project.status_closed') }}

--- a/web/src/pages/purchase-invoices/Export.vue
+++ b/web/src/pages/purchase-invoices/Export.vue
@@ -37,7 +37,7 @@ const isComingSoon = computed(() => false)
     </div>
 
     <!-- Box: nastavení exportu -->
-    <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
+    <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
       <!-- Formát výběr -->
       <div>
         <label class="block text-sm font-medium text-neutral-700 mb-2">{{ t('purchase_invoice.export.format_label') }}</label>
@@ -79,7 +79,7 @@ const isComingSoon = computed(() => false)
         </div>
         <div>
           <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('purchase_invoice.export.date_by_label') }}</label>
-          <select v-model="dateBy" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+          <select v-model="dateBy" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
             <option value="tax">{{ t('purchase_invoice.fields.tax_date') }}</option>
             <option value="issue">{{ t('purchase_invoice.fields.issue_date') }}</option>
             <option value="received">{{ t('purchase_invoice.fields.received_at') }}</option>

--- a/web/src/pages/purchase-invoices/InvoiceDetail.vue
+++ b/web/src/pages/purchase-invoices/InvoiceDetail.vue
@@ -314,7 +314,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
             {{ t('purchase_invoice.export.menu') }}
             <svg class="w-3 h-3 text-neutral-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
           </summary>
-          <div class="absolute right-0 top-full mt-1 z-20 bg-white border border-neutral-200 rounded-md shadow-lg min-w-[220px]">
+          <div class="absolute right-0 top-full mt-1 z-20 bg-surface border border-neutral-200 rounded-md shadow-lg min-w-[220px]">
             <a :href="purchaseInvoicesApi.ourPdfUrl(invoice.id)" target="_blank"
               class="cursor-pointer block px-4 py-2 text-sm hover:bg-neutral-50 text-neutral-700">
               <svg class="inline w-4 h-4 mr-1" viewBox="0 0 32 36"><path fill="#dc2626" d="M4 2h16l8 8v22a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2z"/><text x="16" y="26" fill="#fff" font-size="8" font-weight="700" text-anchor="middle">PDF</text></svg>
@@ -384,7 +384,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
     <!-- ═══ Datumy & metadata (3 sloupce ala vystavená InvoiceDetail) ═══ -->
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <!-- Datumy -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.fields.issue_date') }} / {{ t('purchase_invoice.fields.tax_date') }} / {{ t('purchase_invoice.fields.due_date') }}</h3>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-500">{{ t('purchase_invoice.fields.issue_date') }}</dt><dd class="font-mono">{{ formatDate(invoice.issue_date) }}</dd></div>
@@ -396,7 +396,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
       </div>
 
       <!-- Měna & kurz -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.fields.currency') }}</h3>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-500">{{ t('purchase_invoice.fields.currency') }}</dt><dd class="font-mono">{{ invoice.currency }}</dd></div>
@@ -429,7 +429,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
       </div>
 
       <!-- Platba v jiné měně -->
-      <div v-if="invoice.payment_currency_id" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-if="invoice.payment_currency_id" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.payment_currency.toggle') }}</h3>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-500">{{ t('purchase_invoice.payment_currency.currency') }}</dt><dd class="font-mono">{{ invoice.payment_currency || '—' }}</dd></div>
@@ -441,7 +441,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
     </div>
 
     <!-- ═══ Položky ═══ -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <h3 class="text-sm font-medium text-neutral-700 px-5 py-3 border-b border-neutral-100">{{ t('purchase_invoice.items.title') }}</h3>
       <table class="w-full text-sm">
         <thead class="bg-neutral-50 text-neutral-500 text-xs uppercase tracking-wide">
@@ -469,7 +469,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
 
     <!-- ═══ Totals + VAT breakdown ═══ -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.vat_breakdown.title') }}</h3>
         <table class="w-full text-sm">
           <thead>
@@ -490,7 +490,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
           </tbody>
         </table>
       </div>
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.totals.with_vat') }}</h3>
         <dl class="space-y-2 text-sm">
           <div class="flex justify-between"><dt class="text-neutral-600">{{ t('purchase_invoice.totals.without_vat') }}</dt><dd class="font-mono">{{ formatMoney(invoice.total_without_vat, invoice.currency) }}</dd></div>
@@ -523,7 +523,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
     </div>
 
     <!-- ═══ Propojení se zálohovou fakturou (advance) ═══ -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
       <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.advance_link.title') }}</h3>
 
       <!-- Tento doklad JE záloha → reverzní pohled (kdo ji vyúčtovává) -->
@@ -586,7 +586,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
 
     <!-- Modal výběru zálohy k propojení -->
     <div v-if="advanceModalOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" @click.self="advanceModalOpen = false">
-      <div class="bg-white rounded-lg shadow-xl max-w-lg w-full max-h-[80vh] overflow-hidden flex flex-col">
+      <div class="bg-surface rounded-lg shadow-xl max-w-lg w-full max-h-[80vh] overflow-hidden flex flex-col">
         <div class="px-5 py-3 border-b border-neutral-100 flex items-center justify-between">
           <h3 class="font-medium">{{ t('purchase_invoice.advance_link.modal_title') }}</h3>
           <button type="button" @click="advanceModalOpen = false" class="cursor-pointer text-neutral-400 hover:text-neutral-600">✕</button>
@@ -608,7 +608,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
     </div>
 
     <!-- ═══ Originální PDF od dodavatele ═══ -->
-    <div v-if="invoice.pdf_path" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-if="invoice.pdf_path" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <div class="flex items-center justify-between px-5 py-3 border-b border-neutral-100">
         <div class="flex items-center gap-3">
           <svg class="w-7 h-8 shrink-0" viewBox="0 0 32 36" xmlns="http://www.w3.org/2000/svg">
@@ -652,13 +652,13 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
         ></iframe>
       </div>
     </div>
-    <div v-else class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.pdf.title') }}</h3>
       <p class="text-sm text-neutral-500">{{ t('purchase_invoice.pdf.no_pdf') }}</p>
     </div>
 
     <!-- ═══ Poznámky (jen pokud existují) ═══ -->
-    <div v-if="invoice.note_above_items || invoice.note_below_items" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div v-if="invoice.note_above_items || invoice.note_below_items" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.fields.note_above_items') }} / {{ t('purchase_invoice.fields.note_below_items') }}</h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
         <div v-if="invoice.note_above_items">
@@ -673,7 +673,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
     </div>
 
     <!-- ═══ More actions (vendor detail link, paralel s vystavenou InvoiceDetail) ═══ -->
-    <div v-if="invoice && (invoice.vendor_id || canForceEdit || canForceDelete)" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+    <div v-if="invoice && (invoice.vendor_id || canForceEdit || canForceDelete)" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
       <h3 class="text-xs font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('invoice.more_actions') }}</h3>
       <div class="flex flex-wrap gap-2">
         <RouterLink v-if="invoice.vendor_id" :to="`/clients/${invoice.vendor_id}`"
@@ -699,7 +699,7 @@ function transitionLabel(target: PurchaseInvoiceStatus): string {
     </div>
 
     <!-- ═══ Activity log (paralel s /invoices) ═══ -->
-    <div v-if="activity.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-if="activity.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <header class="px-5 py-3 border-b border-neutral-200">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.activity') }}</h3>
       </header>

--- a/web/src/pages/purchase-invoices/InvoiceEditor.vue
+++ b/web/src/pages/purchase-invoices/InvoiceEditor.vue
@@ -538,7 +538,7 @@ function fieldErr(key: string): string | null {
       </RouterLink>
     </header>
 
-    <div v-if="error" class="p-3 bg-red-50 border border-red-200 text-red-700 rounded-md text-sm">
+    <div v-if="error" class="p-3 bg-danger-50 border border-danger-500/40 text-danger-600 rounded-md text-sm">
       {{ error }}
     </div>
 
@@ -566,7 +566,7 @@ function fieldErr(key: string): string | null {
 
     <form v-else @submit.prevent="submit" class="space-y-5">
       <!-- DRAG & DROP PDF (jen nahoře u nové faktury, schovaný po prvním interaction) -->
-      <div v-if="!isEdit && dropzoneVisible" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-if="!isEdit && dropzoneVisible" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <PdfDropzone :uploading="pdfUploading" @file-dropped="onPdfDropped" @error="onPdfError" />
         <p class="text-xs text-neutral-500 mt-2">
           {{ t('purchase_invoice.extraction.ai_pending') }}
@@ -574,7 +574,7 @@ function fieldErr(key: string): string | null {
       </div>
 
       <!-- Existující PDF na detail/edit (s inline preview, stejný pattern jako InvoiceDetail.vue) -->
-      <div v-if="existingPdf" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div v-if="existingPdf" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <div class="flex items-center justify-between px-4 py-3 border-b border-neutral-100">
           <div class="flex items-center gap-3">
             <svg class="w-7 h-8 shrink-0" viewBox="0 0 32 36" xmlns="http://www.w3.org/2000/svg">
@@ -632,12 +632,12 @@ function fieldErr(key: string): string | null {
       </div>
 
       <!-- Replace dropzone když user vybere replace -->
-      <div v-else-if="isEdit && dropzoneVisible" class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div v-else-if="isEdit && dropzoneVisible" class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <PdfDropzone :uploading="pdfUploading" @file-dropped="onPdfDropped" @error="onPdfError" />
       </div>
 
       <!-- Box 1: Hlavička — vendor + typ + čísla + datumy + měna -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
         <h2 class="text-sm font-medium text-neutral-700 pb-2 border-b border-neutral-100">
           {{ t('purchase_invoice.fields.vendor') }} & {{ t('purchase_invoice.fields.document_kind') }}
         </h2>
@@ -664,7 +664,7 @@ function fieldErr(key: string): string | null {
           </div>
           <div>
             <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.document_kind') }}</label>
-            <select v-model="form.document_kind" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="form.document_kind" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
               <option value="invoice">{{ t('purchase_invoice.document_kind.invoice') }}</option>
               <option value="receipt">{{ t('purchase_invoice.document_kind.receipt') }}</option>
               <option value="credit_note">{{ t('purchase_invoice.document_kind.credit_note') }}</option>
@@ -676,12 +676,12 @@ function fieldErr(key: string): string | null {
         <!-- Vendor invoice number + our varsymbol -->
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.vendor_invoice_number') }} <span class="text-red-500">*</span></label>
+            <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.vendor_invoice_number') }} <span class="text-danger-500">*</span></label>
             <input v-model="form.vendor_invoice_number" type="text" maxlength="50" required
                    class="w-full h-10 px-3 border rounded-md text-sm font-mono"
-                   :class="fieldErr('vendor_invoice_number') ? 'border-red-300' : 'border-neutral-300'" />
+                   :class="fieldErr('vendor_invoice_number') ? 'border-danger-500/40' : 'border-neutral-300'" />
             <p class="text-xs text-neutral-500 mt-1">{{ t('purchase_invoice.fields.vendor_invoice_number_hint') }}</p>
-            <p v-if="fieldErr('vendor_invoice_number')" class="text-xs text-red-600 mt-1">{{ fieldErr('vendor_invoice_number') }}</p>
+            <p v-if="fieldErr('vendor_invoice_number')" class="text-xs text-danger-600 mt-1">{{ fieldErr('vendor_invoice_number') }}</p>
           </div>
           <div>
             <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.varsymbol') }}</label>
@@ -695,7 +695,7 @@ function fieldErr(key: string): string | null {
         <!-- Dates -->
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <div>
-            <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.issue_date') }} <span class="text-red-500">*</span></label>
+            <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.issue_date') }} <span class="text-danger-500">*</span></label>
             <input v-model="form.issue_date" type="date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
           </div>
           <div>
@@ -703,7 +703,7 @@ function fieldErr(key: string): string | null {
             <input v-model="form.tax_date" type="date" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
           </div>
           <div>
-            <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.due_date') }} <span class="text-red-500">*</span></label>
+            <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.due_date') }} <span class="text-danger-500">*</span></label>
             <input v-model="form.due_date" type="date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
           </div>
           <div>
@@ -715,9 +715,9 @@ function fieldErr(key: string): string | null {
         <!-- Currency + exchange rate -->
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
-            <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.currency') }} <span class="text-red-500">*</span></label>
+            <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.currency') }} <span class="text-danger-500">*</span></label>
             <div class="flex items-center gap-2">
-              <select v-model="form.currency_id" required class="flex-1 h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+              <select v-model="form.currency_id" required class="flex-1 h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
                 <option :value="null">—</option>
                 <option v-for="c in currencyOptions" :key="c.id" :value="c.id">
                   {{ c.code }}{{ !c.is_active ? ' · ' + t('purchase_invoice.fields.currency_purchase_only') : '' }}
@@ -757,7 +757,7 @@ function fieldErr(key: string): string | null {
           </label>
           <div class="inline-flex items-center gap-2">
             <label class="text-sm text-neutral-700">{{ t('purchase_invoice.fields.language') }}:</label>
-            <select v-model="form.language" class="h-8 px-2 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="form.language" class="h-8 px-2 border border-neutral-300 rounded-md bg-surface text-sm">
               <option value="cs">CS</option>
               <option value="en">EN</option>
             </select>
@@ -766,7 +766,7 @@ function fieldErr(key: string): string | null {
       </div>
 
       <!-- Box 2: Položky -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
         <header class="flex items-center justify-between px-5 py-3 border-b border-neutral-100">
           <h2 class="text-sm font-medium text-neutral-700">{{ t('purchase_invoice.items.title') }}</h2>
           <button type="button" @click="addItem" class="cursor-pointer px-3 h-8 text-sm bg-primary-600 hover:bg-primary-700 text-white rounded-md font-medium">
@@ -799,7 +799,7 @@ function fieldErr(key: string): string | null {
                 <input v-model="it.quantity" v-math type="text" inputmode="decimal" class="w-full h-9 px-2 border border-neutral-200 rounded text-sm text-right font-mono" />
               </td>
               <td class="py-2 px-1">
-                <select v-model="it.unit" class="w-full h-9 px-1 border border-neutral-200 rounded bg-white text-sm">
+                <select v-model="it.unit" class="w-full h-9 px-1 border border-neutral-200 rounded bg-surface text-sm">
                   <option v-for="u in units" :key="u.code" :value="u.code">{{ u.code }}</option>
                 </select>
               </td>
@@ -807,7 +807,7 @@ function fieldErr(key: string): string | null {
                 <input v-model="it.unit_price_without_vat" v-math type="text" inputmode="decimal" class="w-full h-9 px-2 border border-neutral-200 rounded text-sm text-right font-mono" />
               </td>
               <td class="py-2 px-1">
-                <select v-model.number="it.vat_rate_id" class="w-full h-9 px-1 border border-neutral-200 rounded bg-white text-sm">
+                <select v-model.number="it.vat_rate_id" class="w-full h-9 px-1 border border-neutral-200 rounded bg-surface text-sm">
                   <option v-for="v in vatRates" :key="v.id" :value="v.id">{{ vatRateLabel(v) }}</option>
                 </select>
               </td>
@@ -817,7 +817,7 @@ function fieldErr(key: string): string | null {
                   class="w-full h-9 px-2 border border-neutral-200 rounded text-sm text-right font-mono" />
               </td>
               <td class="py-2 px-1 pr-3 text-center">
-                <button type="button" @click="removeItem(i)" class="cursor-pointer w-8 h-8 inline-flex items-center justify-center text-neutral-400 hover:text-red-600 hover:bg-red-50 rounded" :title="t('purchase_invoice.items.remove')">✕</button>
+                <button type="button" @click="removeItem(i)" class="cursor-pointer w-8 h-8 inline-flex items-center justify-center text-neutral-400 hover:text-danger-600 hover:bg-danger-50 rounded" :title="t('purchase_invoice.items.remove')">✕</button>
               </td>
             </tr>
           </tbody>
@@ -842,7 +842,7 @@ function fieldErr(key: string): string | null {
               </div>
               <div>
                 <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('purchase_invoice.items.unit') }}</label>
-                <select v-model="it.unit" class="w-full h-10 px-2 border border-neutral-200 rounded bg-white text-sm">
+                <select v-model="it.unit" class="w-full h-10 px-2 border border-neutral-200 rounded bg-surface text-sm">
                   <option v-for="u in units" :key="u.code" :value="u.code">{{ u.code }}</option>
                 </select>
               </div>
@@ -854,7 +854,7 @@ function fieldErr(key: string): string | null {
               </div>
               <div>
                 <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('purchase_invoice.items.vat_rate') }}</label>
-                <select v-model.number="it.vat_rate_id" class="w-full h-10 px-2 border border-neutral-200 rounded bg-white text-sm">
+                <select v-model.number="it.vat_rate_id" class="w-full h-10 px-2 border border-neutral-200 rounded bg-surface text-sm">
                   <option v-for="v in vatRates" :key="v.id" :value="v.id">{{ vatRateLabel(v) }}</option>
                 </select>
               </div>
@@ -891,7 +891,7 @@ function fieldErr(key: string): string | null {
       </div>
 
       <!-- Box 3: Multi-currency platba (collapsible — komponenta má vlastní wrapper) -->
-      <div v-if="form.currency_id" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div v-if="form.currency_id" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <PaymentCurrencyBlock
           :invoice-currency-id="form.currency_id"
           :invoice-currency="currencyCode"
@@ -912,12 +912,12 @@ function fieldErr(key: string): string | null {
       </div>
 
       <!-- Box: Klasifikace (kategorie nákladů + VAT klasifikace pro DPHDP3) -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.classification.title') }}</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label class="block text-xs text-neutral-500 mb-1">{{ t('purchase_invoice.classification.expense_category') }}</label>
-            <select v-model="form.expense_category_id" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="form.expense_category_id" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
               <option :value="null">— {{ t('purchase_invoice.classification.no_category') }} —</option>
               <option v-for="c in expenseCategories" :key="c.id" :value="c.id">
                 {{ c.label }} <span class="text-neutral-400">({{ c.code }})</span>
@@ -931,7 +931,7 @@ function fieldErr(key: string): string | null {
           </div>
           <div>
             <label class="block text-xs text-neutral-500 mb-1">{{ t('purchase_invoice.classification.vat_classification') }}</label>
-            <select v-model="form.vat_classification_code" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="form.vat_classification_code" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
               <option :value="null">— {{ t('purchase_invoice.classification.no_vat_class') }} —</option>
               <option v-for="vc in vatClassifications" :key="vc.id" :value="vc.code">
                 {{ vc.code }} — {{ vc.label.length > 60 ? vc.label.slice(0, 60) + '…' : vc.label }}
@@ -941,7 +941,7 @@ function fieldErr(key: string): string | null {
           </div>
           <div>
             <label class="block text-xs text-neutral-500 mb-1">{{ t('purchase_invoice.classification.vat_deduction') }}</label>
-            <select v-model="form.vat_deduction" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+            <select v-model="form.vat_deduction" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
               <option value="full">{{ t('purchase_invoice.vat_deduction.full') }}</option>
               <option value="none">{{ t('purchase_invoice.vat_deduction.none') }}</option>
               <option value="proportional">{{ t('purchase_invoice.vat_deduction.proportional') }}</option>
@@ -949,7 +949,7 @@ function fieldErr(key: string): string | null {
             <template v-if="form.vat_deduction === 'proportional'">
               <div class="mt-2 flex items-center gap-2">
                 <input v-model.number="form.vat_deduction_percent" type="number" min="0" max="100" step="0.01"
-                  class="w-24 h-10 px-3 border border-neutral-300 rounded-md bg-white text-sm text-right" />
+                  class="w-24 h-10 px-3 border border-neutral-300 rounded-md bg-surface text-sm text-right" />
                 <span class="text-sm text-neutral-600">% {{ t('purchase_invoice.vat_deduction_percent') }}</span>
               </div>
               <p class="text-xs text-neutral-500 mt-1">{{ t('purchase_invoice.vat_deduction_percent_hint') }}</p>
@@ -967,7 +967,7 @@ function fieldErr(key: string): string | null {
       </div>
 
       <!-- Box 4: Poznámky -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <h2 class="text-sm font-medium text-neutral-700 mb-3">{{ t('purchase_invoice.fields.note_above_items') }} / {{ t('purchase_invoice.fields.note_below_items') }}</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
@@ -982,7 +982,7 @@ function fieldErr(key: string): string | null {
       </div>
 
       <!-- Submit bar — sticky bottom -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-4 shadow-sm flex items-center justify-end gap-2">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-4 shadow-sm flex items-center justify-end gap-2">
         <RouterLink to="/purchase-invoices" class="px-4 h-10 inline-flex items-center text-sm border border-neutral-300 rounded-md hover:bg-neutral-50">
           {{ t('purchase_invoice.actions.back') }}
         </RouterLink>
@@ -993,8 +993,8 @@ function fieldErr(key: string): string | null {
     </form>
 
     <!-- Quick-add currency modal -->
-    <div v-if="showAddCurrency" class="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/40 p-4" @click.self="showAddCurrency = false">
-      <div class="bg-white rounded-lg shadow-xl max-w-sm w-full p-5 space-y-3">
+    <div v-if="showAddCurrency" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" @click.self="showAddCurrency = false">
+      <div class="bg-surface rounded-lg shadow-xl max-w-sm w-full p-5 space-y-3">
         <h3 class="font-medium">{{ t('purchase_invoice.fields.currency_add_title') }}</h3>
         <p class="text-xs text-neutral-500">{{ t('purchase_invoice.fields.currency_add_iso_hint') }}</p>
         <input

--- a/web/src/pages/purchase-invoices/InvoiceList.vue
+++ b/web/src/pages/purchase-invoices/InvoiceList.vue
@@ -380,7 +380,7 @@ async function bulkDelete() {
     </div>
 
     <!-- ═══ Filtry v boxu ═══ -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm mb-4 p-3">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm mb-4 p-3">
       <div class="flex flex-wrap items-center gap-2">
         <input
           v-model="search"
@@ -388,7 +388,7 @@ async function bulkDelete() {
           :placeholder="t('purchase_invoice.filters.search_placeholder')"
           class="flex-1 min-w-48 h-9 px-3 border border-neutral-300 rounded-md text-sm focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500 outline-none"
         />
-        <select v-model="statusFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model="statusFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option value="">{{ t('purchase_invoice.filters.all_statuses') }}</option>
           <option value="draft">{{ t('purchase_invoice.status.draft') }}</option>
           <option value="received">{{ t('purchase_invoice.status.received') }}</option>
@@ -396,7 +396,7 @@ async function bulkDelete() {
           <option value="paid">{{ t('purchase_invoice.status.paid') }}</option>
           <option value="cancelled">{{ t('purchase_invoice.status.cancelled') }}</option>
         </select>
-        <select v-model="kindFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model="kindFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option value="">{{ t('purchase_invoice.filters.all_kinds') }}</option>
           <option value="invoice">{{ t('purchase_invoice.document_kind.invoice') }}</option>
           <option value="receipt">{{ t('purchase_invoice.document_kind.receipt') }}</option>
@@ -412,12 +412,12 @@ async function bulkDelete() {
           />
         </div>
         <select v-model="yearFilter" :disabled="!!dateFrom || !!dateTo"
-          class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm disabled:opacity-50">
+          class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm disabled:opacity-50">
           <option value="">{{ t('invoice.all_years') }}</option>
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
         </select>
         <select v-model="monthFilter" :disabled="!!dateFrom || !!dateTo || yearFilter === ''"
-          class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm disabled:opacity-50">
+          class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm disabled:opacity-50">
           <option :value="''">{{ t('invoice.all_months') }}</option>
           <option v-for="(label, i) in monthOptions" :key="i + 1" :value="i + 1">{{ label }}</option>
         </select>
@@ -443,7 +443,7 @@ async function bulkDelete() {
     </div>
 
     <!-- ═══ Loading / Error / Empty / Data ═══ -->
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <TableSkeleton :rows="6" :cols="7" />
     </div>
 
@@ -451,7 +451,7 @@ async function bulkDelete() {
       {{ error }}
     </div>
 
-    <div v-else-if="!groups.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div v-else-if="!groups.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <EmptyState
         :title="search || statusFilter || kindFilter ? t('purchase_invoice.empty_filtered') : t('purchase_invoice.empty')"
         :cta="t('purchase_invoice.new')"
@@ -480,7 +480,7 @@ async function bulkDelete() {
         </header>
 
         <!-- Desktop: tabulka -->
-        <div class="hidden md:block bg-white border border-t-0 border-neutral-200 rounded-b-lg overflow-hidden">
+        <div class="hidden md:block bg-surface border border-t-0 border-neutral-200 rounded-b-lg overflow-hidden">
           <div class="overflow-x-auto">
             <table class="w-full text-sm table-sticky-first">
               <thead class="bg-neutral-50 text-neutral-500 text-xs uppercase tracking-wide">
@@ -566,7 +566,7 @@ async function bulkDelete() {
         </div>
 
         <!-- Mobile: karty -->
-        <div class="md:hidden bg-white border border-t-0 border-neutral-200 rounded-b-lg divide-y divide-neutral-100 overflow-hidden">
+        <div class="md:hidden bg-surface border border-t-0 border-neutral-200 rounded-b-lg divide-y divide-neutral-100 overflow-hidden">
           <div
             v-for="inv in g.invoices"
             :key="`m-${inv.id}`"

--- a/web/src/pages/recurring/RecurringDetail.vue
+++ b/web/src/pages/recurring/RecurringDetail.vue
@@ -232,7 +232,7 @@ async function removeAction() {
 
       <!-- Konfigurace -->
       <div class="grid md:grid-cols-3 gap-4">
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-xs font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('recurring.section_periodicity') }}</h3>
           <dl class="space-y-1.5 text-sm">
             <div class="flex justify-between"><dt class="text-neutral-500">{{ t('recurring.frequency') }}</dt><dd>{{ freqLabel(tpl.frequency) }}</dd></div>
@@ -245,7 +245,7 @@ async function removeAction() {
           </dl>
         </div>
 
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-xs font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('recurring.section_invoice_meta') }}</h3>
           <dl class="space-y-1.5 text-sm">
             <div class="flex justify-between">
@@ -267,7 +267,7 @@ async function removeAction() {
           </dl>
         </div>
 
-        <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+        <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
           <h3 class="text-xs font-semibold uppercase tracking-wide text-neutral-500 mb-3">{{ t('recurring.section_automation') }}</h3>
           <dl class="space-y-1.5 text-sm">
             <div class="flex justify-between gap-2">
@@ -286,7 +286,7 @@ async function removeAction() {
       </div>
 
       <!-- Položky šablony -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <div class="px-5 py-3 border-b border-neutral-200">
           <h3 class="font-semibold">{{ t('recurring.items') }}</h3>
         </div>
@@ -333,7 +333,7 @@ async function removeAction() {
       </div>
 
       <!-- Vygenerované faktury -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <div class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
           <h3 class="font-semibold">
             {{ t('recurring.generated_invoices') }}
@@ -398,7 +398,7 @@ async function removeAction() {
     <!-- Run Now modal — date picker s defaultem dnes; varování pokud uživatel zvolí
          budoucí datum (issue_date = budoucnost je daňově problematické). -->
     <div v-if="runNowModal && tpl" class="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-      <div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+      <div class="bg-surface rounded-lg shadow-xl max-w-md w-full p-6">
         <h2 class="text-lg font-semibold mb-1">{{ runNowMode === 'draft' ? t('recurring.run_now_draft_title') : t('recurring.run_now_title') }}</h2>
         <p class="text-sm text-neutral-600 mb-4">{{ tpl.name }}</p>
         <p v-if="runNowMode === 'draft'" class="text-xs text-neutral-500 mb-3 -mt-2">{{ t('recurring.run_now_draft_hint') }}</p>

--- a/web/src/pages/recurring/RecurringForm.vue
+++ b/web/src/pages/recurring/RecurringForm.vue
@@ -502,7 +502,7 @@ async function submit() {
     <div v-if="loading" class="text-center py-12 text-neutral-400">…</div>
     <form v-else @submit.prevent="submit" class="space-y-5">
       <!-- Basics -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
         <div>
           <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('recurring.name') }} *</label>
           <input v-model="form.name" type="text" maxlength="200"
@@ -577,12 +577,12 @@ async function submit() {
       </div>
 
       <!-- Periodicity -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('recurring.section_periodicity') }}</h3>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('recurring.frequency') }} *</label>
-            <select v-model="form.frequency" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+            <select v-model="form.frequency" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
               <option value="monthly">{{ t('recurring.frequency_monthly') }}</option>
               <option value="quarterly">{{ t('recurring.frequency_quarterly') }}</option>
               <option value="semi_annually">{{ t('recurring.frequency_semi_annually') }}</option>
@@ -619,32 +619,32 @@ async function submit() {
       </div>
 
       <!-- Invoice metadata -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-4">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('recurring.section_invoice_meta') }}</h3>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('recurring.invoice_type') }}</label>
-            <select v-model="form.invoice_type" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+            <select v-model="form.invoice_type" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
               <option value="invoice">{{ t('type.invoice') }}</option>
               <option value="proforma">{{ t('type.proforma') }}</option>
             </select>
           </div>
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('recurring.currency') }}</label>
-            <select v-model.number="form.currency_id" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+            <select v-model.number="form.currency_id" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
               <option v-for="c in currencies" :key="c.id" :value="c.id">{{ c.label }}</option>
             </select>
           </div>
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('recurring.language') }}</label>
-            <select v-model="form.language" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+            <select v-model="form.language" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
               <option value="cs">CZ</option>
               <option value="en">EN</option>
             </select>
           </div>
           <div>
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('payment_method.label') }}</label>
-            <select v-model="form.payment_method" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+            <select v-model="form.payment_method" class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
               <option value="bank_transfer">{{ t('payment_method.bank_transfer') }}</option>
               <option value="card">{{ t('payment_method.card') }}</option>
               <option value="cash">{{ t('payment_method.cash') }}</option>
@@ -667,7 +667,7 @@ async function submit() {
           <div class="md:col-span-2">
             <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('recurring.tax_date_mode') }}</label>
             <select v-model="form.tax_date_mode"
-              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+              class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
               <option value="same_as_issue">{{ t('recurring.tax_date_mode_same_as_issue') }}</option>
               <option value="previous_month_last_day">{{ t('recurring.tax_date_mode_previous_month_last_day') }}</option>
             </select>
@@ -677,7 +677,7 @@ async function submit() {
       </div>
 
       <!-- Items -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
         <div class="flex items-center justify-between mb-3">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('recurring.items') }}</h3>
           <button type="button" @click="addItem"
@@ -704,14 +704,14 @@ async function submit() {
               <td class="py-1.5 pr-2"><input v-model="it.description" type="text" class="w-full h-8 px-2 border border-neutral-200 rounded" /></td>
               <td class="py-1.5 pr-2"><input v-model="it.quantity" v-math type="text" inputmode="decimal" :class="['w-full h-8 px-2 border rounded text-right font-mono', itemHasBothNegative(it) ? 'border-danger-400' : 'border-neutral-200']" /></td>
               <td class="py-1.5 pr-2">
-                <select v-model="it.unit" class="w-full h-8 px-1 border border-neutral-200 rounded bg-white text-sm">
+                <select v-model="it.unit" class="w-full h-8 px-1 border border-neutral-200 rounded bg-surface text-sm">
                   <option v-for="u in units" :key="u.id" :value="u.code">{{ u.code }}</option>
                   <option v-if="it.unit && !units.some(u => u.code === it.unit)" :value="it.unit">{{ it.unit }}</option>
                 </select>
               </td>
               <td class="py-1.5 pr-2"><input v-model="it.unit_price_without_vat" v-math type="text" inputmode="decimal" :class="['w-full h-8 px-2 border rounded text-right font-mono', itemHasBothNegative(it) ? 'border-danger-400' : 'border-neutral-200']" /></td>
               <td class="py-1.5 pr-2">
-                <select v-model.number="it.vat_rate_id" class="w-full h-8 px-2 border border-neutral-200 rounded bg-white">
+                <select v-model.number="it.vat_rate_id" class="w-full h-8 px-2 border border-neutral-200 rounded bg-surface">
                   <option v-for="r in vatRates" :key="r.id" :value="r.id">
                     {{ Number(r.rate_percent) > 0 ? r.rate_percent + ' %' : (r.is_reverse_charge ? 'RC' : '0 %') }}
                   </option>
@@ -743,7 +743,7 @@ async function submit() {
               </div>
               <div>
                 <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.items_table.unit') }}</label>
-                <select v-model="it.unit" class="w-full h-10 px-2 border border-neutral-200 rounded bg-white text-sm">
+                <select v-model="it.unit" class="w-full h-10 px-2 border border-neutral-200 rounded bg-surface text-sm">
                   <option v-for="u in units" :key="u.id" :value="u.code">{{ u.code }}</option>
                   <option v-if="it.unit && !units.some(u => u.code === it.unit)" :value="it.unit">{{ it.unit }}</option>
                 </select>
@@ -756,7 +756,7 @@ async function submit() {
               </div>
               <div>
                 <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.items_table.vat') ?? 'DPH' }}</label>
-                <select v-model.number="it.vat_rate_id" class="w-full h-10 px-2 border border-neutral-200 rounded bg-white text-sm">
+                <select v-model.number="it.vat_rate_id" class="w-full h-10 px-2 border border-neutral-200 rounded bg-surface text-sm">
                   <option v-for="r in vatRates" :key="r.id" :value="r.id">
                     {{ Number(r.rate_percent) > 0 ? r.rate_percent + ' %' : (r.is_reverse_charge ? 'RC' : '0 %') }}
                   </option>
@@ -781,13 +781,13 @@ async function submit() {
       </div>
 
       <!-- Automation -->
-      <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-3">
+      <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-3">
         <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('recurring.section_automation') }}</h3>
 
         <div>
           <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('recurring.draft_open_mode') }}</label>
           <select v-model="form.draft_open_mode"
-            class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-white">
+            class="w-full h-10 px-3 border border-neutral-300 rounded-md bg-surface">
             <option value="at_issue">{{ t('recurring.draft_open_mode_at_issue') }}</option>
             <option value="period_start" :disabled="form.frequency !== 'monthly'">
               {{ t('recurring.draft_open_mode_period_start') }}

--- a/web/src/pages/recurring/RecurringList.vue
+++ b/web/src/pages/recurring/RecurringList.vue
@@ -153,9 +153,9 @@ function gotoClient(clientId: number) {
     </div>
 
     <!-- Filtry v boxu (sjednoceno s /invoices a /purchase-invoices) -->
-    <div class="bg-white border border-neutral-200 rounded-lg shadow-sm mb-4 p-3">
+    <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm mb-4 p-3">
       <div class="flex flex-wrap items-center gap-2">
-        <select v-model="statusFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model="statusFilter" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option value="">{{ t('common.all') ?? 'Vše' }} (status)</option>
           <option value="active">{{ t('recurring.status.active') }}</option>
           <option value="paused">{{ t('recurring.status.paused') }}</option>
@@ -170,7 +170,7 @@ function gotoClient(clientId: number) {
             </span>
           </div>
           <select v-model="sortBy" :title="t('recurring.sort.label')"
-            class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+            class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
             <option value="next_run">{{ t('recurring.sort.label') }}: {{ t('recurring.sort.next_run') }}</option>
             <option value="client">{{ t('recurring.sort.label') }}: {{ t('recurring.sort.client') }}</option>
             <option value="amount_czk">{{ t('recurring.sort.label') }}: {{ t('recurring.sort.amount_czk') }}</option>
@@ -180,14 +180,14 @@ function gotoClient(clientId: number) {
     </div>
 
     <div v-if="loading" class="text-center py-12 text-neutral-400">…</div>
-    <div v-else-if="filtered.length === 0" class="bg-white border border-dashed border-neutral-300 rounded-lg p-8 text-center shadow-sm">
+    <div v-else-if="filtered.length === 0" class="bg-surface border border-dashed border-neutral-300 rounded-lg p-8 text-center shadow-sm">
       <p class="text-neutral-500 mb-4">{{ t('recurring.empty') }}</p>
       <button v-if="auth.canWrite" @click="gotoNew" class="cursor-pointer px-4 h-10 text-sm bg-primary-600 hover:bg-primary-700 text-white font-medium rounded-md">
         {{ t('recurring.create_first') }}
       </button>
     </div>
 
-    <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <!-- Desktop: tabulka -->
       <div class="hidden md:block overflow-x-auto">
         <table class="w-full text-sm">

--- a/web/src/pages/reports/DphBookReport.vue
+++ b/web/src/pages/reports/DphBookReport.vue
@@ -79,10 +79,10 @@ onMounted(loadPreview)
         <p class="text-sm text-neutral-500 mt-0.5">{{ t('reports.dph_book.subtitle') }}</p>
       </div>
       <div class="flex items-center gap-2">
-        <select v-model.number="month" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model.number="month" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="(label, i) in monthOptions" :key="i + 1" :value="i + 1">{{ label }}</option>
         </select>
-        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
         </select>
         <button type="button" @click="downloadPdf" :disabled="loading || !preview"
@@ -95,7 +95,7 @@ onMounted(loadPreview)
       </div>
     </div>
 
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">
       {{ t('common.loading') }}…
     </div>
     <div v-else-if="error" class="bg-danger-50 border border-danger-500/40 text-danger-500 rounded-md p-3 text-sm">
@@ -104,7 +104,7 @@ onMounted(loadPreview)
 
     <div v-else-if="preview" class="space-y-4">
       <!-- Period info -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4">
         <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">
           {{ t('reports.dph_book.period_label') }}
         </div>
@@ -113,13 +113,13 @@ onMounted(loadPreview)
 
       <!-- No data -->
       <div v-if="preview.sections.length === 0"
-        class="bg-white border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-500">
+        class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-500">
         {{ t('reports.dph_book.no_data') }}
       </div>
 
       <!-- Sections -->
       <div v-for="section in preview.sections" :key="section.key"
-        class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+        class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="sticky top-0 px-5 py-3 border-b border-neutral-200 bg-neutral-50">
           <h3 class="text-sm font-semibold text-neutral-800">
             <span class="font-mono">{{ section.key }}</span>
@@ -186,7 +186,7 @@ onMounted(loadPreview)
       <!-- Total summary — odděleně uskutečněná (daň na výstupu) a přijatá (odpočet) -->
       <div v-if="preview.sections.length > 0" class="grid gap-4 md:grid-cols-2">
         <!-- Uskutečněná plnění -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-3">
             {{ t('reports.dph_book.summary_issued') }}
           </div>
@@ -206,7 +206,7 @@ onMounted(loadPreview)
           </div>
         </div>
         <!-- Přijatá plnění -->
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-4">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-4">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-3">
             {{ t('reports.dph_book.summary_received') }}
           </div>

--- a/web/src/pages/reports/DphPriznaniReport.vue
+++ b/web/src/pages/reports/DphPriznaniReport.vue
@@ -149,12 +149,12 @@ onMounted(loadAll)
         <!-- Period toggle (override settings.vat_period) -->
         <div class="flex rounded-md border border-neutral-300 overflow-hidden text-sm">
           <button type="button" @click="periodOverride = 'monthly'"
-            :class="effectivePeriod === 'monthly' ? 'bg-primary-600 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-50'"
+            :class="effectivePeriod === 'monthly' ? 'bg-primary-600 text-white' : 'bg-surface text-neutral-700 hover:bg-neutral-50'"
             class="px-3 h-9 cursor-pointer">
             {{ t('reports.dph.monthly') }}
           </button>
           <button type="button" @click="periodOverride = 'quarterly'"
-            :class="effectivePeriod === 'quarterly' ? 'bg-primary-600 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-50'"
+            :class="effectivePeriod === 'quarterly' ? 'bg-primary-600 text-white' : 'bg-surface text-neutral-700 hover:bg-neutral-50'"
             class="px-3 h-9 cursor-pointer border-l border-neutral-300">
             {{ t('reports.dph.quarterly') }}
           </button>
@@ -162,13 +162,13 @@ onMounted(loadAll)
 
         <!-- Quarter picker pokud quarterly, jinak month -->
         <select v-if="isQuarterly" :value="currentQuarter" @change="setQuarter(Number(($event.target as HTMLSelectElement).value))"
-          class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+          class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="q in quarterOptions" :key="q" :value="q">Q{{ q }}</option>
         </select>
-        <select v-else v-model.number="month" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-else v-model.number="month" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="(label, i) in monthOptions" :key="i + 1" :value="i + 1">{{ label }}</option>
         </select>
-        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
         </select>
         <button type="button" @click="downloadXml" :disabled="loading || !preview"
@@ -179,7 +179,7 @@ onMounted(loadAll)
       </div>
     </div>
 
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">
       {{ t('common.loading') }}…
     </div>
 
@@ -198,21 +198,21 @@ onMounted(loadAll)
 
       <!-- Rekapitulace KPI cards (4 — přidán Termín) -->
       <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.dph.vat_output') }}</div>
           <div class="text-xl font-bold font-mono text-neutral-900">
             {{ formatMoney(preview.summary.total_vat_output, 'CZK') }}
           </div>
           <div class="text-xs text-neutral-500 mt-1">{{ t('reports.dph.vat_output_hint') }}</div>
         </div>
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.dph.vat_input') }}</div>
           <div class="text-xl font-bold font-mono text-neutral-900">
             {{ formatMoney(preview.summary.total_vat_input, 'CZK') }}
           </div>
           <div class="text-xs text-neutral-500 mt-1">{{ t('reports.dph.vat_input_hint') }}</div>
         </div>
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">
             {{ preview.summary.is_excess_deduction ? t('reports.dph.excess_deduction') : t('reports.dph.tax_due') }}
           </div>
@@ -225,7 +225,7 @@ onMounted(loadAll)
           </div>
         </div>
         <!-- Deadline countdown -->
-        <div v-if="preview.summary.submission_deadline" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div v-if="preview.summary.submission_deadline" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.dph.deadline') }}</div>
           <div class="text-xl font-bold font-mono"
             :class="(daysToDeadline ?? 999) < 0 ? 'text-danger-500' : (daysToDeadline ?? 999) <= 7 ? 'text-warning-600' : 'text-neutral-900'">
@@ -280,7 +280,7 @@ onMounted(loadAll)
       </div>
 
       <!-- Monthly DPH trend chart — tabulkový layout, čísla zarovnaná doprava -->
-      <div v-if="trend.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div v-if="trend.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200 flex items-center justify-between">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('reports.dph.monthly_trend') }}</h3>
           <div class="flex items-center gap-3 text-xs">
@@ -320,7 +320,7 @@ onMounted(loadAll)
       </div>
 
       <!-- DPH na výstupu -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200 bg-neutral-50">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-700">{{ t('reports.dph.output_section') }}</h3>
         </header>
@@ -348,7 +348,7 @@ onMounted(loadAll)
       </div>
 
       <!-- DPH na vstupu -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200 bg-neutral-50">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-700">{{ t('reports.dph.input_section') }}</h3>
         </header>

--- a/web/src/pages/reports/IncomeTaxReport.vue
+++ b/web/src/pages/reports/IncomeTaxReport.vue
@@ -65,13 +65,13 @@ onMounted(loadPreview)
       <div class="flex items-center gap-2">
         <div class="flex rounded-md border border-neutral-300 overflow-hidden text-sm">
           <button type="button" @click="taxpayerType = 'fo'"
-            :class="taxpayerType === 'fo' ? 'bg-primary-600 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-50'"
+            :class="taxpayerType === 'fo' ? 'bg-primary-600 text-white' : 'bg-surface text-neutral-700 hover:bg-neutral-50'"
             class="px-3 h-9 cursor-pointer">DPFO</button>
           <button type="button" @click="taxpayerType = 'po'"
-            :class="taxpayerType === 'po' ? 'bg-primary-600 text-white' : 'bg-white text-neutral-700 hover:bg-neutral-50'"
+            :class="taxpayerType === 'po' ? 'bg-primary-600 text-white' : 'bg-surface text-neutral-700 hover:bg-neutral-50'"
             class="px-3 h-9 cursor-pointer border-l border-neutral-300">DPPO</button>
         </div>
-        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
         </select>
         <button type="button" @click="downloadXml" :disabled="loading || !preview"
@@ -82,7 +82,7 @@ onMounted(loadPreview)
       </div>
     </div>
 
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">{{ t('common.loading') }}…</div>
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">{{ t('common.loading') }}…</div>
     <div v-else-if="error" class="bg-danger-50 border border-danger-500/40 text-danger-500 rounded-md p-3 text-sm">{{ error }}</div>
 
     <div v-else-if="preview" class="space-y-4">
@@ -96,7 +96,7 @@ onMounted(loadPreview)
 
       <!-- Orientační čísla -->
       <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.income_tax.revenue_orientacni') }}</div>
           <div class="text-xl font-bold font-mono text-neutral-900">
             {{ formatMoney(preview.summary.revenue_orientacni, 'CZK') }}
@@ -106,7 +106,7 @@ onMounted(loadPreview)
             {{ preview.summary.is_vat_payer ? t('reports.income_tax.vat_base_excl') : t('reports.income_tax.vat_base_incl') }}
           </div>
         </div>
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.income_tax.costs_orientacni') }}</div>
           <div class="text-xl font-bold font-mono text-neutral-900">
             {{ formatMoney(preview.summary.costs_orientacni, 'CZK') }}
@@ -116,7 +116,7 @@ onMounted(loadPreview)
             {{ preview.summary.is_vat_payer ? t('reports.income_tax.vat_base_excl') : t('reports.income_tax.vat_base_incl') }}
           </div>
         </div>
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.income_tax.profit_orientacni') }}</div>
           <div class="text-xl font-bold font-mono"
             :class="preview.summary.profit_orientacni >= 0 ? 'text-success-600' : 'text-danger-500'">
@@ -124,7 +124,7 @@ onMounted(loadPreview)
           </div>
           <div class="text-xs text-neutral-500 mt-1">{{ t('reports.income_tax.profit_hint') }}</div>
         </div>
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.dph.deadline') }}</div>
           <div class="text-xl font-bold font-mono text-neutral-900">
             {{ preview.summary.submission_deadline }}

--- a/web/src/pages/reports/KontrolniHlaseniReport.vue
+++ b/web/src/pages/reports/KontrolniHlaseniReport.vue
@@ -73,10 +73,10 @@ onMounted(loadPreview)
         <p class="text-sm text-neutral-500 mt-0.5">{{ t('reports.kh.subtitle') }}</p>
       </div>
       <div class="flex items-center gap-2">
-        <select v-model.number="month" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model.number="month" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="(label, i) in monthOptions" :key="i + 1" :value="i + 1">{{ label }}</option>
         </select>
-        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
         </select>
         <button type="button" @click="downloadXml" :disabled="loading || !preview"
@@ -87,7 +87,7 @@ onMounted(loadPreview)
       </div>
     </div>
 
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">{{ t('common.loading') }}…</div>
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">{{ t('common.loading') }}…</div>
     <div v-else-if="error" class="bg-danger-50 border border-danger-500/40 text-danger-500 rounded-md p-3 text-sm">{{ error }}</div>
 
     <div v-else-if="preview" class="space-y-4">
@@ -100,7 +100,7 @@ onMounted(loadPreview)
       </div>
 
       <!-- Deadline card -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
         <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.dph.deadline') }}</div>
         <div class="text-xl font-bold font-mono"
           :class="(daysToDeadline ?? 999) < 0 ? 'text-danger-500' : (daysToDeadline ?? 999) <= 7 ? 'text-warning-600' : 'text-neutral-900'">
@@ -114,7 +114,7 @@ onMounted(loadPreview)
       </div>
 
       <!-- Sekce A — vystavené -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200 bg-neutral-50">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-700">{{ t('reports.kh.section_a_title') }}</h3>
         </header>
@@ -143,7 +143,7 @@ onMounted(loadPreview)
       </div>
 
       <!-- Sekce B — přijaté -->
-      <div class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200 bg-neutral-50">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-700">{{ t('reports.kh.section_b_title') }}</h3>
         </header>

--- a/web/src/pages/reports/MonthlyExportReport.vue
+++ b/web/src/pages/reports/MonthlyExportReport.vue
@@ -179,10 +179,10 @@ onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
         <p class="text-sm text-neutral-500 mt-0.5">{{ t('reports.monthly_export.subtitle') }}</p>
       </div>
       <div class="flex items-center gap-2">
-        <select v-model.number="month" :disabled="anyActive" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm disabled:bg-neutral-100">
+        <select v-model.number="month" :disabled="anyActive" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm disabled:bg-neutral-100">
           <option v-for="(label, i) in monthOptions" :key="i + 1" :value="i + 1">{{ label }}</option>
         </select>
-        <select v-model.number="year" :disabled="anyActive" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm disabled:bg-neutral-100">
+        <select v-model.number="year" :disabled="anyActive" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm disabled:bg-neutral-100">
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
         </select>
       </div>
@@ -192,7 +192,7 @@ onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
       {{ error }}
     </div>
 
-    <div class="bg-white border border-neutral-200 rounded-lg p-5 shadow-sm space-y-5">
+    <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm space-y-5">
       <!-- Daňově korektní zařazení dokladů do období -->
       <div class="flex items-start gap-2 rounded-md bg-primary-50 border border-primary-200 px-3 py-2.5 text-sm text-primary-800">
         <svg class="w-5 h-5 flex-shrink-0 mt-0.5 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg>
@@ -259,7 +259,7 @@ onUnmounted(() => { if (pollTimer) clearInterval(pollTimer) })
     </div>
 
     <!-- Historie exportů (zůstávají ke stažení) -->
-    <div v-if="jobs.length" class="bg-white border border-neutral-200 rounded-lg shadow-sm">
+    <div v-if="jobs.length" class="bg-surface border border-neutral-200 rounded-lg shadow-sm">
       <div class="px-5 py-3 border-b border-neutral-200 text-sm font-medium text-neutral-700">
         {{ t('reports.monthly_export.job.history') }}
       </div>

--- a/web/src/pages/reports/SouhrnneHlaseniReport.vue
+++ b/web/src/pages/reports/SouhrnneHlaseniReport.vue
@@ -84,10 +84,10 @@ onMounted(loadPreview)
         <p class="text-sm text-neutral-500 mt-0.5">{{ t('reports.shv.subtitle') }}</p>
       </div>
       <div class="flex items-center gap-2">
-        <select v-model.number="month" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model.number="month" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="(label, i) in monthOptions" :key="i + 1" :value="i + 1">{{ label }}</option>
         </select>
-        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-white text-sm">
+        <select v-model.number="year" class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
           <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
         </select>
         <button type="button" @click="downloadXml" :disabled="loading || !preview"
@@ -98,7 +98,7 @@ onMounted(loadPreview)
       </div>
     </div>
 
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">{{ t('common.loading') }}…</div>
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-8 text-center text-neutral-400">{{ t('common.loading') }}…</div>
     <div v-else-if="error" class="bg-danger-50 border border-danger-500/40 text-danger-500 rounded-md p-3 text-sm">{{ error }}</div>
 
     <div v-else-if="preview" class="space-y-4">
@@ -112,19 +112,19 @@ onMounted(loadPreview)
 
       <!-- KPI -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.shv.rows_count') }}</div>
           <div class="text-2xl font-bold font-mono text-neutral-900">{{ preview.summary.rows_count }}</div>
           <div class="text-xs text-neutral-500 mt-1">{{ t('reports.shv.rows_hint') }}</div>
         </div>
-        <div class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.shv.total_amount') }}</div>
           <div class="text-2xl font-bold font-mono text-neutral-900">
             {{ formatMoney(preview.summary.total_amount, 'CZK') }}
           </div>
           <div class="text-xs text-neutral-500 mt-1">{{ t('reports.shv.total_hint') }}</div>
         </div>
-        <div v-if="preview.summary.submission_deadline" class="bg-white border border-neutral-200 rounded-lg shadow-sm p-5">
+        <div v-if="preview.summary.submission_deadline" class="bg-surface border border-neutral-200 rounded-lg shadow-sm p-5">
           <div class="text-xs uppercase tracking-wide text-neutral-500 font-medium mb-1">{{ t('reports.dph.deadline') }}</div>
           <div class="text-xl font-bold font-mono"
             :class="(daysToDeadline ?? 999) < 0 ? 'text-danger-500' : (daysToDeadline ?? 999) <= 7 ? 'text-warning-600' : 'text-neutral-900'">
@@ -139,7 +139,7 @@ onMounted(loadPreview)
       </div>
 
       <!-- Rows table -->
-      <div v-if="preview.summary.rows.length > 0" class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div v-if="preview.summary.rows.length > 0" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
         <header class="px-5 py-3 border-b border-neutral-200 bg-neutral-50">
           <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-700">{{ t('reports.shv.rows_title') }}</h3>
         </header>
@@ -170,7 +170,7 @@ onMounted(loadPreview)
         </table>
       </div>
 
-      <div v-else class="bg-white border border-dashed border-neutral-300 rounded-md p-6 text-center text-sm text-neutral-500">
+      <div v-else class="bg-surface border border-dashed border-neutral-300 rounded-md p-6 text-center text-sm text-neutral-500">
         {{ t('reports.shv.no_data') }}
       </div>
 

--- a/web/src/pages/reports/TaxSubmissions.vue
+++ b/web/src/pages/reports/TaxSubmissions.vue
@@ -103,14 +103,14 @@ onMounted(load)
       </button>
     </div>
 
-    <div v-if="loading" class="bg-white border border-neutral-200 rounded-lg p-8 text-center text-sm text-neutral-400">{{ t('common.loading') }}…</div>
+    <div v-if="loading" class="bg-surface border border-neutral-200 rounded-lg p-8 text-center text-sm text-neutral-400">{{ t('common.loading') }}…</div>
     <div v-else-if="error" class="bg-danger-50 border border-danger-500/40 text-danger-500 rounded-md p-3 text-sm">{{ error }}</div>
 
-    <div v-else-if="items.length === 0" class="bg-white border border-dashed border-neutral-300 rounded-lg p-8 text-center text-sm text-neutral-500">
+    <div v-else-if="items.length === 0" class="bg-surface border border-dashed border-neutral-300 rounded-lg p-8 text-center text-sm text-neutral-500">
       {{ t('reports.submissions.empty') }}
     </div>
 
-    <div v-else class="bg-white border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+    <div v-else class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
       <table class="w-full text-sm">
         <thead class="bg-neutral-50 text-xs text-neutral-500 uppercase tracking-wide">
           <tr>

--- a/web/src/styles/main.css
+++ b/web/src/styles/main.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+/* Dark mode řízený třídou .dark na <html> (nastavuje composable useTheme přes VueUse).
+   :where() drží specificitu na 0, aby utility nebyly přebity. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   /* ─── Primary — indigo (sladěno s MyWebdesign.cz brand #3B2D83) ─── */
   --color-primary-50:  #F4F2FB;
@@ -24,6 +28,9 @@
   --color-neutral-700: #403B52;
   --color-neutral-800: #2A2638;
   --color-neutral-900: #15131D;   /* text */
+
+  /* ─── Surfaces (hodnoty přepínané v .dark) ─── */
+  --color-surface:   #FFFFFF;   /* karty, panely, modály, topbar, sidebar (light = bílá) */
 
   /* ─── Accent — pastel sky blue ─── */
   --color-accent-50:   #EFF6FC;
@@ -65,6 +72,44 @@
   --radius-xl: 12px;
 }
 
+/* ═══════════════════════ DARK MODE ═══════════════════════
+ * Why: nepřebarvujeme komponenty, jen v .dark přepíšeme HODNOTY tokenů.
+ * Neutral škála se obrací (50 = nejtmavší pozadí … 900 = nejsvětlejší text),
+ * takže ~3400 výskytů bg-neutral-50 / text-neutral-900 / border-neutral-200
+ * se překlopí samo. bg-white se nahrazuje za bg-surface (viz převod komponent).
+ * Laděno k indigo brandu #3B2D83. Light mód zůstává beze změny.
+ * How to apply: .dark třídu na <html> řídí composable useTheme. */
+.dark {
+  /* Neutral — invertovaná, teplá indigo tmavá */
+  --color-neutral-50:  #14121C;   /* page background */
+  --color-neutral-100: #1C1A28;   /* subtle tint / hover */
+  --color-neutral-200: #2C2840;   /* borders */
+  --color-neutral-300: #3B3656;
+  --color-neutral-400: #585173;
+  --color-neutral-500: #837C99;
+  --color-neutral-600: #A8A1BE;   /* sekundární text */
+  --color-neutral-700: #C6C0DA;
+  --color-neutral-800: #E2DEEC;
+  --color-neutral-900: #F3F1F9;   /* hlavní text */
+
+  /* Plochy nad pozadím */
+  --color-surface:   #1E1B2B;   /* karty / panely / topbar / sidebar */
+
+  /* Primary — zesvětlené pro kontrast a sytost na tmavém podkladu */
+  --color-primary-50:  #221C3A;   /* soft pill bg (bg-primary-50) */
+  --color-primary-100: #2C2450;
+  --color-primary-600: #7C68C4;   /* primary button */
+  --color-primary-700: #9C8FDA;   /* accent text (text-primary-700) — čitelný na tmavém */
+  --color-primary-800: #B7AAE8;   /* silnější accent text (text-primary-800) */
+  --color-primary-900: #D4CCF3;   /* nejsilnější accent text (text-primary-900) */
+
+  /* Semantic soft pozadí (-50) → tmavé tinty */
+  --color-success-50: #16261D;
+  --color-warning-50: #2A2113;
+  --color-danger-50:  #2C1717;
+  --color-accent-50:  #122231;
+}
+
 html, body {
   background: var(--color-neutral-50);
   color: var(--color-neutral-900);
@@ -101,6 +146,6 @@ html, body {
      :where() drží specificitu na 0, takže Tailwind utility (bg-warning-50,
      hover:bg-neutral-50, …) na <tr> stále vyhrávají. */
   :where(.table-sticky-first tbody tr) {
-    background-color: white;
+    background-color: var(--color-surface);
   }
 }


### PR DESCRIPTION
## Summary

Adds a full **dark mode** with a **System / Light / Dark** switcher in the top bar. Default is *System* (follows `prefers-color-scheme`); a manual choice is persisted to `localStorage`.

## Approach

Token-driven, not per-component `dark:` variants. The `.dark` class on `<html>` overrides the **values** of the existing `@theme` CSS variables in `main.css` — the neutral scale inverts, with added `surface` tokens and adjusted primary/semantic tints. Because components already use these tokens (`bg-neutral-*`, `text-neutral-*`, `border-neutral-*`, …), the whole UI adapts centrally without touching hundreds of call sites. Hardcoded `bg-white` surfaces became `bg-surface`; modal backdrops use a fixed dark scrim; chart.js colors (which can't read CSS variables) react to the mode via a small `useChartColors` helper.

**Light mode is unchanged by design** — token values only diverge under `.dark`.

## What's included

- `composables/useTheme.ts` — VueUse-based (`useStorage` + `usePreferredDark`), applies `.dark` to `<html>`
- `components/layout/ThemeToggle.vue` — 3-state segment in the top bar, next to the locale switcher
- Anti-FOUC inline script in `index.html` (no flash on reload)
- `theme.*` i18n keys (cs / en)
- Dark coverage across all pages incl. the new Documents section, shared components, modals, and 13 charts (chrome + a dark-adjusted categorical palette)
- Cleanup: replaced a few unmapped Tailwind palette classes (`red/green/emerald/amber/purple`) with the project's semantic tokens

## Testing

- `pnpm build` (vue-tsc + vite) passes
- Manually verified light + dark across dashboard, invoices (list/detail), clients, projects, recurring, approvals, exports/imports, tax reports, settings, and documents

## Notes / possible follow-ups

- Chart palette values are mirrored from `main.css` tokens inside `useChartColors` (chart.js can't read CSS vars); a comment flags the coupling
- Pre-existing dead semantic-shade classes (e.g. `text-warning-700`, where only `50/500/600` are defined in `@theme`) were left as-is — out of scope here
- The repeated chart option boilerplate (tooltip/legend/scale) could later be factored into shared `themed*` helpers
