### PR TITLE
fix(import): oprava importu vydaných faktur z Fakturoidu (IČ, historické DPH, dedup VS)

### DIFF
--- a/api/src/Service/Import/FakturoidImportService.php
+++ b/api/src/Service/Import/FakturoidImportService.php
@@ -246,6 +246,7 @@ final class FakturoidImportService
         $invoiceId = $this->invoices->createDraft($payload, $userId);
 
         $vatRates = $this->loadVatRateMap();
+        $defaultVatRateId = $this->matchVatRateId($vatRates, 21.0) ?? $this->matchVatRateId($vatRates, 0.0) ?? 0;
         $items = [];
         foreach (($i['lines'] ?? []) as $idx => $line) {
             $rate = (float) ($line['vat_rate'] ?? 0);
@@ -254,7 +255,7 @@ final class FakturoidImportService
                 'quantity'               => (float) ($line['quantity'] ?? 1),
                 'unit'                   => (string) ($line['unit_name'] ?? 'ks'),
                 'unit_price_without_vat' => (float) ($line['unit_price'] ?? 0),
-                'vat_rate_id'            => $this->matchVatRateId($vatRates, $rate),
+                'vat_rate_id'            => $this->matchVatRateId($vatRates, $rate) ?? $defaultVatRateId,
                 'order_index'            => $idx,
             ];
         }
@@ -405,11 +406,14 @@ final class FakturoidImportService
 
     private function loadVatRateMap(): array
     {
-        // vat_rates nemá is_active — platnost se řídí valid_from/valid_to (k dnešku).
+        // Bereme VŠECHNY sazby bez ohledu na valid_from/valid_to — importujeme
+        // historické doklady (2019+), kde platí dobové sazby (CZ-15 %, CZ-10 %,
+        // valid_to 2023-12-31, viz migrace 0049). Filtr k dnešku by je vyřadil →
+        // matchVatRateId by vrátil null → vat_rate_id=0 → fk_ii_vat violation.
+        // Konkrétní % se snapshotuje do invoice_items.vat_rate_snapshot, takže
+        // výpočty/výkazy zůstávají korektní.
         $rows = $this->db->pdo()->query(
-            'SELECT id, rate_percent FROM vat_rates
-              WHERE (valid_from IS NULL OR valid_from <= CURDATE())
-                AND (valid_to   IS NULL OR valid_to   >= CURDATE())'
+            'SELECT id, rate_percent FROM vat_rates'
         )->fetchAll(\PDO::FETCH_ASSOC);
         $map = [];
         foreach ($rows as $r) $map[(int) $r['id']] = (float) $r['rate_percent'];

--- a/api/src/Service/Import/FakturoidImportService.php
+++ b/api/src/Service/Import/FakturoidImportService.php
@@ -240,7 +240,7 @@ final class FakturoidImportService
             'currency_id'    => $this->resolveCurrencyId((string) ($i['currency'] ?? 'CZK'), $supplierId, isActive: true),
             'reverse_charge' => !empty($i['transferred_tax_liability']),
             'language'       => 'cs',
-            'varsymbol'      => $this->sanitizeVarsymbol((string) ($i['variable_symbol'] ?? $i['number'] ?? '')),
+            'varsymbol'      => $this->uniqueVarsymbol((string) ($i['variable_symbol'] ?? $i['number'] ?? ''), $supplierId),
             'payment_method' => 'bank_transfer',
         ];
         $invoiceId = $this->invoices->createDraft($payload, $userId);
@@ -431,6 +431,34 @@ final class FakturoidImportService
         $vs = preg_replace('/[^A-Za-z0-9_-]/', '', $vs) ?? '';
         if ($vs === '') return 'FAKT-' . substr((string) random_int(1000, 9999), 0, 4);
         return substr($vs, 0, 20);
