### PR TITLE
fix(security): vstříknout Config do IpMatcher v DI — reálná IP za reverse proxy (audit/brute-force)

### DIFF
--- a/api/src/Bootstrap.php
+++ b/api/src/Bootstrap.php
@@ -19,6 +19,7 @@ use MyInvoice\Middleware\RateLimitMiddleware;
 use MyInvoice\Middleware\RequireTotpMiddleware;
 use MyInvoice\Middleware\RoleMiddleware;
 use MyInvoice\Middleware\SupplierScopeMiddleware;
+use MyInvoice\Service\IpMatcher;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger;
 use Psr\Container\ContainerInterface;
@@ -87,6 +88,13 @@ final class Bootstrap
             Connection::class      => fn (ContainerInterface $c) => new Connection($c->get(Config::class), $c->get(LoggerInterface::class)),
             RedisProbe::class      => fn (ContainerInterface $c) => new RedisProbe($c->get(Config::class)),
             RedisFactory::class    => fn (ContainerInterface $c) => new RedisFactory($c->get(Config::class)),
+
+            // IpMatcher má v konstruktoru volitelný `?Config $config = null`. Autowiring
+            // takový parametr neresolvuje (dosadí default null), takže clientIpFromRequest()
+            // by ignorovalo cfg.ip_allowlist.trusted_proxies a vždy vracelo REMOTE_ADDR.
+            // Za reverse proxy → audit log a brute-force lockout vidí IP proxy místo
+            // reálného klienta. Explicitní injekce Configu to opravuje.
+            IpMatcher::class       => fn (ContainerInterface $c) => new IpMatcher($c->get(Config::class)),
         ]);
 
         $container = $builder->build();

--- a/api/tests/Integration/IpMatcherWiringTest.php
+++ b/api/tests/Integration/IpMatcherWiringTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Integration;
+
+use MyInvoice\Bootstrap;
+use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Service\IpMatcher;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * IpMatcher musí z DI kontejneru dostat vstříknutý Config. IpMatcher má
+ * v konstruktoru volitelný `?Config $config = null`, který autowiring NEresolvuje
+ * (dosadí default null). Bez explicitní DI definice v Bootstrap tak
+ * `clientIpFromRequest()` ignoruje `cfg.ip_allowlist.trusted_proxies` a za reverse
+ * proxy loguje/počítá IP proxy místo reálného klienta (audit log, brute-force lockout).
+ *
+ * Soft-skip bez cfg.php (CI runner bez DI bootstrapu).
+ */
+#[Group('integration')]
+final class IpMatcherWiringTest extends TestCase
+{
+    public function testContainerInjectsConfigIntoIpMatcher(): void
+    {
+        $rootDir = dirname(__DIR__, 3);
+        if (!is_file($rootDir . '/cfg.php')) {
+            $this->markTestSkipped('cfg.php neexistuje — test vyžaduje DI bootstrap.');
+        }
+        try {
+            $matcher = Bootstrap::buildApp()->getContainer()->get(IpMatcher::class);
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('DI nedostupné: ' . $e->getMessage());
+        }
+
+        // Regresní jádro: kontejner musí IpMatcheru vstříknout Config (před opravou null).
+        $prop = (new \ReflectionObject($matcher))->getProperty('config');
+        $prop->setAccessible(true);
+        self::assertInstanceOf(
+            Config::class,
+            $prop->getValue($matcher),
+            'IpMatcher z kontejneru nemá vstříknutý Config → trusted_proxies se ignoruje.'
+        );
+
+        // Funkční důkaz: od důvěryhodné proxy přečte reálnou IP z X-Forwarded-For.
+        $resolved = $matcher->clientIp(
+            ['REMOTE_ADDR' => '10.9.9.9', 'HTTP_X_FORWARDED_FOR' => '203.0.113.7'],
+            ['10.9.9.9'],
+        );
+        self::assertSame('203.0.113.7', $resolved);
+    }
+}

--- a/manual/20_Bezpecnost.md
+++ b/manual/20_Bezpecnost.md
@@ -294,6 +294,23 @@ Viz [19. Nastavení → § 15.6](19_Nastaveni.md) pro UI.
 - **PII klientů** mimo to, co bylo změněno (jen fields seznam, ne hodnoty)
 - **Bankovní transakce** — log obsahuje jen ID importovaného výpisu
 
