### PR TITLE
Tenký scrollbar laděný do palety pro postranní menu

### DIFF
--- a/web/src/components/layout/AppLayout.vue
+++ b/web/src/components/layout/AppLayout.vue
@@ -373,7 +373,7 @@ onMounted(async () => {
           mobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
         ]"
       >
-        <nav class="flex-1 overflow-y-auto px-2.5 py-3">
+        <nav class="flex-1 overflow-y-auto scrollbar-slim px-2.5 py-3">
           <!-- Globální vyhledávač (před Přehled) — našeptává menu + hledá klienty/faktury -->
           <GlobalSearch :menu-items="flatNavItems" @navigated="mobileOpen = false" />
 

--- a/web/src/styles/main.css
+++ b/web/src/styles/main.css
@@ -148,4 +148,33 @@ html, body {
   :where(.table-sticky-first tbody tr) {
     background-color: var(--color-surface);
   }
+
+  /*
+   * Tenký „plovoucí" scrollbar.
+   * Why: nativní systémový scrollbar (hlavně na Windows a v dark módu) je tlustý
+   * a barevně mimo paletu — v postranním menu vyloženě ruší. Kreslíme vlastní úzký
+   * thumb z neutral tokenů, takže se light/dark přepne sám (neutral škála se v .dark
+   * obrací) a nemusíme řešit dvě varianty.
+   * How to apply: class="scrollbar-slim" na scrollovaný element (overflow-y-auto …).
+   */
+  .scrollbar-slim {
+    scrollbar-width: thin;                                  /* Firefox */
+    scrollbar-color: var(--color-neutral-300) transparent;  /* thumb / track */
+  }
+  .scrollbar-slim::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  .scrollbar-slim::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .scrollbar-slim::-webkit-scrollbar-thumb {
+    background-color: var(--color-neutral-300);
+    border-radius: 9999px;
+    border: 2px solid transparent;     /* odsazení → opticky tenčí, „plovoucí" thumb */
+    background-clip: padding-box;
+  }
+  .scrollbar-slim::-webkit-scrollbar-thumb:hover {
+    background-color: var(--color-neutral-400);
+  }
 }


### PR DESCRIPTION
## Co

Nahrazuje holý nativní systémový scrollbar v postranním menu (`AppLayout.vue` → `<nav>`) tenkým vlastním scrollbarem přes novou reusable utilitu `.scrollbar-slim`.

## Proč

Nativní scrollbar (hlavně na Windows a v dark módu) je tlustý a barevně mimo paletu — v sidebaru vyloženě ruší (viz původní podnět). 

## Jak

- Utilita `.scrollbar-slim` v `@layer components` (`web/src/styles/main.css`), stejný vzor a „Why / How to apply" komentář jako stávající `.table-sticky-first`.
- Thumb bere barvu z `var(--color-neutral-300)` (hover `--color-neutral-400`). Protože se v `.dark` přepisují jen **hodnoty** neutral tokenů, scrollbar se překlopí light/dark sám — žádná druhá varianta.
- Pokrývá obě enginové cesty: Firefox (`scrollbar-width` / `scrollbar-color`) i WebKit (`::-webkit-scrollbar`). „Plovoucí" tenčí thumb přes `border: 2px solid transparent` + `background-clip: padding-box`.
- Track je explicitně `transparent` — po nastylování `::-webkit-scrollbar` přepne WebKit na „classic" scrollbar, jehož default track není spolehlivě průhledný.

## Rozsah

Čistě CSS, bez nových závislostí. Aplikováno **jen** na sidebar `<nav>`. Třída je záměrně obecná, takže ji lze v navazujícím PR použít i na další scroll kontejnery (modály, dropdowny) pro konzistenci.