+    }
+
+    /**
+     * Zajistí unikátnost varsymbolu vůči invoices(supplier_id, varsymbol).
+     * Fakturoid běžně sdílí variabilní symbol mezi proformou a ostrou fakturou
+     * (resp. dobropisem) → naše UNIQUE (uq_inv_supplier_varsymbol) by hodil
+     * 1062 duplicate. Při kolizi disambiguujeme suffixem -N (ořez na 20 znaků
+     * dle DB sloupce). Jako poslední záchrana null (UNIQUE povoluje více NULL).
+     */
+    private function uniqueVarsymbol(string $raw, int $supplierId): ?string
+    {
+        $base = $this->sanitizeVarsymbol($raw);
+        if (!$this->varsymbolTaken($base, $supplierId)) return $base;
+        for ($n = 2; $n <= 99; $n++) {
+            $suffix = '-' . $n;
+            $candidate = substr($base, 0, 20 - strlen($suffix)) . $suffix;
+            if (!$this->varsymbolTaken($candidate, $supplierId)) return $candidate;
+        }
+        return null;
+    }
+
+    private function varsymbolTaken(string $vs, int $supplierId): bool
+    {
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT 1 FROM invoices WHERE supplier_id = ? AND varsymbol = ? LIMIT 1'
+        );
+        $stmt->execute([$supplierId, $vs]);
+        return $stmt->fetchColumn() !== false;
     }
 
     private function sanitizeVendorNumber(string $vn): string

--- a/db/migrations/0083_widen_ic_column.sql
+++ b/db/migrations/0083_widen_ic_column.sql
@@ -1,0 +1,15 @@
+-- MyInvoice.cz — rozšíření sloupce IČ (clients.ic, supplier.ic) na VARCHAR(20)
+--
+-- Fakturoid import padal na zahraničních subjektech:
+--   "SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'ic'"
+-- Tuzemské IČO má 8 číslic, ale `registration_no` zahraničního subjektu (SK/PL/DE…)
+-- bývá delší než 10 znaků. Sloupec zarovnáváme na VARCHAR(20) (stejně jako `dic`).
+--
+-- ares_cache.ic záměrně NEMĚNÍME — drží jen tuzemská IČO (ARES je CZ registr).
+--
+-- Idempotence: MODIFY je deklarativní (opakované spuštění nastaví stejnou definici).
+
+SET NAMES utf8mb4;
+
+ALTER TABLE clients  MODIFY COLUMN ic VARCHAR(20) NULL;
+ALTER TABLE supplier MODIFY COLUMN ic VARCHAR(20) NULL;


### PR DESCRIPTION
## Co a proč

Import historických dat z Fakturoidu (2019→2026) padal na **vydaných** fakturách třemi různými DB chybami. `createExpense` (přijaté) měl ochrany, které `createIssued` (vydané) postrádal — tento PR je doplňuje symetricky.

## Opravy

- **Rozšíření IČ na VARCHAR(20)** — zahraniční subjekty mají `registration_no` delší než 10 znaků → `Data too long for column 'ic'`. `clients.ic` i `supplier.ic` zarovnány na VARCHAR(20) (jako `dic`). Migrace `0083`.

- **Historické sazby DPH** — `loadVatRateMap` filtroval sazby dle `valid_from/valid_to` k dnešku, takže dobové CZ-15 %/CZ-10 % (doklady do 2023) chyběly → `vat_rate_id = 0` → `fk_ii_vat` constraint fail. Nově mapujeme všechny sazby (% se snapshotuje do `vat_rate_snapshot`) + default fallback 21 %.

- **Dedup variabilního symbolu** — Fakturoid sdílí VS mezi proformou a ostrou fakturou/dobropisem → `1062 Duplicate entry` na `UNIQUE (supplier_id, varsymbol)`. `createIssued` přes `uniqueVarsymbol()` kolizi disambiguuje suffixem `-N` (ořez na 20 znaků), fallback NULL.

## Změny
- `api/src/Service/Import/FakturoidImportService.php` (+44/−6)
- `db/migrations/0083_widen_ic_column.sql` (nová, idempotentní `MODIFY`)

Otestováno lokálně na dumpu produkční DB (Docker/MariaDB): plný import 64 klientů + 242 vydaných + 2 přijaté faktury, 0 chyb. Migrace `0083` aplikována na reálná data. `php -l` prochází. (Import nemá automatické testy.)