### PR TITLE
Refaktoring parserů bankovních e-mailových avíz

### DIFF
--- a/api/src/Service/Bank/EmailNotice/Parser/AbstractBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/AbstractBankEmailNoticeParser.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Bank\EmailNotice\Parser;
+
+use MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer;
+
+abstract class AbstractBankEmailNoticeParser implements BankEmailNoticeParserInterface
+{
+    protected EmailNoticeTextNormalizer $normalizer;
+
+    public function __construct(?EmailNoticeTextNormalizer $normalizer = null)
+    {
+        $this->normalizer = $normalizer ?? new EmailNoticeTextNormalizer();
+    }
+
+    abstract public function defaultProvider(): ?BankEmailNoticeProvider;
+
+    protected function normalizeText(string $text): string
+    {
+        return $this->normalizer->normalize($text);
+    }
+
+    protected function compact(string $value): string
+    {
+        return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    protected function match(string $text, string $pattern): ?array
+    {
+        if (preg_match($pattern, $text, $m) !== 1) {
+            return null;
+        }
+        $out = [];
+        foreach ($m as $key => $value) {
+            if (is_string($key)) {
+                $out[$key] = trim((string) $value);
+            }
+        }
+        return $out;
+    }
+
+    protected function required(string $text, string $pattern, string $label): string
+    {
+        $value = $this->optional($text, $pattern);
+        if ($value === null) {
+            throw new \RuntimeException($this->parserLabel() . " parser nenašel {$label}.");
+        }
+        return $value;
+    }
+
+    protected function optional(string $text, string $pattern): ?string
+    {
+        $m = $this->match($text, $pattern);
+        if ($m === null || !isset($m['value'])) {
+            return null;
+        }
+        return $this->cleanNullable($m['value']);
+    }
+
+    protected function parseAmount(string $value): float
+    {
+        $value = preg_replace('/[^\d,.\-+]/u', '', trim($value)) ?? $value;
+        $negative = str_starts_with($value, '-');
+        $value = ltrim($value, '+-');
+
+        $lastComma = strrpos($value, ',');
+        $lastDot = strrpos($value, '.');
+        if ($lastComma !== false && $lastDot !== false) {
+            if ($lastDot > $lastComma) {
+                $value = str_replace(',', '', $value);
+            } else {
+                $value = str_replace('.', '', $value);
+                $value = str_replace(',', '.', $value);
+            }
+        } elseif ($lastComma !== false) {
+            $value = str_replace(',', '.', $value);
+        }
+
+        $amount = (float) $value;
+        return $negative ? -$amount : $amount;
+    }
+
+    protected function parseDate(string $value, string $label = 'validní datum platby'): string
+    {
+        $value = $this->compact($value);
+        foreach ([
+            'd.m.Y H:i:s',
+            'd.m.Y H:i',
+            'd. m. Y H:i:s',
+            'd. m. Y H:i',
+            'd.m.Y',
+            'd. m. Y',
+            \DateTimeInterface::ATOM,
+            \DateTimeInterface::RFC2822,
+        ] as $format) {
+            $dt = \DateTimeImmutable::createFromFormat($format, $value);
+            if ($dt instanceof \DateTimeImmutable) {
+                return $dt->format('Y-m-d');
+            }
+        }
+
+        try {
+            return (new \DateTimeImmutable($value))->format('Y-m-d');
+        } catch (\Throwable) {
+            throw new \RuntimeException($this->parserLabel() . " parser nenašel {$label}.");
+        }
+    }
+
+    /**
+     * @return array{0:?string,1:?string}
+     */
+    protected function splitAccount(string $value): array
+    {
+        $value = $this->normalizeAccount($value);
+        if ($value === '') {
+            return [null, null];
+        }
+        if (preg_match('/^(?<account>[0-9\-]+)\/(?<bank>[0-9]{4})$/', $value, $m) === 1) {
+            return [$m['account'], $m['bank']];
+        }
+        return [$value, null];
+    }
+
+    protected function normalizeAccount(string $value): string
+    {
+        $value = trim($value);
+        if (preg_match('/[0-9\-]+\/[0-9]{4}/', $value, $m) === 1) {
+            return $m[0];
+        }
+        return $value;
+    }
+
+    protected function normalizeSymbol(string $value): string
+    {
+        $digits = $this->digitsOnly($value);
+        $trimmed = ltrim($digits, '0');
+        return $trimmed !== '' ? $trimmed : $digits;
+    }
+
+    protected function digitsOnly(string $value): string
+    {
+        return preg_replace('/\D+/', '', $value) ?? '';
+    }
+
+    protected function cleanNullable(string $value): ?string
+    {
+        $value = $this->compact($value);
+        if ($value === '' || in_array(strtoupper($value), ['N/A', 'NA'], true)) {
+            return null;
+        }
+        return mb_substr($value, 0, 255);
+    }
+
+    protected function senderAllowed(string $sender, string $whitelist): bool
+    {
+        $whitelist = trim($whitelist);
+        if ($whitelist === '') {
+            return true;
+        }
+        $sender = strtolower($sender);
+        foreach (preg_split('/[\s,;]+/', strtolower($whitelist)) ?: [] as $allowed) {
+            $allowed = trim($allowed);
+            if ($allowed === '') {
+                continue;
+            }
+            if ($sender === $allowed || str_contains($sender, '<' . $allowed . '>')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function normalizeCurrency(string $value): string
+    {
+        $v = trim($value);
+        $upper = mb_strtoupper($v, 'UTF-8');
+        $map = [
+            'KČ' => 'CZK',
+            'KC' => 'CZK',
+            'CZK' => 'CZK',
+            '€' => 'EUR',
+            'EUR' => 'EUR',
+            '$' => 'USD',
+            'USD' => 'USD',
+            '£' => 'GBP',
+            'GBP' => 'GBP',
+            'ZŁ' => 'PLN',
+            'ZL' => 'PLN',
+            'PLN' => 'PLN',
+        ];
+        if (isset($map[$upper])) {
+            return $map[$upper];
+        }
+        if (isset($map[$v])) {
+            return $map[$v];
+        }
+        $letters = preg_replace('/[^A-ZÁ-Ž]/u', '', $upper) ?? $upper;
+        if (isset($map[$letters])) {
+            return $map[$letters];
+        }
+        return $letters !== '' ? mb_substr($letters, 0, 3, 'UTF-8') : $upper;
+    }
+
+    protected function applyDirection(float $amount, string $direction): float
+    {
+        $direction = mb_strtolower(trim($direction), 'UTF-8');
+        if ($direction === '') {
+            return $amount;
+        }
+        if (preg_match('/odchoz|výdej|vydej|debet|odepsán|odepsan|outgoing/u', $direction) === 1) {
+            return -abs($amount);
+        }
+        return abs($amount);
+    }
+
+    abstract protected function parserLabel(): string;
+}

--- a/api/src/Service/Bank/EmailNotice/Parser/CsobBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/CsobBankEmailNoticeParser.php
@@ -5,21 +5,18 @@ declare(strict_types=1);
 namespace MyInvoice\Service\Bank\EmailNotice\Parser;
 
 use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
-use MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer;
 use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
 
-final class CsobBankEmailNoticeParser implements BankEmailNoticeParserInterface
+final class CsobBankEmailNoticeParser extends AbstractBankEmailNoticeParser
 {
-    private EmailNoticeTextNormalizer $normalizer;
-
-    public function __construct(?EmailNoticeTextNormalizer $normalizer = null)
-    {
-        $this->normalizer = $normalizer ?? new EmailNoticeTextNormalizer();
-    }
-
     public function key(): string
     {
         return 'csob';
+    }
+
+    protected function parserLabel(): string
+    {
+        return 'ČSOB';
     }
 
     public function defaultProvider(): ?BankEmailNoticeProvider
@@ -55,7 +52,7 @@ final class CsobBankEmailNoticeParser implements BankEmailNoticeParserInterface
             return false;
         }
 
-        $text = $this->compact(mb_strtolower($this->normalizer->normalize($message->text), 'UTF-8'));
+        $text = $this->compact(mb_strtolower($this->normalizeText($message->text), 'UTF-8'));
         return str_contains($text, 'parametry platby')
             && (str_contains($text, 'vaše čsob') || str_contains($text, 'vase csob') || str_contains($text, 'čsob'))
             && (str_contains($text, 'částka') || str_contains($text, 'castka'));
@@ -63,7 +60,7 @@ final class CsobBankEmailNoticeParser implements BankEmailNoticeParserInterface
 
     public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
     {
-        $text = $this->normalizer->normalize($message->text);
+        $text = $this->normalizeText($message->text);
 
         $recipientAccount = $this->required(
             $text,
@@ -105,7 +102,7 @@ final class CsobBankEmailNoticeParser implements BankEmailNoticeParserInterface
             variableSymbol: $this->normalizeSymbol((string) $variableSymbol),
             amount: $this->parseAmount((string) $amountCurrency['amount']),
             currency: strtoupper((string) $amountCurrency['currency']),
-            postedAt: $this->parseDate($postedAt),
+            postedAt: $this->parseDate($postedAt, 'validní datum účtování'),
             recipientAccount: $recipientAccount,
             counterpartyAccount: $cpAccount,
             counterpartyBank: $cpBank,
@@ -114,90 +111,4 @@ final class CsobBankEmailNoticeParser implements BankEmailNoticeParserInterface
         );
     }
 
-    /**
-     * @return array<string,string>|null
-     */
-    private function match(string $text, string $pattern): ?array
-    {
-        if (preg_match($pattern, $text, $m) !== 1) {
-            return null;
-        }
-        $out = [];
-        foreach ($m as $key => $value) {
-            if (is_string($key)) {
-                $out[$key] = trim((string) $value);
-            }
-        }
-        return $out;
-    }
-
-    private function required(string $text, string $pattern, string $label): string
-    {
-        $value = $this->optional($text, $pattern);
-        if ($value === null) {
-            throw new \RuntimeException("ČSOB parser nenašel {$label}.");
-        }
-        return $value;
-    }
-
-    private function optional(string $text, string $pattern): ?string
-    {
-        $m = $this->match($text, $pattern);
-        if ($m === null || !isset($m['value'])) {
-            return null;
-        }
-        return $this->cleanNullable($m['value']);
-    }
-
-    private function parseAmount(string $value): float
-    {
-        $value = str_replace(["\xc2\xa0", ' ', '+'], '', trim($value));
-        $value = str_replace(',', '.', $value);
-        return (float) $value;
-    }
-
-    private function parseDate(string $value): string
-    {
-        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        foreach (['d.m.Y', 'd. m. Y'] as $format) {
-            $dt = \DateTimeImmutable::createFromFormat($format, $value);
-            if ($dt instanceof \DateTimeImmutable) {
-                return $dt->format('Y-m-d');
-            }
-        }
-        throw new \RuntimeException('ČSOB parser nenašel validní datum účtování.');
-    }
-
-    /**
-     * @return array{0:?string,1:?string}
-     */
-    private function splitAccount(string $value): array
-    {
-        $value = trim($value);
-        if ($value === '') {
-            return [null, null];
-        }
-        if (preg_match('/^(?<account>[0-9\-]+)\/(?<bank>[0-9]{4})$/', $value, $m) === 1) {
-            return [$m['account'], $m['bank']];
-        }
-        return [$value, null];
-    }
-
-    private function normalizeSymbol(string $value): string
-    {
-        $digits = preg_replace('/\D+/', '', $value) ?? '';
-        $trimmed = ltrim($digits, '0');
-        return $trimmed !== '' ? $trimmed : $digits;
-    }
-
-    private function cleanNullable(string $value): ?string
-    {
-        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        return $value !== '' ? mb_substr($value, 0, 255) : null;
-    }
-
-    private function compact(string $value): string
-    {
-        return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-    }
 }

--- a/api/src/Service/Bank/EmailNotice/Parser/RaiffeisenbankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/RaiffeisenbankEmailNoticeParser.php
@@ -5,21 +5,18 @@ declare(strict_types=1);
 namespace MyInvoice\Service\Bank\EmailNotice\Parser;
 
 use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
-use MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer;
 use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
 
-final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInterface
+final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParser
 {
-    private EmailNoticeTextNormalizer $normalizer;
-
-    public function __construct(?EmailNoticeTextNormalizer $normalizer = null)
-    {
-        $this->normalizer = $normalizer ?? new EmailNoticeTextNormalizer();
-    }
-
     public function key(): string
     {
         return 'raiffeisenbank';
+    }
+
+    protected function parserLabel(): string
+    {
+        return 'Raiffeisenbank';
     }
 
     public function defaultProvider(): ?BankEmailNoticeProvider
@@ -50,7 +47,7 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
         if (!str_contains($subject, 'pohyb na účtě') && !str_contains($subject, 'pohyb na ucte')) {
             return false;
         }
-        $text = mb_strtolower($this->normalizer->normalize($message->text));
+        $text = mb_strtolower($this->normalizeText($message->text));
         return str_contains($text, 'variabilní symbol')
             && str_contains($text, 'částka v měně účtu')
             && str_contains($text, 'na účet');
@@ -58,7 +55,7 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
 
     public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
     {
-        $text = $this->normalizer->normalize($message->text);
+        $text = $this->normalizeText($message->text);
 
         $postedAt = $this->required($text, '/Datum\s+a\s+čas\s*(?<value>\d{1,2}\.\s*\d{1,2}\.\s*\d{4}\s+\d{1,2}:\d{2})/iu', 'datum');
         $recipientAccount = $this->required($text, '/Na\s+účet\s*(?<value>[0-9\-]+\/[0-9]{4})/iu', 'cílový účet');
@@ -87,78 +84,4 @@ final class RaiffeisenbankEmailNoticeParser implements BankEmailNoticeParserInte
         );
     }
 
-    /**
-     * @return array<string,string>|null
-     */
-    private function match(string $text, string $pattern): ?array
-    {
-        if (preg_match($pattern, $text, $m) !== 1) {
-            return null;
-        }
-        $out = [];
-        foreach ($m as $key => $value) {
-            if (is_string($key)) {
-                $out[$key] = trim((string) $value);
-            }
-        }
-        return $out;
-    }
-
-    private function required(string $text, string $pattern, string $label): string
-    {
-        $value = $this->optional($text, $pattern);
-        if ($value === null) {
-            throw new \RuntimeException("Raiffeisenbank parser nenašel {$label}.");
-        }
-        return $value;
-    }
-
-    private function optional(string $text, string $pattern): ?string
-    {
-        $m = $this->match($text, $pattern);
-        if ($m === null || !isset($m['value'])) {
-            return null;
-        }
-        return $this->cleanNullable($m['value']);
-    }
-
-    private function parseAmount(string $value): float
-    {
-        $value = str_replace(["\xc2\xa0", ' ', '+', '.'], '', trim($value));
-        $value = str_replace(',', '.', $value);
-        return (float) $value;
-    }
-
-    private function parseDate(string $value): string
-    {
-        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        foreach (['d. m. Y H:i', 'd.m.Y H:i'] as $format) {
-            $dt = \DateTimeImmutable::createFromFormat($format, $value);
-            if ($dt instanceof \DateTimeImmutable) {
-                return $dt->format('Y-m-d');
-            }
-        }
-        throw new \RuntimeException('Raiffeisenbank parser nenašel validní datum platby.');
-    }
-
-    /**
-     * @return array{0:?string,1:?string}
-     */
-    private function splitAccount(string $value): array
-    {
-        $value = trim($value);
-        if ($value === '') {
-            return [null, null];
-        }
-        if (preg_match('/^(?<account>[0-9\-]+)\/(?<bank>[0-9]{4})$/', $value, $m) === 1) {
-            return [$m['account'], $m['bank']];
-        }
-        return [$value, null];
-    }
-
-    private function cleanNullable(string $value): ?string
-    {
-        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        return $value !== '' ? mb_substr($value, 0, 255) : null;
-    }
 }

--- a/api/src/Service/Bank/EmailNotice/Parser/RegexBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/RegexBankEmailNoticeParser.php
@@ -5,18 +5,10 @@ declare(strict_types=1);
 namespace MyInvoice\Service\Bank\EmailNotice\Parser;
 
 use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
-use MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer;
 use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
 
-final class RegexBankEmailNoticeParser implements BankEmailNoticeParserInterface
+final class RegexBankEmailNoticeParser extends AbstractBankEmailNoticeParser
 {
-    private EmailNoticeTextNormalizer $normalizer;
-
-    public function __construct(?EmailNoticeTextNormalizer $normalizer = null)
-    {
-        $this->normalizer = $normalizer ?? new EmailNoticeTextNormalizer();
-    }
-
     public function key(): string
     {
         return 'regex';
@@ -25,6 +17,11 @@ final class RegexBankEmailNoticeParser implements BankEmailNoticeParserInterface
     public function defaultProvider(): ?BankEmailNoticeProvider
     {
         return null;
+    }
+
+    protected function parserLabel(): string
+    {
+        return 'Regex';
     }
 
     public function supports(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): bool
@@ -37,7 +34,7 @@ final class RegexBankEmailNoticeParser implements BankEmailNoticeParserInterface
             return false;
         }
         $bodyPattern = trim((string) ($provider->bodyPattern ?? ''));
-        if ($bodyPattern !== '' && !preg_match('~' . $bodyPattern . '~iu', $this->normalizer->normalize($message->text))) {
+        if ($bodyPattern !== '' && !preg_match('~' . $bodyPattern . '~iu', $this->normalizeText($message->text))) {
             return false;
         }
         return true;
@@ -45,7 +42,7 @@ final class RegexBankEmailNoticeParser implements BankEmailNoticeParserInterface
 
     public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
     {
-        $text = $this->normalizer->normalize($message->text);
+        $text = $this->normalizeText($message->text);
         $patterns = $provider->fieldPatterns;
 
         $data = [];
@@ -91,7 +88,7 @@ final class RegexBankEmailNoticeParser implements BankEmailNoticeParserInterface
         $postedAt = $this->parseDate((string) $data['posted_at']);
 
         return new ParsedBankEmailNotice(
-            variableSymbol: preg_replace('/\D+/', '', (string) $data['variable_symbol']) ?? (string) $data['variable_symbol'],
+            variableSymbol: $this->digitsOnly((string) $data['variable_symbol']),
             amount: $this->applyDirection($this->parseAmount((string) $data['amount']), (string) ($data['direction'] ?? '')),
             currency: $this->normalizeCurrency((string) $data['currency']),
             postedAt: $postedAt,
@@ -103,127 +100,5 @@ final class RegexBankEmailNoticeParser implements BankEmailNoticeParserInterface
             message: $this->cleanNullable((string) ($data['message'] ?? '')),
             bankRef: $this->cleanNullable((string) ($data['bank_ref'] ?? '')),
         );
-    }
-
-    private function senderAllowed(string $sender, string $whitelist): bool
-    {
-        $whitelist = trim($whitelist);
-        if ($whitelist === '') {
-            return true;
-        }
-        $sender = strtolower($sender);
-        foreach (preg_split('/[\s,;]+/', strtolower($whitelist)) ?: [] as $allowed) {
-            $allowed = trim($allowed);
-            if ($allowed === '') {
-                continue;
-            }
-            if ($sender === $allowed || str_contains($sender, '<' . $allowed . '>')) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Sjednotí měnu na ISO kód. Banky často píší symbol „Kč" / „€" místo „CZK" / „EUR".
-     */
-    private function normalizeCurrency(string $value): string
-    {
-        $v = trim($value);
-        $upper = mb_strtoupper($v, 'UTF-8');
-        $map = [
-            'KČ' => 'CZK', 'KC' => 'CZK', 'CZK' => 'CZK',
-            '€' => 'EUR', 'EUR' => 'EUR',
-            '$' => 'USD', 'USD' => 'USD',
-            '£' => 'GBP', 'GBP' => 'GBP',
-            'ZŁ' => 'PLN', 'ZL' => 'PLN', 'PLN' => 'PLN',
-        ];
-        if (isset($map[$upper])) {
-            return $map[$upper];
-        }
-        if (isset($map[$v])) {
-            return $map[$v];
-        }
-        // Ponech jen písmena (odstraní tečky/mezery); 3-písmenný ISO kód vrať jak je.
-        $letters = preg_replace('/[^A-ZÁ-Ž]/u', '', $upper) ?? $upper;
-        if (isset($map[$letters])) {
-            return $map[$letters];
-        }
-        return $letters !== '' ? mb_substr($letters, 0, 3, 'UTF-8') : $upper;
-    }
-
-    /**
-     * Česká spořitelna nerozlišuje příjem/výdej znaménkem, ale řádkem
-     * „Směr platby: příchozí/odchozí". Odchozí platbu ulož se záporným znaménkem
-     * (konzistentní s GPC), ať se nepáruje proti pohledávkám.
-     */
-    private function applyDirection(float $amount, string $direction): float
-    {
-        $direction = mb_strtolower(trim($direction), 'UTF-8');
-        if ($direction === '') {
-            return $amount;
-        }
-        if (preg_match('/odchoz|výdej|vydej|debet|odepsán|odepsan|outgoing/u', $direction) === 1) {
-            return -abs($amount);
-        }
-        return abs($amount);
-    }
-
-    private function parseAmount(string $value): float
-    {
-        $v = str_replace(["\xc2\xa0", ' ', '+'], '', trim($value));
-        if (str_contains($v, ',') && str_contains($v, '.')) {
-            $v = str_replace('.', '', $v);
-            $v = str_replace(',', '.', $v);
-        } elseif (str_contains($v, ',')) {
-            $v = str_replace(',', '.', $v);
-        }
-        return (float) $v;
-    }
-
-    private function parseDate(string $value): string
-    {
-        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        foreach (['d. m. Y H:i', 'd.m.Y H:i', 'd. m. Y', 'd.m.Y', \DateTimeInterface::ATOM, \DateTimeInterface::RFC2822] as $fmt) {
-            $dt = \DateTimeImmutable::createFromFormat($fmt, $value);
-            if ($dt instanceof \DateTimeImmutable) {
-                return $dt->format('Y-m-d');
-            }
-        }
-        try {
-            return (new \DateTimeImmutable($value))->format('Y-m-d');
-        } catch (\Throwable) {
-            throw new \RuntimeException('Parser nenašel validní datum platby.');
-        }
-    }
-
-    /**
-     * @return array{0:?string,1:?string}
-     */
-    private function splitAccount(string $value): array
-    {
-        $value = $this->normalizeAccount($value);
-        if ($value === '') {
-            return [null, null];
-        }
-        if (preg_match('/^(?<account>[0-9\-]+)\/(?<bank>[0-9]{4})$/', $value, $m) === 1) {
-            return [$m['account'], $m['bank']];
-        }
-        return [$value, null];
-    }
-
-    private function normalizeAccount(string $value): string
-    {
-        $value = trim($value);
-        if (preg_match('/[0-9\-]+\/[0-9]{4}/', $value, $m) === 1) {
-            return $m[0];
-        }
-        return $value;
-    }
-
-    private function cleanNullable(string $value): ?string
-    {
-        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        return $value !== '' ? mb_substr($value, 0, 255) : null;
     }
 }

--- a/api/src/Service/Bank/EmailNotice/Parser/UnicreditBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/UnicreditBankEmailNoticeParser.php
@@ -5,21 +5,18 @@ declare(strict_types=1);
 namespace MyInvoice\Service\Bank\EmailNotice\Parser;
 
 use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
-use MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer;
 use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
 
-final class UnicreditBankEmailNoticeParser implements BankEmailNoticeParserInterface
+final class UnicreditBankEmailNoticeParser extends AbstractBankEmailNoticeParser
 {
-    private EmailNoticeTextNormalizer $normalizer;
-
-    public function __construct(?EmailNoticeTextNormalizer $normalizer = null)
-    {
-        $this->normalizer = $normalizer ?? new EmailNoticeTextNormalizer();
-    }
-
     public function key(): string
     {
         return 'unicredit';
+    }
+
+    protected function parserLabel(): string
+    {
+        return 'UniCredit Bank';
     }
 
     public function defaultProvider(): ?BankEmailNoticeProvider
@@ -55,7 +52,7 @@ final class UnicreditBankEmailNoticeParser implements BankEmailNoticeParserInter
             return false;
         }
 
-        $text = $this->compact(mb_strtolower($this->normalizer->normalize($message->text), 'UTF-8'));
+        $text = $this->compact(mb_strtolower($this->normalizeText($message->text), 'UTF-8'));
         return (str_contains($text, 'variabilní symbol') || str_contains($text, 'variabilni symbol'))
             && (str_contains($text, 'číslo účtu protistrany') || str_contains($text, 'cislo uctu protistrany'))
             && str_contains($text, 'unicredit bank');
@@ -63,7 +60,7 @@ final class UnicreditBankEmailNoticeParser implements BankEmailNoticeParserInter
 
     public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
     {
-        $text = $this->normalizer->normalize($message->text);
+        $text = $this->normalizeText($message->text);
 
         $recipientAccount = $this->required(
             $text,
@@ -112,109 +109,4 @@ final class UnicreditBankEmailNoticeParser implements BankEmailNoticeParserInter
         );
     }
 
-    /**
-     * @return array<string,string>|null
-     */
-    private function match(string $text, string $pattern): ?array
-    {
-        if (preg_match($pattern, $text, $m) !== 1) {
-            return null;
-        }
-        $out = [];
-        foreach ($m as $key => $value) {
-            if (is_string($key)) {
-                $out[$key] = trim((string) $value);
-            }
-        }
-        return $out;
-    }
-
-    private function required(string $text, string $pattern, string $label): string
-    {
-        $value = $this->optional($text, $pattern);
-        if ($value === null) {
-            throw new \RuntimeException("UniCredit Bank parser nenašel {$label}.");
-        }
-        return $value;
-    }
-
-    private function optional(string $text, string $pattern): ?string
-    {
-        $m = $this->match($text, $pattern);
-        if ($m === null || !isset($m['value'])) {
-            return null;
-        }
-        return $this->cleanNullable($m['value']);
-    }
-
-    private function parseAmount(string $value): float
-    {
-        $value = preg_replace('/[^\d,.\-+]/u', '', trim($value)) ?? $value;
-        $negative = str_starts_with($value, '-');
-        $value = ltrim($value, '+-');
-
-        $lastComma = strrpos($value, ',');
-        $lastDot = strrpos($value, '.');
-        if ($lastComma !== false && $lastDot !== false) {
-            if ($lastDot > $lastComma) {
-                $value = str_replace(',', '', $value);
-            } else {
-                $value = str_replace('.', '', $value);
-                $value = str_replace(',', '.', $value);
-            }
-        } elseif ($lastComma !== false) {
-            $value = str_replace(',', '.', $value);
-        }
-
-        $amount = (float) $value;
-        return $negative ? -$amount : $amount;
-    }
-
-    private function parseDate(string $value): string
-    {
-        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        foreach (['d.m.Y H:i:s', 'd.m.Y H:i', 'd. m. Y H:i:s', 'd. m. Y H:i'] as $format) {
-            $dt = \DateTimeImmutable::createFromFormat($format, $value);
-            if ($dt instanceof \DateTimeImmutable) {
-                return $dt->format('Y-m-d');
-            }
-        }
-        throw new \RuntimeException('UniCredit Bank parser nenašel validní datum platby.');
-    }
-
-    /**
-     * @return array{0:?string,1:?string}
-     */
-    private function splitAccount(string $value): array
-    {
-        $value = trim($value);
-        if ($value === '') {
-            return [null, null];
-        }
-        if (preg_match('/^(?<account>[0-9\-]+)\/(?<bank>[0-9]{4})$/', $value, $m) === 1) {
-            return [$m['account'], $m['bank']];
-        }
-        return [$value, null];
-    }
-
-    private function normalizeSymbol(string $value): string
-    {
-        $digits = preg_replace('/\D+/', '', $value) ?? '';
-        $trimmed = ltrim($digits, '0');
-        return $trimmed !== '' ? $trimmed : $digits;
-    }
-
-    private function cleanNullable(string $value): ?string
-    {
-        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-        if ($value === '' || in_array(strtoupper($value), ['N/A', 'NA'], true)) {
-            return null;
-        }
-        return mb_substr($value, 0, 255);
-    }
-
-    private function compact(string $value): string
-    {
-        return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
-    }
 }


### PR DESCRIPTION
  - přidává společný AbstractBankEmailNoticeParser
  - přesouvá sdílené helpery pro normalizaci, regexy, datumy, částky, účty a symboly
  - zachovává bank-specific supports() a parse() logiku v konkrétních parserech
  - sjednocuje regex parser se stejnou pomocnou vrstvou