### PR TITLE
feat: doplnění systémových parserů bankovních e-mailových avíz

### DIFF
--- a/api/bin/reset.php
+++ b/api/bin/reset.php
@@ -110,7 +110,7 @@ if ($keepCache) {
 // Tabulky s globálním seedem (supplier_id IS NULL) — smaž jen per-tenant řádky.
 $partial = [
     'vat_classifications'         => 'supplier_id IS NOT NULL',
-    'bank_email_notice_providers' => 'supplier_id IS NOT NULL', // ponech globální seed (raiffeisenbank)
+    'bank_email_notice_providers' => 'supplier_id IS NOT NULL', // ponech globální bankovní providery
 ];
 
 $allTables = $pdo->query('SHOW TABLES')->fetchAll(\PDO::FETCH_COLUMN);

--- a/api/src/Action/Bank/BankEmailNoticeAction.php
+++ b/api/src/Action/Bank/BankEmailNoticeAction.php
@@ -12,6 +12,7 @@ use MyInvoice\Service\ActivityLogger;
 use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
 use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeScanner;
 use MyInvoice\Service\Bank\EmailNotice\ImapMailboxClientInterface;
+use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeProvider;
 use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeParserRepository;
 use MyInvoice\Service\IpMatcher;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -36,7 +37,10 @@ final class BankEmailNoticeAction
             return Json::ok($response, [
                 'imap' => $this->repo->imapSettings($sid),
                 'imap_accounts' => $this->repo->imapAccounts($sid),
-                'providers' => $this->repo->providers($sid),
+                'providers' => array_map(
+                    fn (BankEmailNoticeProvider $provider): array => $this->providerPayload($provider),
+                    $this->parsers->providers(null, $sid, false),
+                ),
                 'mappings' => $this->repo->accountMappings($sid),
                 'messages' => $this->repo->processedMessages($sid, 50, 0),
                 'messages_total' => $this->repo->countProcessedMessages($sid),
@@ -208,19 +212,14 @@ final class BankEmailNoticeAction
         try {
             $parsed = $this->parsers->parse(
                 $message,
-                !empty($body['provider_id']) ? (int) $body['provider_id'] : null,
+                !empty($body['provider_ref']) ? (string) $body['provider_ref'] : null,
                 $this->supplierId($request),
             );
         } catch (\Throwable $e) {
             return Json::error($response, 'parse_failed', $e->getMessage(), 400);
         }
         return Json::ok($response, [
-            'provider' => [
-                'id' => $parsed['provider']['id'],
-                'code' => $parsed['provider']['code'],
-                'name' => $parsed['provider']['name'],
-                'parser_type' => $parsed['provider']['parser_type'],
-            ],
+            'provider' => $this->providerPayload($parsed['provider']),
             'parsed' => $parsed['parsed']->toArray(),
         ]);
     }
@@ -298,6 +297,42 @@ final class BankEmailNoticeAction
         }
 
         return $settings;
+    }
+
+    /**
+     * @return array{
+     *   id:?int,
+     *   supplier_id:?int,
+     *   provider_ref:string,
+     *   code:string,
+     *   name:string,
+     *   parser_type:string,
+     *   enabled:bool,
+     *   sender_whitelist:?string,
+     *   subject_pattern:?string,
+     *   body_pattern:?string,
+     *   field_patterns:array<string,mixed>,
+     *   normalizer_config:array<string,mixed>,
+     *   system:bool
+     * }
+     */
+    private function providerPayload(BankEmailNoticeProvider $provider): array
+    {
+        return [
+            'id' => $provider->id,
+            'supplier_id' => $provider->supplierId,
+            'provider_ref' => $provider->providerRef,
+            'code' => $provider->code,
+            'name' => $provider->name,
+            'parser_type' => $provider->parserType,
+            'enabled' => $provider->enabled,
+            'sender_whitelist' => $provider->senderWhitelist,
+            'subject_pattern' => $provider->subjectPattern,
+            'body_pattern' => $provider->bodyPattern,
+            'field_patterns' => $provider->fieldPatterns,
+            'normalizer_config' => $provider->normalizerConfig,
+            'system' => $provider->system,
+        ];
     }
 
     /**

--- a/api/src/Bootstrap.php
+++ b/api/src/Bootstrap.php
@@ -109,6 +109,10 @@ final class Bootstrap
             \MyInvoice\Service\Bank\EmailNotice\ImapMailboxClientInterface::class => fn (ContainerInterface $c) => new \MyInvoice\Service\Bank\EmailNotice\WebklexImapMailboxClient(
                 $c->get(\MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer::class),
             ),
+            \MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeParserRepository::class => fn (ContainerInterface $c) => new \MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeParserRepository(
+                $c->get(Connection::class),
+                self::bankEmailNoticeParsers($c, $config),
+            ),
             \MyInvoice\Service\Bank\StatementMatcher::class => fn (ContainerInterface $c) => new \MyInvoice\Service\Bank\StatementMatcher(
                 $c->get(Connection::class),
                 $c->get(\MyInvoice\Service\Invoice\FinalFromProformaCreator::class),
@@ -150,6 +154,46 @@ final class Bootstrap
         $app->addErrorMiddleware($displayErrors, true, true, $container->get(LoggerInterface::class));
 
         return $app;
+    }
+
+    /**
+     * @return array<string,\MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeParserInterface>
+     */
+    private static function bankEmailNoticeParsers(ContainerInterface $container, Config $config): array
+    {
+        $classes = $config->get('bank_email.notice_parsers', []);
+        if (!is_array($classes) || $classes === []) {
+            throw new \RuntimeException('cfg.bank_email.notice_parsers musí být neprázdná mapa parser slot => class.');
+        }
+
+        $parsers = [];
+        foreach ($classes as $class) {
+            if ($class === null || $class === false || $class === '') {
+                continue;
+            }
+            $class = trim((string) $class);
+            if ($class === '') {
+                throw new \RuntimeException('cfg.bank_email.notice_parsers obsahuje prázdný class name.');
+            }
+
+            $parser = $container->get($class);
+            if (!$parser instanceof \MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeParserInterface) {
+                throw new \RuntimeException("Parser {$class} neimplementuje BankEmailNoticeParserInterface.");
+            }
+            $code = trim($parser->key());
+            if ($code === '') {
+                throw new \RuntimeException("Parser {$class} vrací prázdný key().");
+            }
+            if (isset($parsers[$code])) {
+                throw new \RuntimeException("Duplicitní bank email parser key: {$code}.");
+            }
+            $parsers[$code] = $parser;
+        }
+        if ($parsers === []) {
+            throw new \RuntimeException('cfg.bank_email.notice_parsers neobsahuje žádný aktivní parser.');
+        }
+
+        return $parsers;
     }
 
     private static function resolveLogLevel(string $level): \Monolog\Level