+### 20.7.2 Jak se do logu zapisuje IP adresa
+
+Aplikace bere IP klienta z **IP síťového spojení** (`REMOTE_ADDR`). Když běží
+**za reverse proxy** (Docker, nginx, Cloudflare…), je tím spojením proxy — bez
+konfigurace by se proto do auditu zapisovala **IP proxy**, ne reálného klienta
+(typicky uvidíš pořád stejnou IP, např. bránu Dockeru `172.x.0.1`).
+
+Reálnou IP přečte aplikace z hlavičky `X-Forwarded-For` **pouze tehdy**, když
+`REMOTE_ADDR` odpovídá rozsahu v `cfg.ip_allowlist.trusted_proxies` (viz
+§ 20.4.1). Z hlavičky se bere **první** adresa (původní klient). Bez nastavené
+`trusted_proxies` se `X-Forwarded-For` ignoruje (ochrana proti podvržení).
+
+> 🛈 Stejná logika se zjišťování IP používá i pro **brute-force lockout**
+> (kap. 20.3). Za reverse proxy bez `trusted_proxies` proto lockout počítá
+> pokusy podle IP proxy = fakticky globálně. Po nastavení `trusted_proxies`
+> začnou audit log i lockout pracovat s reálnou klientskou IP.
+
 ## 20.8 DKIM podpis e-mailů
 
 Pro **deliverabilitu** (aby gmail / o365 / seznam tvé maily nepoznačily jako

--- a/manual/20_Bezpecnost.md
+++ b/manual/20_Bezpecnost.md
@@ -190,6 +190,36 @@ Doporučení v produkci:
 > deploy. Není v UI **schválně** — v případě omylu by ses zablokoval
 > a nemohl si ho přes UI sundat.
 
+### 20.4.1 Za reverse proxy: `trusted_proxies` (důležité)
+
+Pokud aplikace běží **za reverse proxy** (doporučené produkční nasazení — viz
+kap. 2), vidí všechny požadavky přicházet z IP proxy (např. brána Dockeru
+`172.x.0.1`), ne od reálného klienta. Bez konfigurace pak:
+
+- **IP allowlist** filtruje podle IP proxy — buď zablokuje všechny, nebo (když
+  přidáš proxy do `allow`) pustí všechny → ochrana je neúčinná.
+- **Brute-force lockout** (kap. 20.3) je fakticky **globální** — všechny pokusy
+  vypadají ze stejné IP.
+- **Audit log** loguje IP proxy místo reálného klienta (ztráta forenzní hodnoty).
+
+Proto za reverse proxy uveď proxy do `trusted_proxies` — aplikace pak vezme
+skutečnou klientskou IP z hlavičky `X-Forwarded-For`:
+
+```php
+'ip_allowlist' => [
+    'trusted_proxies' => [
+        '172.16.0.0/12',         // Docker bridge sítě
+        // '10.0.0.0/8',         // nebo konkrétní IP/rozsah tvé proxy
+    ],
+    'header' => 'X-Forwarded-For', // výchozí; odkud číst reálnou IP (jen za trusted proxy)
+],
+```
+
+> ⚠️ Do `trusted_proxies` patří **jen** IP/rozsahy proxy, kterým věříš —
+> klient za nedůvěryhodnou proxy by jinak mohl `X-Forwarded-For` podvrhnout.
+> Aplikace hlavičku respektuje pouze tehdy, když `REMOTE_ADDR` odpovídá
+> `trusted_proxies`.
+
 ## 20.5 RBAC (role-based access)
 
 Tři role. Hierarchie: **admin > accountant > readonly**.


### PR DESCRIPTION
## Problém (bezpečnostní)
Za **reverse proxy** (doporučené produkční nasazení dle kap. 2) appka loguje a vyhodnocuje IP **proxy** místo reálného klienta:
- **Audit log** ukazuje IP proxy (např. brána Dockeru `172.x.0.1`) → bez forenzní hodnoty.
- **Brute-force lockout** (per IP) je fakticky **globální** — všechny pokusy ze stejné IP.

`cfg.ip_allowlist.trusted_proxies` na to existuje, ale **nefunguje**.

## Příčina
`IpMatcher` má konstruktor `__construct(?Config $config = null)`. PHP-DI autowiring volitelný nullable parametr **neresolvuje** (dosadí `null`). `IpMatcher` z kontejneru tak má `config = null` a `clientIpFromRequest()` zahodí `trusted_proxies`, takže vždy vrátí `REMOTE_ADDR`.

Diagnóza (probe z reálného kontejneru):
```
config injected: NULL
clientIpFromRequest=172.23.0.1   // i s nastaveným trusted_proxies a přítomnou X-Forwarded-For
```

`IpAllowlistMiddleware` (403) zasažený **není** — `Config` má jako non-nullable a `trusted_proxies` předává do `clientIp()` explicitně. Problém je u všech konzumentů `clientIpFromRequest()` (audit log, login/brute-force).

## Oprava
Explicitní DI definice v `Bootstrap.php`:
```php
IpMatcher::class => fn (ContainerInterface $c) => new IpMatcher($c->get(Config::class)),
```

Po opravě (stejný probe):
```
config injected: MyInvoice\Infrastructure\Config\Config
clientIpFromRequest=203.0.113.88
```
A **end-to-end**: request s `X-Forwarded-For: 203.0.113.88` (REMOTE_ADDR = brána Dockeru v `trusted_proxies`) → audit log zapsal `auth.login` s IP **203.0.113.88** (dřív brána Dockeru).

## Součásti PR
- **`api/src/Bootstrap.php`** — DI definice `IpMatcher::class` s injektovaným `Config`.
- **`api/tests/Integration/IpMatcherWiringTest.php`** — regresní guard: kontejner musí vrátit `IpMatcher` s `Config` (před opravou `null`) + `clientIp()` čte XFF od trusted proxy. Soft-skip bez cfg.php (vzor ostatních integračních testů).
- **`manual/20_Bezpecnost.md`** — nová sekce §20.4.1: `trusted_proxies` za reverse proxy + dopad na allowlist / brute-force / audit + varování o spoofingu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
