### PR TITLE
fix(signing): pdf_signing_enabled cast na int — uložení nastavení vrací 500 (regrese 4.6.1)

### DIFF
--- a/api/src/Action/Settings/SettingsAction.php
+++ b/api/src/Action/Settings/SettingsAction.php
@@ -306,7 +306,7 @@ final class SettingsAction
         foreach ($allowed as $f) {
             if (array_key_exists($f, $body)) {
                 $sets[] = "$f = ?";
-                $params[] = in_array($f, ['is_vat_payer', 'auto_send_reminders', 'auto_generate_recurring', 'embed_isdoc', 'email_branding_enabled', 'pdf_logo_show_name'], true)
+                $params[] = in_array($f, ['is_vat_payer', 'auto_send_reminders', 'auto_generate_recurring', 'embed_isdoc', 'email_branding_enabled', 'pdf_logo_show_name', 'pdf_signing_enabled'], true)
                     ? ((int) (bool) $body[$f])
                     : $body[$f];
             }


### PR DESCRIPTION
Po nasazení **4.6.1** vrací `PUT /api/settings/supplier` chybu **500**, když tělo obsahuje `pdf_signing_enabled` (typicky uložení karty *Nastavení → Podpis PDF*).

### Chyba
```
SQLSTATE[22007]: 1366 Incorrect integer value: '' for column `supplier`.`pdf_signing_enabled` at row 1
SQL: UPDATE supplier SET pdf_signing_enabled = ?, signing_tsa_url = ?, ... WHERE id = ?
params: [false, null, "", null, 1]   (SettingsAction.php:325)
```

### Příčina
V `SettingsAction::updateSupplierById()` je whitelist sloupců castovaných bool→int před bindem. `pdf_signing_enabled` (`tinyint(1) NOT NULL`) v něm chybí → propadne do `else`, PHP `false` PDO naváže jako `''` a MariaDB ve strict módu to na integer sloupci odmítne (1366). `true` projde (`'1'`), proto chyba padá jen při ukládání s **vypnutým** podpisem.

### Oprava
Přidání `pdf_signing_enabled` do bool→int seznamu (1 řádek).

Ověřeno na čisté 4.6.1: před `pdf_signing_enabled=false` → 500, po opravě `false` i `true` → 200.

Regrese z #70 (moje) — sloupec jsem přidal do `allowed`, ale ne do bool-cast seznamu; testy podpis vždy zapínaly, takže se `false` větev netrefila. Omlouvám se.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