--- a/api/src/Infrastructure/Config/Config.php
+++ b/api/src/Infrastructure/Config/Config.php
@@ -178,7 +178,8 @@ final class Config
      */
     /**
      * Baseline defaults aplikované **před** cfg.php — jen pro non-secret veřejné
-     * konstanty (URLs třetích stran, timeouty, TTL cache). Vše, co je opravdu
+     * konstanty a statické registry služeb (URLs třetích stran, timeouty,
+     * TTL cache, výchozí parser class names). Vše, co je opravdu
      * tajné nebo per-instance (DB credentials, pepper, SMTP host, ...), tady
      * NESMÍ být — to musí přijít z cfg.php / ENV.
      *
@@ -207,6 +208,14 @@ final class Config
                 'endpoint'  => 'https://adisrws.mfcr.cz/adistc/axis2/services/rozhraniCRPDPH.rozhraniCRPDPHSOAP',
                 'cache_ttl' => 86400,
                 'timeout'   => 8,
+            ],
+            'bank_email' => [
+                'notice_parsers' => [
+                    'regex' => \MyInvoice\Service\Bank\EmailNotice\Parser\RegexBankEmailNoticeParser::class,
+                    'raiffeisenbank' => \MyInvoice\Service\Bank\EmailNotice\Parser\RaiffeisenbankEmailNoticeParser::class,
+                    'unicredit' => \MyInvoice\Service\Bank\EmailNotice\Parser\UnicreditBankEmailNoticeParser::class,
+                    'csob' => \MyInvoice\Service\Bank\EmailNotice\Parser\CsobBankEmailNoticeParser::class,
+                ],
             ],
         ];
     }

--- a/api/src/Repository/BankEmailNoticeRepository.php
+++ b/api/src/Repository/BankEmailNoticeRepository.php
@@ -253,9 +253,10 @@ final class BankEmailNoticeRepository
     {
         $stmt = $this->db->pdo()->prepare(
             'SELECT c.id AS currency_id, c.code AS currency_code, c.label, c.account_number, c.bank_code, c.bank_name,
-                    m.id, m.imap_account_id, m.provider_id, m.enabled, m.amount_tolerance,
+                    m.id, m.imap_account_id, m.provider_id, m.provider_code AS mapped_provider_code, m.enabled, m.amount_tolerance,
                     im.name AS imap_account_name,
-                    p.code AS provider_code, p.name AS provider_name
+                    COALESCE(p.code, m.provider_code) AS provider_code,
+                    COALESCE(p.name, m.provider_code) AS provider_name
                FROM currencies c
           LEFT JOIN bank_email_account_mappings m ON m.currency_id = c.id
           LEFT JOIN bank_email_imap_settings im ON im.id = m.imap_account_id AND im.supplier_id = c.supplier_id
@@ -270,6 +271,8 @@ final class BankEmailNoticeRepository
             $row['currency_id'] = (int) $row['currency_id'];
             $row['imap_account_id'] = $row['imap_account_id'] !== null ? (int) $row['imap_account_id'] : null;
             $row['provider_id'] = $row['provider_id'] !== null ? (int) $row['provider_id'] : null;
+            $row['provider_ref'] = $this->providerRefFromMapping($row);
+            $row['mapped_provider_code'] = $this->nullable($row['mapped_provider_code'] ?? null);
             $row['enabled'] = (bool) ($row['enabled'] ?? false);
             $row['amount_tolerance'] = (float) ($row['amount_tolerance'] ?? 0.05);
         }
@@ -284,10 +287,10 @@ final class BankEmailNoticeRepository
         $pdo = $this->db->pdo();
         $stmt = $pdo->prepare(
             'INSERT INTO bank_email_account_mappings
-                (supplier_id, currency_id, imap_account_id, provider_id, enabled, amount_tolerance)
-             VALUES (?, ?, ?, ?, ?, ?)
+                (supplier_id, currency_id, imap_account_id, provider_id, provider_code, enabled, amount_tolerance)
+             VALUES (?, ?, ?, ?, ?, ?, ?)
              ON DUPLICATE KEY UPDATE
-                imap_account_id = VALUES(imap_account_id), provider_id = VALUES(provider_id),
+                imap_account_id = VALUES(imap_account_id), provider_id = VALUES(provider_id), provider_code = VALUES(provider_code),
                 enabled = VALUES(enabled), amount_tolerance = VALUES(amount_tolerance)'
         );
         foreach ($rows as $row) {
@@ -301,7 +304,7 @@ final class BankEmailNoticeRepository
             if ($imapAccountId !== null && !$this->imapAccountBelongsToSupplier($imapAccountId, $supplierId)) {
                 continue;
             }
-            $providerId = !empty($row['provider_id']) ? (int) $row['provider_id'] : null;
+            [$providerId, $providerCode] = $this->providerTargetFromMappingPayload($row, $supplierId);
             if ($providerId !== null && !$this->providerAvailableToSupplier($providerId, $supplierId)) {
                 continue;
             }
@@ -310,6 +313,7 @@ final class BankEmailNoticeRepository
                 $currencyId,
                 $imapAccountId,
                 $providerId,
+                $providerCode,
                 !empty($row['enabled']) && !$noImapAccount ? 1 : 0,
                 max(0.0, (float) ($row['amount_tolerance'] ?? 0.05)),
             ]);
@@ -323,7 +327,7 @@ final class BankEmailNoticeRepository
         int $supplierId,
         string $recipientAccount,
         ?int $imapAccountId = null,
-        ?int $providerId = null,
+        ?string $providerRef = null,
     ): ?array
     {
         [$account, $bankCode] = $this->splitAccount($recipientAccount);
@@ -334,7 +338,7 @@ final class BankEmailNoticeRepository
             if ($imapAccountId !== null && $row['imap_account_id'] !== null && (int) $row['imap_account_id'] !== $imapAccountId) {
                 continue;
             }
-            if ($providerId !== null && $row['provider_id'] !== null && (int) $row['provider_id'] !== $providerId) {
+            if ($providerRef !== null && $row['provider_ref'] !== null && (string) $row['provider_ref'] !== $providerRef) {
                 continue;
             }
             if ($bankCode !== null && !empty($row['bank_code']) && (string) $row['bank_code'] !== $bankCode) {
@@ -647,6 +651,40 @@ final class BankEmailNoticeRepository
         $row['enabled'] = (bool) $row['enabled'];
         $row['field_patterns'] = $this->decodeJson($row['field_patterns'] ?? '{}');
         $row['normalizer_config'] = $this->decodeJson($row['normalizer_config'] ?? '{}');
+        $row['provider_ref'] = 'db:' . $row['id'];
+        $row['system'] = false;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function providerRefFromMapping(array $row): ?string
+    {
+        if (!empty($row['provider_id'])) {
+            return 'db:' . (int) $row['provider_id'];
+        }
+        $code = $this->nullable($row['mapped_provider_code'] ?? null);
+        return $code !== null ? 'system:' . $code : null;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @return array{0:?int,1:?string}
+     */
+    private function providerTargetFromMappingPayload(array $row, int $supplierId): array
+    {
+        $ref = trim((string) ($row['provider_ref'] ?? ''));
+        if ($ref === '') {
+            return [null, null];
+        }
+        if (preg_match('/^db:(\d+)$/', $ref, $m) === 1) {
+            $id = (int) $m[1];
+            return $this->providerAvailableToSupplier($id, $supplierId) ? [$id, null] : [null, null];
+        }
+        if (preg_match('/^system:([a-z0-9_\\-]{1,80})$/', $ref, $m) === 1) {
+            return [null, $m[1]];
+        }
+        return [null, null];
     }
 
     private function currencyBelongsToSupplier(int $currencyId, int $supplierId): bool

--- a/api/src/Service/Bank/EmailNotice/BankEmailNoticeScanner.php
+++ b/api/src/Service/Bank/EmailNotice/BankEmailNoticeScanner.php
@@ -6,6 +6,7 @@ namespace MyInvoice\Service\Bank\EmailNotice;
 
 use MyInvoice\Repository\BankEmailNoticeRepository;
 use MyInvoice\Service\Bank\StatementMatcher;
+use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeProvider;
 use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeParserRepository;
 
 final class BankEmailNoticeScanner
@@ -207,8 +208,8 @@ final class BankEmailNoticeScanner
             $mapping = $resolved['mapping'];
             if ($mapping === null) {
                 $this->repo->recordMessage($base + [
-                    'provider_id' => $provider['id'] ?? null,
-                    'provider_code' => $provider['code'] ?? null,
+                    'provider_id' => $provider->id,
+                    'provider_code' => $provider->code,
                     'status' => 'match_failed',
                     'parsed_payload' => $notice->toArray(),
                     'error_message' => 'Cílový účet avíza není namapovaný na bankovní účet dodavatele.',
@@ -237,8 +238,8 @@ final class BankEmailNoticeScanner
                 $postError = $this->safePostProcess($settings, $message, 'failure');
             }
             $recordId = $this->repo->recordMessage($base + [
-                'provider_id' => $provider['id'] ?? null,
-                'provider_code' => $provider['code'] ?? null,
+                'provider_id' => $provider->id,
+                'provider_code' => $provider->code,
                 'status' => $status,
                 'parsed_payload' => $notice->toArray() + ['match_result' => $match],
                 'bank_statement_id' => $tx['statement_id'],
@@ -282,7 +283,7 @@ final class BankEmailNoticeScanner
     }
 
     /**
-     * @return array{provider:array<string,mixed>,notice:ParsedBankEmailNotice,mapping:array<string,mixed>|null}
+     * @return array{provider:BankEmailNoticeProvider,notice:ParsedBankEmailNotice,mapping:array<string,mixed>|null}
      */
     private function parseAndResolveMapping(int $supplierId, int $imapAccountId, BankEmailNoticeMessage $message): array
     {
@@ -290,9 +291,9 @@ final class BankEmailNoticeScanner
         $fallback = null;
         $lastError = null;
 
-        foreach ($this->preferredProviderIds($supplierId, $imapAccountId) as $providerId) {
+        foreach ($this->preferredProviderRefs($supplierId, $imapAccountId) as $providerRef) {
             try {
-                $parsed = $this->parsers->parse($message, $providerId, $supplierId);
+                $parsed = $this->parsers->parse($message, $providerRef, $supplierId);
             } catch (\Throwable $e) {
                 $lastError = $e;
                 continue;
@@ -300,11 +301,12 @@ final class BankEmailNoticeScanner
 
             $provider = $parsed['provider'];
             $notice = $parsed['parsed'];
+            $providerRef = $provider->providerRef;
             $mapping = $this->repo->mappingForRecipientAccount(
                 $supplierId,
                 $notice->recipientAccount,
                 $imapFilter,
-                (int) $provider['id'],
+                $providerRef,
             );
             $resolved = ['provider' => $provider, 'notice' => $notice, 'mapping' => $mapping];
             if ($mapping !== null) {
@@ -324,7 +326,7 @@ final class BankEmailNoticeScanner
                     $supplierId,
                     $notice->recipientAccount,
                     $imapFilter,
-                    isset($provider['id']) ? (int) $provider['id'] : null,
+                    $provider->providerRef,
                 ),
             ];
         } catch (\Throwable $e) {
@@ -336,20 +338,20 @@ final class BankEmailNoticeScanner
     }
 
     /**
-     * @return list<int>
+     * @return list<string>
      */
-    private function preferredProviderIds(int $supplierId, int $imapAccountId): array
+    private function preferredProviderRefs(int $supplierId, int $imapAccountId): array
     {
-        $ids = [];
+        $refs = [];
         foreach ($this->repo->accountMappings($supplierId) as $mapping) {
-            if (empty($mapping['enabled']) || empty($mapping['provider_id'])) {
+            if (empty($mapping['enabled']) || empty($mapping['provider_ref'])) {
                 continue;
             }
             if ($imapAccountId > 0 && $mapping['imap_account_id'] !== null && (int) $mapping['imap_account_id'] !== $imapAccountId) {
                 continue;
             }
-            $ids[(int) $mapping['provider_id']] = true;
+            $refs[(string) $mapping['provider_ref']] = true;
         }
-        return array_keys($ids);
+        return array_keys($refs);
     }
 }

--- a/api/src/Service/Bank/EmailNotice/Parser/BankEmailNoticeParserInterface.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/BankEmailNoticeParserInterface.php
@@ -10,12 +10,18 @@ use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
 interface BankEmailNoticeParserInterface
 {
     /**
-     * @param array<string,mixed> $provider
+     * Stabilní parser_type klíč používaný v provider konfiguraci a logu.
      */
-    public function supports(BankEmailNoticeMessage $message, array $provider): bool;
+    public function key(): string;
 
     /**
-     * @param array<string,mixed> $provider
+     * Volitelný systémový provider dodaný parserem bez DB řádku.
+     *
+     * Regex/custom parsery vrací null, protože jejich konfigurace žije v DB/UI.
      */
-    public function parse(BankEmailNoticeMessage $message, array $provider): ParsedBankEmailNotice;
+    public function defaultProvider(): ?BankEmailNoticeProvider;
+
+    public function supports(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): bool;
+
+    public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice;
 }

--- a/api/src/Service/Bank/EmailNotice/Parser/BankEmailNoticeParserRepository.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/BankEmailNoticeParserRepository.php
@@ -13,28 +13,50 @@ final class BankEmailNoticeParserRepository
     /**
      * @var array<string,BankEmailNoticeParserInterface>
      */
-    private array $parsers;
+    private array $parsers = [];
 
+    /**
+     * @var array<string,list<BankEmailNoticeProvider>>
+     */
+    private array $providersCache = [];
+
+    /**
+     * @var list<BankEmailNoticeProvider>|null
+     */
+    private ?array $defaultProvidersCache = null;
+
+    /**
+     * @param array<string,BankEmailNoticeParserInterface> $parsers
+     */
     public function __construct(
         private readonly Connection $db,
-        ?RegexBankEmailNoticeParser $regexParser = null,
-        ?RaiffeisenbankEmailNoticeParser $raiffeisenbankParser = null,
+        array $parsers,
     ) {
-        $regexParser ??= new RegexBankEmailNoticeParser();
-        $raiffeisenbankParser ??= new RaiffeisenbankEmailNoticeParser();
-        $this->parsers = [
-            'regex' => $regexParser,
-            'raiffeisenbank' => $raiffeisenbankParser,
-        ];
+        foreach ($parsers as $parser) {
+            if (!$parser instanceof BankEmailNoticeParserInterface) {
+                throw new \RuntimeException('Parser registry obsahuje službu bez BankEmailNoticeParserInterface.');
+            }
+            $code = trim($parser->key());
+            if ($code === '') {
+                throw new \RuntimeException('Parser registry obsahuje parser s prázdným key().');
+            }
+            if (isset($this->parsers[$code])) {
+                throw new \RuntimeException("Duplicitní bank email parser key: {$code}.");
+            }
+            $this->parsers[$code] = $parser;
+        }
+        if ($this->parsers === []) {
+            throw new \RuntimeException('Parser registry je prázdný.');
+        }
     }
 
     /**
-     * @return array{provider:array<string,mixed>, parsed:ParsedBankEmailNotice}
+     * @return array{provider:BankEmailNoticeProvider, parsed:ParsedBankEmailNotice}
      */
-    public function parse(BankEmailNoticeMessage $message, ?int $preferredProviderId = null, ?int $supplierId = null): array
+    public function parse(BankEmailNoticeMessage $message, ?string $preferredProviderRef = null, ?int $supplierId = null): array
     {
-        foreach ($this->providers($preferredProviderId, $supplierId) as $provider) {
-            $parser = $this->parsers[(string) $provider['parser_type']] ?? null;
+        foreach ($this->providers($preferredProviderRef, $supplierId) as $provider) {
+            $parser = $this->parsers[$provider->parserType] ?? null;
             if ($parser === null) {
                 continue;
             }
@@ -48,32 +70,64 @@ final class BankEmailNoticeParserRepository
     }
 
     /**
-     * @return list<array<string,mixed>>
+     * @return list<BankEmailNoticeProvider>
      */
-    public function providers(?int $preferredProviderId = null, ?int $supplierId = null): array
+    public function providers(?string $preferredProviderRef = null, ?int $supplierId = null, bool $enabledOnly = true): array
     {
-        $sql = 'SELECT * FROM bank_email_notice_providers WHERE enabled = 1';
+        $providers = $this->providersForScope($supplierId, $enabledOnly);
+
+        if ($preferredProviderRef !== null && trim($preferredProviderRef) !== '') {
+            $ref = trim($preferredProviderRef);
+            return array_values(array_filter(
+                $providers,
+                static fn (BankEmailNoticeProvider $provider): bool => $provider->providerRef === $ref,
+            ));
+        }
+
+        return $providers;
+    }
+
+    public function clearCache(): void
+    {
+        $this->providersCache = [];
+        $this->defaultProvidersCache = null;
+    }
+
+    /**
+     * @return list<BankEmailNoticeProvider>
+     */
+    private function providersForScope(?int $supplierId, bool $enabledOnly): array
+    {
+        $cacheKey = ($enabledOnly ? 'enabled' : 'all') . ':' . (($supplierId !== null && $supplierId > 0) ? (string) $supplierId : 'global');
+        if (isset($this->providersCache[$cacheKey])) {
+            return $this->providersCache[$cacheKey];
+        }
+
+        $sql = 'SELECT * FROM bank_email_notice_providers WHERE 1 = 1';
         $params = [];
+        if ($enabledOnly) {
+            $sql .= ' AND enabled = 1';
+        }
         if ($supplierId !== null && $supplierId > 0) {
             $sql .= ' AND (supplier_id IS NULL OR supplier_id = ?)';
             $params[] = $supplierId;
-        }
-        if ($preferredProviderId !== null && $preferredProviderId > 0) {
-            $sql .= ' AND id = ?';
-            $params[] = $preferredProviderId;
         }
         $sql .= ' ORDER BY supplier_id IS NOT NULL DESC, id ASC';
         $stmt = $this->db->pdo()->prepare($sql);
         $stmt->execute($params);
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
-        foreach ($rows as &$row) {
-            $row['id'] = (int) $row['id'];
-            $row['supplier_id'] = $row['supplier_id'] !== null ? (int) $row['supplier_id'] : null;
-            $row['enabled'] = (bool) $row['enabled'];
+        $providers = [];
+        foreach ($rows as $row) {
             $row['field_patterns'] = $this->json((string) $row['field_patterns']);
             $row['normalizer_config'] = $this->json((string) ($row['normalizer_config'] ?? '{}'));
+            $providers[] = $this->providerFromDatabaseRow($row);
         }
-        return $rows;
+
+        foreach ($this->defaultProviders() as $provider) {
+            $providers[] = $provider;
+        }
+
+        return $this->providersCache[$cacheKey] = $providers;
     }
 
     /**
@@ -83,5 +137,53 @@ final class BankEmailNoticeParserRepository
     {
         $decoded = json_decode($json !== '' ? $json : '{}', true);
         return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function providerFromDatabaseRow(array $row): BankEmailNoticeProvider
+    {
+        $id = (int) $row['id'];
+        return new BankEmailNoticeProvider(
+            id: $id,
+            supplierId: $row['supplier_id'] !== null ? (int) $row['supplier_id'] : null,
+            providerRef: 'db:' . $id,
+            code: (string) $row['code'],
+            name: (string) $row['name'],
+            parserType: (string) $row['parser_type'],
+            enabled: (bool) $row['enabled'],
+            senderWhitelist: $this->stringOrNull($row['sender_whitelist'] ?? null),
+            subjectPattern: $this->stringOrNull($row['subject_pattern'] ?? null),
+            bodyPattern: $this->stringOrNull($row['body_pattern'] ?? null),
+            fieldPatterns: is_array($row['field_patterns'] ?? null) ? $row['field_patterns'] : [],
+            normalizerConfig: is_array($row['normalizer_config'] ?? null) ? $row['normalizer_config'] : [],
+            system: false,
+        );
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        $value = trim((string) ($value ?? ''));
+        return $value !== '' ? $value : null;
+    }
+
+    /**
+     * @return list<BankEmailNoticeProvider>
+     */
+    private function defaultProviders(): array
+    {
+        if ($this->defaultProvidersCache !== null) {
+            return $this->defaultProvidersCache;
+        }
+
+        $providers = [];
+        foreach ($this->parsers as $parser) {
+            $provider = $parser->defaultProvider();
+            if ($provider !== null) {
+                $providers[] = $provider;
+            }
+        }
+        return $this->defaultProvidersCache = $providers;
     }
 }

--- a/api/src/Service/Bank/EmailNotice/Parser/BankEmailNoticeProvider.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/BankEmailNoticeProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Bank\EmailNotice\Parser;
+
+final readonly class BankEmailNoticeProvider
+{
+    /**
+     * @param array<string,mixed> $fieldPatterns
+     * @param array<string,mixed> $normalizerConfig
+     */
+    public function __construct(
+        public ?int $id,
+        public ?int $supplierId,
+        public string $providerRef,
+        public string $code,
+        public string $name,
+        public string $parserType,
+        public bool $enabled,
+        public ?string $senderWhitelist,
+        public ?string $subjectPattern,
+        public ?string $bodyPattern,
+        public array $fieldPatterns,
+        public array $normalizerConfig,
+        public bool $system,
+    ) {}
+
+}

--- a/api/src/Service/Bank/EmailNotice/Parser/CsobBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/CsobBankEmailNoticeParser.php
@@ -8,7 +8,7 @@ use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
 use MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer;
 use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
 
-final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInterface
+final class CsobBankEmailNoticeParser implements BankEmailNoticeParserInterface
 {
     private EmailNoticeTextNormalizer $normalizer;
 
@@ -19,7 +19,7 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
 
     public function key(): string
     {
-        return 'raiffeisenbank';
+        return 'csob';
     }
 
     public function defaultProvider(): ?BankEmailNoticeProvider
@@ -29,12 +29,12 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
             supplierId: null,
             providerRef: 'system:' . $this->key(),
             code: $this->key(),
-            name: 'Raiffeisenbank - Pohyb na ucte',
+            name: 'ČSOB - Moje info Avízo',
             parserType: $this->key(),
             enabled: true,
-            senderWhitelist: 'info@rb.cz',
-            subjectPattern: 'Pohyb\\s+na\\s+účtě|Pohyb\\s+na\\s+ucte',
-            bodyPattern: 'Variabilní\\s+symbol',
+            senderWhitelist: 'noreply@csob.cz',
+            subjectPattern: 'Moje\\s+info\\s+-\\s+Avízo|Moje\\s+info\\s+-\\s+Avizo',
+            bodyPattern: 'Parametry\\s+platby',
             fieldPatterns: [],
             normalizerConfig: [],
             system: true,
@@ -44,47 +44,74 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
     public function supports(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): bool
     {
         $sender = strtolower($message->sender);
-        if (!str_contains($sender, 'info@rb.cz') && !str_contains($sender, '@rb.cz')) {
+        if (!str_contains($sender, 'noreply@csob.cz') && !str_contains($sender, '@csob.cz')) {
             return false;
         }
-        $subject = mb_strtolower($message->subject);
-        if (!str_contains($subject, 'pohyb na účtě') && !str_contains($subject, 'pohyb na ucte')) {
+
+        $subject = $this->compact(mb_strtolower($message->subject, 'UTF-8'));
+        if (
+            !str_contains($subject, 'moje info')
+            || (!str_contains($subject, 'avízo') && !str_contains($subject, 'avizo'))
+        ) {
             return false;
         }
-        $text = mb_strtolower($this->normalizer->normalize($message->text));
-        return str_contains($text, 'variabilní symbol')
-            && str_contains($text, 'částka v měně účtu')
-            && str_contains($text, 'na účet');
+
+        $text = $this->compact(mb_strtolower($this->normalizer->normalize($message->text), 'UTF-8'));
+        return str_contains($text, 'parametry platby')
+            && (str_contains($text, 'vaše čsob') || str_contains($text, 'vase csob') || str_contains($text, 'čsob'))
+            && (str_contains($text, 'částka') || str_contains($text, 'castka'));
     }
 
     public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
     {
         $text = $this->normalizer->normalize($message->text);
 
-        $postedAt = $this->required($text, '/Datum\s+a\s+čas\s*(?<value>\d{1,2}\.\s*\d{1,2}\.\s*\d{4}\s+\d{1,2}:\d{2})/iu', 'datum');
-        $recipientAccount = $this->required($text, '/Na\s+účet\s*(?<value>[0-9\-]+\/[0-9]{4})/iu', 'cílový účet');
-        $amountCurrency = $this->match($text, '/Částka\s+v\s+měně\s+účtu\s*(?<amount>[+\-]?[0-9 .]+,[0-9]{2})\s*(?<currency>[A-Z]{3})/iu');
+        $recipientAccount = $this->required(
+            $text,
+            '/(?:^|\R)\s*Účet\s*\R\s*(?<value>[0-9\-]+\/[0-9]{4})/u',
+            'cílový účet',
+        );
+        $counterpartyAccount = $this->optional(
+            $text,
+            '/(?:^|\R)\s*Účet\s+protistrany\s*\R\s*(?<value>[0-9\-]+\/[0-9]{4})/u',
+        );
+        $counterpartyName = $this->optional(
+            $text,
+            '/(?:^|\R)\s*Název\s+protistrany\s*\R\s*(?<value>[^\r\n]+)/u',
+        );
+        $postedAt = $this->required(
+            $text,
+            '/(?:^|\R)\s*Datum\s+účtování\s*\R\s*(?<value>\d{1,2}\.\d{1,2}\.\d{4})/u',
+            'datum účtování',
+        );
+        $amountCurrency = $this->match(
+            $text,
+            '/(?:^|\R)\s*Částka\s*\R\s*(?<amount>[+\-]?[0-9 ]+,[0-9]{2})\s*(?<currency>[A-Z]{3})/u',
+        );
         if ($amountCurrency === null) {
-            throw new \RuntimeException('Raiffeisenbank parser nenašel částku a měnu.');
+            throw new \RuntimeException('ČSOB parser nenašel částku a měnu.');
         }
-        $counterparty = $this->match($text, '/Z\s+účtu\s*(?<account>[0-9\-]+\/[0-9]{4})(?<name>.*?)Variabilní\s+symbol/isu');
-        $variableSymbol = $this->required($text, '/Variabilní\s+symbol\s*(?<value>[0-9]+)/iu', 'variabilní symbol');
-        $constantSymbol = $this->optional($text, '/Konstantní\s+symbol\s*(?<value>[0-9]+)/iu');
-        $note = $this->optional($text, '/Zpráva\s+pro\s+příjemce\s*(?<value>.*?)Disponibilní\s+zůstatek/isu');
+        $variableSymbol = $this->optional(
+            $text,
+            '/(?:^|\R)\s*Variabilní\s+symbol\s*\R\s*(?<value>[0-9]+)/u',
+        );
+        $constantSymbol = $this->optional(
+            $text,
+            '/(?:^|\R)\s*Konstantní\s+symbol\s*\R\s*(?<value>[0-9]+)/u',
+        );
 
-        [$counterpartyAccount, $counterpartyBank] = $this->splitAccount((string) ($counterparty['account'] ?? ''));
+        [$cpAccount, $cpBank] = $this->splitAccount((string) $counterpartyAccount);
 
         return new ParsedBankEmailNotice(
-            variableSymbol: $variableSymbol,
+            variableSymbol: $this->normalizeSymbol((string) $variableSymbol),
             amount: $this->parseAmount((string) $amountCurrency['amount']),
             currency: strtoupper((string) $amountCurrency['currency']),
             postedAt: $this->parseDate($postedAt),
             recipientAccount: $recipientAccount,
-            counterpartyAccount: $counterpartyAccount,
-            counterpartyBank: $counterpartyBank,
-            counterpartyName: $this->cleanNullable((string) ($counterparty['name'] ?? '')),
+            counterpartyAccount: $cpAccount,
+            counterpartyBank: $cpBank,
+            counterpartyName: $counterpartyName,
             constantSymbol: $constantSymbol,
-            message: $note,
         );
     }
 
@@ -109,7 +136,7 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
     {
         $value = $this->optional($text, $pattern);
         if ($value === null) {
-            throw new \RuntimeException("Raiffeisenbank parser nenašel {$label}.");
+            throw new \RuntimeException("ČSOB parser nenašel {$label}.");
         }
         return $value;
     }
@@ -125,7 +152,7 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
 
     private function parseAmount(string $value): float
     {
-        $value = str_replace(["\xc2\xa0", ' ', '+', '.'], '', trim($value));
+        $value = str_replace(["\xc2\xa0", ' ', '+'], '', trim($value));
         $value = str_replace(',', '.', $value);
         return (float) $value;
     }
@@ -133,13 +160,13 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
     private function parseDate(string $value): string
     {
         $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        foreach (['d. m. Y H:i', 'd.m.Y H:i'] as $format) {
+        foreach (['d.m.Y', 'd. m. Y'] as $format) {
             $dt = \DateTimeImmutable::createFromFormat($format, $value);
             if ($dt instanceof \DateTimeImmutable) {
                 return $dt->format('Y-m-d');
             }
         }
-        throw new \RuntimeException('Raiffeisenbank parser nenašel validní datum platby.');
+        throw new \RuntimeException('ČSOB parser nenašel validní datum účtování.');
     }
 
     /**
@@ -157,9 +184,21 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
         return [$value, null];
     }
 
+    private function normalizeSymbol(string $value): string
+    {
+        $digits = preg_replace('/\D+/', '', $value) ?? '';
+        $trimmed = ltrim($digits, '0');
+        return $trimmed !== '' ? $trimmed : $digits;
+    }
+
     private function cleanNullable(string $value): ?string
     {
         $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
         return $value !== '' ? mb_substr($value, 0, 255) : null;
+    }
+
+    private function compact(string $value): string
+    {
+        return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
     }
 }

--- a/api/src/Service/Bank/EmailNotice/Parser/RegexBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/RegexBankEmailNoticeParser.php
@@ -17,29 +17,36 @@ final class RegexBankEmailNoticeParser implements BankEmailNoticeParserInterface
         $this->normalizer = $normalizer ?? new EmailNoticeTextNormalizer();
     }
 
-    public function supports(BankEmailNoticeMessage $message, array $provider): bool
+    public function key(): string
     {
-        if (!$this->senderAllowed($message->sender, (string) ($provider['sender_whitelist'] ?? ''))) {
+        return 'regex';
+    }
+
+    public function defaultProvider(): ?BankEmailNoticeProvider
+    {
+        return null;
+    }
+
+    public function supports(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): bool
+    {
+        if (!$this->senderAllowed($message->sender, (string) ($provider->senderWhitelist ?? ''))) {
             return false;
         }
-        $subjectPattern = trim((string) ($provider['subject_pattern'] ?? ''));
+        $subjectPattern = trim((string) ($provider->subjectPattern ?? ''));
         if ($subjectPattern !== '' && !preg_match('~' . $subjectPattern . '~iu', $message->subject)) {
             return false;
         }
-        $bodyPattern = trim((string) ($provider['body_pattern'] ?? ''));
+        $bodyPattern = trim((string) ($provider->bodyPattern ?? ''));
         if ($bodyPattern !== '' && !preg_match('~' . $bodyPattern . '~iu', $this->normalizer->normalize($message->text))) {
             return false;
         }
         return true;
     }
 
-    public function parse(BankEmailNoticeMessage $message, array $provider): ParsedBankEmailNotice
+    public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
     {
         $text = $this->normalizer->normalize($message->text);
-        $patterns = $provider['field_patterns'] ?? [];
-        if (!is_array($patterns)) {
-            throw new \RuntimeException('Provider nemá validní field_patterns.');
-        }
+        $patterns = $provider->fieldPatterns;
 
         $data = [];
         foreach ($patterns as $field => $pattern) {

--- a/api/src/Service/Bank/EmailNotice/Parser/UnicreditBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/UnicreditBankEmailNoticeParser.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Bank\EmailNotice\Parser;
+
+use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer;
+use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
+
+final class UnicreditBankEmailNoticeParser implements BankEmailNoticeParserInterface
+{
+    private EmailNoticeTextNormalizer $normalizer;
+
+    public function __construct(?EmailNoticeTextNormalizer $normalizer = null)
+    {
+        $this->normalizer = $normalizer ?? new EmailNoticeTextNormalizer();
+    }
+
+    public function key(): string
+    {
+        return 'unicredit';
+    }
+
+    public function defaultProvider(): ?BankEmailNoticeProvider
+    {
+        return new BankEmailNoticeProvider(
+            id: null,
+            supplierId: null,
+            providerRef: 'system:' . $this->key(),
+            code: $this->key(),
+            name: 'UniCredit Bank - Informace o pohybu na účtu',
+            parserType: $this->key(),
+            enabled: true,
+            senderWhitelist: 'unicreditbank@unicreditgroup.cz noe@unicredit.eu',
+            subjectPattern: 'Informace\\s+o\\s+pohybu\\s+na\\s+účtu|Informace\\s+o\\s+pohybu\\s+na\\s+uctu',
+            bodyPattern: 'UniCredit\\s+Bank',
+            fieldPatterns: [],
+            normalizerConfig: [],
+            system: true,
+        );
+    }
+
+    public function supports(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): bool
+    {
+        $sender = strtolower($message->sender);
+        if (
+            !str_contains($sender, 'unicreditbank@unicreditgroup.cz')
+            && !str_contains($sender, '@unicreditgroup.cz')
+            && !str_contains($sender, 'noe@unicredit.eu')
+        ) {
+            return false;
+        }
+
+        $subject = $this->compact(mb_strtolower(str_replace('_', ' ', $message->subject), 'UTF-8'));
+        if (
+            !str_contains($subject, 'informace o pohybu na účtu')
+            && !str_contains($subject, 'informace o pohybu na uctu')
+        ) {
+            return false;
+        }
+
+        $text = $this->compact(mb_strtolower($this->normalizer->normalize($message->text), 'UTF-8'));
+        return (str_contains($text, 'variabilní symbol') || str_contains($text, 'variabilni symbol'))
+            && (str_contains($text, 'číslo účtu protistrany') || str_contains($text, 'cislo uctu protistrany'))
+            && str_contains($text, 'unicredit bank');
+    }
+
+    public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
+    {
+        $text = $this->normalizer->normalize($message->text);
+
+        $recipientAccount = $this->required(
+            $text,
+            '/na\s+Va[šs]em\s+[úu][čc]tu\s+[čc]\.\s*(?<value>[0-9\-]+)/iu',
+            'cílový účet',
+        );
+        $amountCurrency = $this->match($text, '/[ČC]ástka:\s*(?<amount>[+\-]?[0-9,. ]+)\s*(?<currency>[A-Z]{3})/u');
+        if ($amountCurrency === null) {
+            throw new \RuntimeException('UniCredit Bank parser nenašel částku a měnu.');
+        }
+        $counterpartyAccount = $this->optional(
+            $text,
+            '/[ČC]íslo\s+[úu][čc]tu\s+protistrany:\s*(?<value>[0-9\-]+\/[0-9]{4})/iu',
+        );
+        $counterpartyName = $this->optional(
+            $text,
+            '/N[áa]zev\s+[úu][čc]tu\s+protistrany:\s*(?<value>.*?)\s*Variabiln[íi]\s+symbol:/isu',
+        );
+        $variableSymbol = $this->required(
+            $text,
+            '/Variabiln[íi]\s+symbol:\s*(?<value>[0-9]+)/iu',
+            'variabilní symbol',
+        );
+        $messageText = $this->optional(
+            $text,
+            '/Detaily\s+transakce:\s*(?<value>.*?)\s*Datum:/isu',
+        );
+        $postedAt = $this->required(
+            $text,
+            '/Datum:\s*(?<value>\d{1,2}\.\d{1,2}\.\d{4}\s+\d{1,2}:\d{2}(?::\d{2})?)/u',
+            'datum',
+        );
+
+        [$cpAccount, $cpBank] = $this->splitAccount((string) $counterpartyAccount);
+
+        return new ParsedBankEmailNotice(
+            variableSymbol: $this->normalizeSymbol($variableSymbol),
+            amount: $this->parseAmount((string) $amountCurrency['amount']),
+            currency: strtoupper((string) $amountCurrency['currency']),
+            postedAt: $this->parseDate($postedAt),
+            recipientAccount: $recipientAccount,
+            counterpartyAccount: $cpAccount,
+            counterpartyBank: $cpBank,
+            counterpartyName: $counterpartyName,
+            message: $messageText,
+        );
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    private function match(string $text, string $pattern): ?array
+    {
+        if (preg_match($pattern, $text, $m) !== 1) {
+            return null;
+        }
+        $out = [];
+        foreach ($m as $key => $value) {
+            if (is_string($key)) {
+                $out[$key] = trim((string) $value);
+            }
+        }
+        return $out;
+    }
+
+    private function required(string $text, string $pattern, string $label): string
+    {
+        $value = $this->optional($text, $pattern);
+        if ($value === null) {
+            throw new \RuntimeException("UniCredit Bank parser nenašel {$label}.");
+        }
+        return $value;
+    }
+
+    private function optional(string $text, string $pattern): ?string
+    {
+        $m = $this->match($text, $pattern);
+        if ($m === null || !isset($m['value'])) {
+            return null;
+        }
+        return $this->cleanNullable($m['value']);
+    }
+
+    private function parseAmount(string $value): float
+    {
+        $value = preg_replace('/[^\d,.\-+]/u', '', trim($value)) ?? $value;
+        $negative = str_starts_with($value, '-');
+        $value = ltrim($value, '+-');
+
+        $lastComma = strrpos($value, ',');
+        $lastDot = strrpos($value, '.');
+        if ($lastComma !== false && $lastDot !== false) {
+            if ($lastDot > $lastComma) {
+                $value = str_replace(',', '', $value);
+            } else {
+                $value = str_replace('.', '', $value);
+                $value = str_replace(',', '.', $value);
+            }
+        } elseif ($lastComma !== false) {
+            $value = str_replace(',', '.', $value);
+        }
+
+        $amount = (float) $value;
+        return $negative ? -$amount : $amount;
+    }
+
+    private function parseDate(string $value): string
+    {
+        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
+        foreach (['d.m.Y H:i:s', 'd.m.Y H:i', 'd. m. Y H:i:s', 'd. m. Y H:i'] as $format) {
+            $dt = \DateTimeImmutable::createFromFormat($format, $value);
+            if ($dt instanceof \DateTimeImmutable) {
+                return $dt->format('Y-m-d');
+            }
+        }
+        throw new \RuntimeException('UniCredit Bank parser nenašel validní datum platby.');
+    }
+
+    /**
+     * @return array{0:?string,1:?string}
+     */
+    private function splitAccount(string $value): array
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return [null, null];
+        }
+        if (preg_match('/^(?<account>[0-9\-]+)\/(?<bank>[0-9]{4})$/', $value, $m) === 1) {
+            return [$m['account'], $m['bank']];
+        }
+        return [$value, null];
+    }
+
+    private function normalizeSymbol(string $value): string
+    {
+        $digits = preg_replace('/\D+/', '', $value) ?? '';
+        $trimmed = ltrim($digits, '0');
+        return $trimmed !== '' ? $trimmed : $digits;
+    }
+
+    private function cleanNullable(string $value): ?string
+    {
+        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
+        if ($value === '' || in_array(strtoupper($value), ['N/A', 'NA'], true)) {
+            return null;
+        }
+        return mb_substr($value, 0, 255);
+    }
+
+    private function compact(string $value): string
+    {
+        return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
+    }
+}

--- a/api/tests/Unit/Bank/CsobBankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/CsobBankEmailNoticeParserTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Bank;
+
+use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeProvider;
+use MyInvoice\Service\Bank\EmailNotice\Parser\CsobBankEmailNoticeParser;
+use PHPUnit\Framework\TestCase;
+
+final class CsobBankEmailNoticeParserTest extends TestCase
+{
+    public function testParsesIncomingNoticeWithoutVariableSymbol(): void
+    {
+        $body = <<<TEXT
+Dobrý den,
+dne 31.5.2026 byla na účtu 123456789 zaúčtována transakce typu: Příchozí úhrada okamžitá.
+
+Parametry platby
+Účet
+123456789/0300
+Účet protistrany
+1002201927/2700
+Název protistrany
+PLÁTCE DEMO
+Datum účtování
+31.5.2026
+Částka
++10 000,00 CZK
+Zůstatek na účtu po zaúčtování transakce: +10 000,00 CZK.
+
+Přejeme příjemný den.
+Vaše ČSOB
+TEXT;
+
+        $parser = new CsobBankEmailNoticeParser();
+        $message = $this->message($body);
+        $provider = $this->provider($parser);
+
+        self::assertTrue($parser->supports($message, $provider));
+
+        $parsed = $parser->parse($message, $provider);
+
+        self::assertSame('', $parsed->variableSymbol);
+        self::assertSame(10000.0, $parsed->amount);
+        self::assertSame('CZK', $parsed->currency);
+        self::assertSame('2026-05-31', $parsed->postedAt);
+        self::assertSame('123456789/0300', $parsed->recipientAccount);
+        self::assertSame('1002201927', $parsed->counterpartyAccount);
+        self::assertSame('2700', $parsed->counterpartyBank);
+        self::assertSame('PLÁTCE DEMO', $parsed->counterpartyName);
+    }
+
+    public function testParsesOutgoingNoticeWithSymbols(): void
+    {
+        $body = <<<TEXT
+Dobrý den,
+dne 31.5.2026 byla na účtu 123456789 zaúčtována transakce typu: Odchozí úhrada okamžitá.
+
+Parametry platby
+Účet
+123456789/0300
+Účet protistrany
+35-4544230267/0100
+Datum účtování
+31.5.2026
+Částka
+-10 000,00 CZK
+Variabilní symbol
+0009002567593
+Konstantní symbol
+1120
+Zůstatek na účtu po zaúčtování transakce: +0,00 CZK.
+
+Přejeme příjemný den.
+Vaše ČSOB
+TEXT;
+
+        $parser = new CsobBankEmailNoticeParser();
+        $parsed = $parser->parse($this->message($body), $this->provider($parser));
+
+        self::assertSame('9002567593', $parsed->variableSymbol);
+        self::assertSame(-10000.0, $parsed->amount);
+        self::assertSame('35-4544230267', $parsed->counterpartyAccount);
+        self::assertSame('0100', $parsed->counterpartyBank);
+        self::assertSame('1120', $parsed->constantSymbol);
+    }
+
+    private function message(string $body): BankEmailNoticeMessage
+    {
+        return new BankEmailNoticeMessage(
+            uid: 1,
+            messageId: '<sanitized-sample@csob.cz>',
+            date: new \DateTimeImmutable('2026-05-31 10:00:00'),
+            sender: 'ČSOB <noreply@csob.cz>',
+            subject: 'Moje info - Avízo',
+            text: $body,
+            raw: $body,
+        );
+    }
+
+    private function provider(CsobBankEmailNoticeParser $parser): BankEmailNoticeProvider
+    {
+        $provider = $parser->defaultProvider();
+        self::assertInstanceOf(BankEmailNoticeProvider::class, $provider);
+        return $provider;
+    }
+}

--- a/api/tests/Unit/Bank/RaiffeisenbankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/RaiffeisenbankEmailNoticeParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MyInvoice\Tests\Unit\Bank;
 
 use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeProvider;
 use MyInvoice\Service\Bank\EmailNotice\Parser\RaiffeisenbankEmailNoticeParser;
 use PHPUnit\Framework\TestCase;
 
@@ -42,9 +43,11 @@ TEXT;
         );
 
         $parser = new RaiffeisenbankEmailNoticeParser();
-        self::assertTrue($parser->supports($message, ['parser_type' => 'raiffeisenbank']));
+        $provider = $parser->defaultProvider();
+        self::assertInstanceOf(BankEmailNoticeProvider::class, $provider);
+        self::assertTrue($parser->supports($message, $provider));
 
-        $parsed = $parser->parse($message, ['parser_type' => 'raiffeisenbank']);
+        $parsed = $parser->parse($message, $provider);
 
         self::assertSame('2606001', $parsed->variableSymbol);
         self::assertSame(1234.56, $parsed->amount);

--- a/api/tests/Unit/Bank/RegexBankEmailNoticeParserCsTest.php
+++ b/api/tests/Unit/Bank/RegexBankEmailNoticeParserCsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MyInvoice\Tests\Unit\Bank;
 
 use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeProvider;
 use MyInvoice\Service\Bank\EmailNotice\Parser\RegexBankEmailNoticeParser;
 use PHPUnit\Framework\TestCase;
 
@@ -26,15 +27,23 @@ final class RegexBankEmailNoticeParserCsTest extends TestCase
         ];
     }
 
-    private function csProvider(): array
+    private function csProvider(): BankEmailNoticeProvider
     {
-        return [
-            'parser_type' => 'regex',
-            'sender_whitelist' => '',
-            'subject_pattern' => '',
-            'body_pattern' => '',
-            'field_patterns' => $this->csFieldPatterns(),
-        ];
+        return new BankEmailNoticeProvider(
+            id: null,
+            supplierId: null,
+            providerRef: 'test:regex-cs',
+            code: 'regex_cs',
+            name: 'Regex ČS test',
+            parserType: 'regex',
+            enabled: true,
+            senderWhitelist: null,
+            subjectPattern: null,
+            bodyPattern: null,
+            fieldPatterns: $this->csFieldPatterns(),
+            normalizerConfig: [],
+            system: false,
+        );
     }
 
     private function csMessage(string $body): BankEmailNoticeMessage

--- a/api/tests/Unit/Bank/UnicreditBankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/UnicreditBankEmailNoticeParserTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Bank;
+
+use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeProvider;
+use MyInvoice\Service\Bank\EmailNotice\Parser\UnicreditBankEmailNoticeParser;
+use PHPUnit\Framework\TestCase;
+
+final class UnicreditBankEmailNoticeParserTest extends TestCase
+{
+    public function testParsesSanitizedQuotedPrintableHtmlNotice(): void
+    {
+        $html = <<<HTML
+<html>Dobrý den,<br/>
+na Vašem účtu č. 123456789 (CZK) Test právě proběhla transakce s následujícími údaji:<br/>
+<br/>
+Částka: 20,546.00 CZK<br/>
+Číslo účtu protistrany: 0-987654321/0600<br/>
+Název účtu protistrany: PLÁTCE DEMO s.r.o.<br/>
+Variabilní symbol: 0002026017<br/>
+Specifický symbol: <br/>
+Detaily transakce: Faktura 2026017<br/>
+Datum: 25.05.2026 13:02:31<br/>
+<br/>
+S pozdravem,<br/>
+Vaše UniCredit Bank<br/>
+</html>
+HTML;
+        $raw = "Content-Type: text/html; charset=utf-8\n"
+            . "Content-Transfer-Encoding: quoted-printable\n\n"
+            . quoted_printable_encode($html);
+        $message = new BankEmailNoticeMessage(
+            uid: 1,
+            messageId: '<sanitized-sample@unicreditgroup.cz>',
+            date: new \DateTimeImmutable('2026-05-25 13:02:54'),
+            sender: 'UniCredit Bank <unicreditbank@unicreditgroup.cz>',
+            subject: 'Informace_o_pohybu_na_účtu',
+            text: $raw,
+            raw: $raw,
+        );
+
+        $parser = new UnicreditBankEmailNoticeParser();
+        $provider = $parser->defaultProvider();
+        self::assertInstanceOf(BankEmailNoticeProvider::class, $provider);
+        self::assertTrue($parser->supports($message, $provider));
+
+        $parsed = $parser->parse($message, $provider);
+
+        self::assertSame('2026017', $parsed->variableSymbol);
+        self::assertSame(20546.0, $parsed->amount);
+        self::assertSame('CZK', $parsed->currency);
+        self::assertSame('2026-05-25', $parsed->postedAt);
+        self::assertSame('123456789', $parsed->recipientAccount);
+        self::assertSame('0-987654321', $parsed->counterpartyAccount);
+        self::assertSame('0600', $parsed->counterpartyBank);
+        self::assertSame('PLÁTCE DEMO s.r.o.', $parsed->counterpartyName);
+        self::assertSame('Faktura 2026017', $parsed->message);
+    }
+}

--- a/cfg.sample.php
+++ b/cfg.sample.php
@@ -272,6 +272,19 @@ return [
         'header' => 'X-Forwarded-For',               // hlavička se skutečnou klient IP (přepíše REMOTE_ADDR za trusted proxy)
     ],
 
+    // Registry parserů bankovních e-mailových avíz. Klíč pole je konfigurační
+    // slot pro override; skutečný parser_type dodává parser metodou key().
+    // Hodnotou je class name služby, kterou DI container vytvoří a ověří proti
+    // BankEmailNoticeParserInterface. Hodnota null/false daný slot vypne.
+    'bank_email' => [
+        'notice_parsers' => [
+            'regex' => \MyInvoice\Service\Bank\EmailNotice\Parser\RegexBankEmailNoticeParser::class,
+            'raiffeisenbank' => \MyInvoice\Service\Bank\EmailNotice\Parser\RaiffeisenbankEmailNoticeParser::class,
+            'unicredit' => \MyInvoice\Service\Bank\EmailNotice\Parser\UnicreditBankEmailNoticeParser::class,
+            'csob' => \MyInvoice\Service\Bank\EmailNotice\Parser\CsobBankEmailNoticeParser::class,
+        ],
+    ],
+
     // Auto-import bankovních výpisů (GPC/ABO) z monitorovaného adresáře.
     // Manuální upload přes UI funguje vždy bez ohledu na tuto sekci.
     'bank_import' => [

--- a/db/migrations/0099_bank_email_notice_parser_type_varchar.sql
+++ b/db/migrations/0099_bank_email_notice_parser_type_varchar.sql
@@ -1,0 +1,29 @@
+-- MyInvoice.cz - FR-58 parser registry pro bankovní e-mailová avíza
+--
+-- parser_type převádíme z ENUM na VARCHAR, aby registry parserů šla rozšiřovat
+-- přes cfg.php a DI container bez další změny schématu pro každý nový parser.
+-- Systémové parsery dodávají svůj provider z kódu; DB provider zůstává pro
+-- regex/custom konfigurace z UI. Starý globální Raiffeisenbank seed z migrace
+-- 0096 už je systémový provider z parseru, proto ho odstraníme z DB.
+
+SET NAMES utf8mb4;
+
+ALTER TABLE bank_email_notice_providers
+  MODIFY COLUMN parser_type VARCHAR(80) NOT NULL DEFAULT 'regex';
+
+ALTER TABLE bank_email_account_mappings
+  ADD COLUMN IF NOT EXISTS provider_code VARCHAR(80) NULL AFTER provider_id,
+  ADD KEY IF NOT EXISTS idx_beam_provider_code (provider_code);
+
+UPDATE bank_email_account_mappings m
+  JOIN bank_email_notice_providers p ON p.id = m.provider_id
+   SET m.provider_code = p.code
+ WHERE p.supplier_id IS NULL
+   AND p.code = 'raiffeisenbank'
+   AND p.parser_type = 'raiffeisenbank'
+   AND m.provider_code IS NULL;
+
+DELETE FROM bank_email_notice_providers
+ WHERE supplier_id IS NULL
+   AND code = 'raiffeisenbank'
+   AND parser_type = 'raiffeisenbank';

--- a/manual/13_Banka.md
+++ b/manual/13_Banka.md
@@ -217,7 +217,7 @@ Provider říká, jak poznat e-mail dané banky a jak z něj vytěžit platební
 
 Typy providerů:
 
-- **Systémový provider** — dodaný aplikací, např. Raiffeisenbank.
+- **Systémový provider** — dodaný aplikací, např. Raiffeisenbank, UniCredit Bank, ČSOB nebo Česká spořitelna.
 - **Regex provider** — vlastní provider dodavatele, konfigurovaný v UI.
 
 U regex provideru nastavuješ:

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -135,11 +135,13 @@ export interface BankEmailImapSettings {
 }
 
 export interface BankEmailProvider {
-  id: number
+  id: number | null
+  provider_ref: string
+  system?: boolean
   supplier_id: number | null
   code: string
   name: string
-  parser_type: 'regex' | 'raiffeisenbank'
+  parser_type: string
   enabled: boolean
   sender_whitelist: string | null
   subject_pattern: string | null
@@ -159,6 +161,7 @@ export interface BankEmailAccountMapping {
   imap_account_id: number | null
   imap_account_name?: string | null
   provider_id: number | null
+  provider_ref: string | null
   enabled: boolean
   amount_tolerance: number
   provider_code: string | null
@@ -447,8 +450,8 @@ export const settingsApi = {
     api.delete<{ deleted: boolean }>(`/settings/bank-email-notices/providers/${id}`).then(r => r.data),
   updateBankEmailMappings: (mappings: Partial<BankEmailAccountMapping>[]) =>
     api.put<BankEmailAccountMapping[]>('/settings/bank-email-notices/mappings', { mappings }).then(r => r.data),
-  testBankEmailParser: (payload: { provider_id?: number | null; sender?: string; subject?: string; text: string }) =>
-    api.post<{ provider: Pick<BankEmailProvider, 'id' | 'code' | 'name' | 'parser_type'>; parsed: Record<string, any> }>(
+  testBankEmailParser: (payload: { provider_ref?: string | null; sender?: string; subject?: string; text: string }) =>
+    api.post<{ provider: Pick<BankEmailProvider, 'id' | 'code' | 'name' | 'parser_type' | 'provider_ref'>; parsed: Record<string, any> }>(
       '/settings/bank-email-notices/parser/test',
       payload,
     ).then(r => r.data),

--- a/web/src/pages/admin/BankAccounts.vue
+++ b/web/src/pages/admin/BankAccounts.vue
@@ -44,7 +44,7 @@ const emailNoticesOpen = ref(false)
 const parserText = ref('')
 const parserSender = ref('info@rb.cz')
 const parserSubject = ref('Pohyb na účtě')
-const parserProviderId = ref<number | null>(null)
+const parserProviderRef = ref<string | null>(null)
 const parserResult = ref<Record<string, any> | null>(null)
 const scanSummary = ref<Record<string, any> | null>(null)
 const bankEmailLoadError = ref<string | null>(null)
@@ -321,7 +321,7 @@ async function saveMappings() {
     await settingsApi.updateBankEmailMappings(mappings.value.map(m => ({
       currency_id: m.currency_id,
       imap_account_id: m.imap_account_id === 0 ? null : m.imap_account_id,
-      provider_id: m.provider_id,
+      provider_ref: m.provider_ref,
       enabled: m.imap_account_id === 0 ? false : m.enabled,
       amount_tolerance: m.amount_tolerance,
     })))
@@ -448,14 +448,20 @@ function providerOwnerLabel(provider: BankEmailProvider): string {
 
 function parserTypeLabel(parserType: BankEmailProvider['parser_type']): string {
   if (parserType === 'raiffeisenbank') return 'Raiffeisenbank'
+  if (parserType === 'unicredit') return 'UniCredit Bank'
+  if (parserType === 'csob') return 'ČSOB'
   return 'Regex'
+}
+
+function providerSelectLabel(provider: BankEmailProvider): string {
+  return `${provider.name} (${providerOwnerLabel(provider)})`
 }
 
 async function testParser() {
   parserResult.value = null
   try {
     const r = await settingsApi.testBankEmailParser({
-      provider_id: parserProviderId.value,
+      provider_ref: parserProviderRef.value,
       sender: parserSender.value,
       subject: parserSubject.value,
       text: parserText.value,
@@ -477,7 +483,7 @@ function startNewRegexProvider() {
 }
 
 function startEditProvider(provider: BankEmailProvider) {
-  if (provider.supplier_id === null || provider.parser_type !== 'regex') return
+  if (provider.id === null || provider.supplier_id === null || provider.parser_type !== 'regex') return
   const patterns = defaultFieldPatterns()
   for (const field of regexFieldDefinitions) {
     patterns[field.key] = String(provider.field_patterns?.[field.key] ?? '')
@@ -555,7 +561,7 @@ async function saveProvider() {
 }
 
 async function removeProvider(provider: BankEmailProvider) {
-  if (provider.supplier_id === null) return
+  if (provider.id === null || provider.supplier_id === null) return
   if (!window.confirm(t('bank_accounts.delete_provider_confirm', { name: provider.name }))) return
   try {
     await settingsApi.deleteBankEmailProvider(provider.id)
@@ -751,10 +757,12 @@ async function deleteMessage(m: BankEmailProcessedMessage) {
                   </select>
                 </td>
                 <td class="px-3 py-2">
-                  <select v-model.number="mapping.provider_id"
+                  <select v-model="mapping.provider_ref"
                     class="h-9 w-56 px-2 bg-surface border border-neutral-300 rounded-md text-sm">
                     <option :value="null">{{ t('bank_accounts.provider_auto') }}</option>
-                    <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }}</option>
+                    <option v-for="p in providers" :key="p.provider_ref" :value="p.provider_ref">
+                      {{ providerSelectLabel(p) }}
+                    </option>
                   </select>
                 </td>
                 <td class="px-3 py-2">
@@ -963,7 +971,7 @@ async function deleteMessage(m: BankEmailProcessedMessage) {
               <tr v-if="providers.length === 0">
                 <td colspan="6" class="px-3 py-4 text-sm text-neutral-500">{{ t('bank_accounts.providers_empty') }}</td>
               </tr>
-              <tr v-for="p in providers" :key="p.id">
+              <tr v-for="p in providers" :key="p.provider_ref">
                 <td class="px-3 py-2">
                   <div class="font-medium">{{ p.name }}</div>
                   <div class="text-xs text-neutral-500 font-mono">{{ p.code }}</div>
@@ -984,11 +992,11 @@ async function deleteMessage(m: BankEmailProcessedMessage) {
                   <span :class="p.enabled ? 'text-success-600' : 'text-neutral-500'">{{ p.enabled ? t('common.yes') : t('common.no') }}</span>
                 </td>
                 <td class="px-3 py-2 text-right whitespace-nowrap">
-                  <button v-if="p.supplier_id !== null && p.parser_type === 'regex'" type="button" @click="startEditProvider(p)"
+                  <button v-if="p.id !== null && p.supplier_id !== null && p.parser_type === 'regex'" type="button" @click="startEditProvider(p)"
                     class="cursor-pointer text-primary-600 hover:text-primary-700 text-xs">
                     {{ t('common.edit') }}
                   </button>
-                  <button v-if="p.supplier_id !== null" type="button" @click="removeProvider(p)"
+                  <button v-if="p.id !== null && p.supplier_id !== null" type="button" @click="removeProvider(p)"
                     class="cursor-pointer text-danger-600 hover:text-danger-700 text-xs ml-2">
                     {{ t('common.delete') }}
                   </button>
@@ -999,9 +1007,11 @@ async function deleteMessage(m: BankEmailProcessedMessage) {
         </div>
         <div class="p-5 border-t border-neutral-200">
             <h3 class="text-sm font-medium mb-2">{{ t('bank_accounts.parser_test_title') }}</h3>
-            <select v-model.number="parserProviderId" class="w-full h-10 px-3 bg-surface border border-neutral-300 rounded-md text-sm mb-2">
+            <select v-model="parserProviderRef" class="w-full h-10 px-3 bg-surface border border-neutral-300 rounded-md text-sm mb-2">
               <option :value="null">{{ t('bank_accounts.provider_auto') }}</option>
-              <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }}</option>
+              <option v-for="p in providers" :key="p.provider_ref" :value="p.provider_ref">
+                {{ providerSelectLabel(p) }}
+              </option>
             </select>
             <div class="grid md:grid-cols-2 gap-3 mb-2">
               <div>


### PR DESCRIPTION
- přidán typovaný provider a DI registry pro bankovní e-mailové parsery
- doplněny systémové parsery pro UniCredit Bank a ČSOB
- sjednocen výběr DB i systémových parserů přes provider_ref
- upraveno mapování bankovní účet / IMAP účet / parser
- rozšířeno UI o výběr všech dostupných parserů
- doplněna migrace pro parser_type a provider_code
- doplněny unit testy parserů a manuál

Refs #58 