### PR TITLE
feat: Přidání exportu vydaných faktur pro Kastner Stereo

### DIFF
--- a/api/src/Action/Admin/ExportAction.php
+++ b/api/src/Action/Admin/ExportAction.php
@@ -14,6 +14,7 @@ use MyInvoice\Service\Export\ExportPeriod;
 use MyInvoice\Service\Export\ExportPeriodResolver;
 use MyInvoice\Service\Export\IsdocExporter;
 use MyInvoice\Service\Export\PohodaXmlExporter;
+use MyInvoice\Service\Export\StereoXmlExporter;
 use MyInvoice\Service\IpMatcher;
 use MyInvoice\Service\Pdf\InvoicePdfRenderer;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -24,8 +25,8 @@ use ZipArchive;
 /**
  * Generický export faktur za měsíc nebo čtvrtletí do různých formátů:
  *
- *   GET /api/admin/export?format=pdf-zip|isdoc|pohoda&month=YYYY-MM[&type=invoice][&date_by=issue|tax]
- *   GET /api/admin/export?format=pdf-zip|isdoc|pohoda&period=quarterly&year=YYYY&quarter=1..4
+ *   GET /api/admin/export?format=pdf-zip|isdoc|pohoda|stereo&month=YYYY-MM[&type=invoice][&date_by=issue|tax]
+ *   GET /api/admin/export?format=pdf-zip|isdoc|pohoda|stereo&period=quarterly&year=YYYY&quarter=1..4
  *
  * Sdílený filter: period + type + date_by + supplier_id (z X-Supplier-Id middleware).
  * Per-format: výstup MIME a filename.
@@ -40,6 +41,7 @@ final class ExportAction
         private readonly InvoicePdfRenderer $pdf,
         private readonly IsdocExporter $isdoc,
         private readonly PohodaXmlExporter $pohoda,
+        private readonly StereoXmlExporter $stereo,
         private readonly ExportPeriodResolver $periodResolver,
         private readonly ActivityLogger $logger,
         private readonly IpMatcher $ipMatcher,
@@ -80,6 +82,7 @@ final class ExportAction
                 'pdf-zip' => $this->buildPdfZip($ids, $period, $type, $userId),
                 'isdoc'   => $this->buildIsdoc($ids, $period),
                 'pohoda'  => $this->buildPohoda($ids, $sid, $period),
+                'stereo'  => $this->buildStereo($ids, $period),
                 default   => throw new \InvalidArgumentException("Neznámý formát: $format"),
             };
         } catch (\InvalidArgumentException $e) {
@@ -188,6 +191,16 @@ final class ExportAction
     private function buildPohoda(array $ids, int $sid, ExportPeriod $period): array
     {
         $r = $this->pohoda->export($ids, $sid, $period->label);
+        return [$r['filename'], $r['content'], $r['mime']];
+    }
+
+    /**
+     * @param int[] $ids
+     * @return array{0:string,1:string,2:string}
+     */
+    private function buildStereo(array $ids, ExportPeriod $period): array
+    {
+        $r = $this->stereo->export($ids, $period->label);
         return [$r['filename'], $r['content'], $r['mime']];
     }
 }

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -63,6 +63,7 @@ final class InvoiceRepository
                     c.ic AS client_ic, c.dic AS client_dic,
                     c.language AS client_language,
                     c.reverse_charge AS client_reverse_charge,
+                    u.name AS created_by_name,
                     p.name AS project_name, p.hourly_rate AS project_hourly_rate,
                     p.payment_due_days AS project_payment_due_days,
                     p.project_number AS project_number, p.contract_number AS contract_number,
@@ -74,6 +75,7 @@ final class InvoiceRepository
                     rcat.label AS revenue_category_label, rcat.code AS revenue_category_code
                FROM invoices i
                JOIN clients c ON c.id = i.client_id
+          LEFT JOIN users u ON u.id = i.created_by
           LEFT JOIN projects p ON p.id = i.project_id
                JOIN currencies cur ON cur.id = i.currency_id
           LEFT JOIN revenue_categories rcat ON rcat.id = i.revenue_category_id

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -349,7 +349,7 @@ final class Routes
         $app->get    ('/api/admin/cron-jobs',       CronJobsAction::class);
         $app->post   ('/api/admin/cron-jobs/{script:cron-[a-z0-9-]+}/run', RunCronJobAction::class);
         $app->get    ('/api/admin/invoices-zip',    InvoicesZipAction::class);  // legacy — drží se kvůli historickým bookmark URL
-        $app->get    ('/api/admin/export',          ExportAction::class);       // generic export (?format=pdf-zip|isdoc|pohoda&month=YYYY-MM nebo period=quarterly)
+        $app->get    ('/api/admin/export',          ExportAction::class);       // generic export (?format=pdf-zip|isdoc|pohoda|stereo&month=YYYY-MM nebo period=quarterly)
         $app->post   ('/api/admin/import',          ImportAction::class);       // import vystavených faktur z Pohoda XML / ISDOC (single nebo ZIP)
 
         // iDoklad API import (fáze 2a) — credentials + background job lifecycle

--- a/api/src/Service/Export/InvoiceExportDataResolver.php
+++ b/api/src/Service/Export/InvoiceExportDataResolver.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Export;
+
+use MyInvoice\Infrastructure\Database\Connection;
+
+/**
+ * Shared party/payment data resolver for invoice XML exports.
+ *
+ * Issued invoices should use immutable snapshots, but legacy/imported data may
+ * miss snapshots or individual snapshot fields. Live rows are therefore used as
+ * a defensive base and snapshots win when present.
+ */
+final class InvoiceExportDataResolver
+{
+    public function __construct(private readonly Connection $db) {}
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @return array<string,mixed>
+     */
+    public function supplier(array $invoice): array
+    {
+        $live = $this->loadLiveSupplier((int) ($invoice['supplier_id'] ?? 0));
+        $snapshot = $this->snapshot($invoice['supplier_snapshot'] ?? null);
+
+        return $snapshot !== [] ? array_merge($live, $snapshot) : $live;
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @return array<string,mixed>
+     */
+    public function client(array $invoice): array
+    {
+        $live = $this->loadLiveClient((int) ($invoice['client_id'] ?? 0));
+        $snapshot = $this->snapshot($invoice['client_snapshot'] ?? null);
+        if ($snapshot !== []) {
+            return array_merge($live, $snapshot);
+        }
+        if ($live !== []) {
+            return $live;
+        }
+
+        return [
+            'company_name' => $invoice['client_company_name'] ?? '',
+            'ic' => $invoice['client_ic'] ?? '',
+            'dic' => $invoice['client_dic'] ?? '',
+            'main_email' => $invoice['client_main_email'] ?? '',
+            'country_iso2' => 'CZ',
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @return array<string,mixed>|null
+     */
+    public function bank(array $invoice): ?array
+    {
+        $snapshot = $this->snapshot($invoice['bank_snapshot'] ?? null);
+        if ($snapshot !== []) {
+            return $snapshot;
+        }
+        if (!empty($invoice['bank_account_number']) || !empty($invoice['bank_iban'])) {
+            return [
+                'account_number' => $invoice['bank_account_number'] ?? null,
+                'bank_code' => $invoice['bank_code'] ?? null,
+                'bank_name' => $invoice['bank_name'] ?? null,
+                'iban' => $invoice['bank_iban'] ?? null,
+                'bic' => $invoice['bank_bic'] ?? null,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    public function issuePerson(array $invoice): string
+    {
+        $direct = $this->nonEmptyString($invoice['issue_person'] ?? null)
+            ?? $this->nonEmptyString($invoice['created_by_name'] ?? null)
+            ?? $this->nonEmptyString($invoice['user_name'] ?? null);
+        if ($direct !== null) {
+            return $direct;
+        }
+
+        $userId = (int) ($invoice['created_by'] ?? 0);
+        if ($userId <= 0) {
+            return '';
+        }
+
+        try {
+            $stmt = $this->db->pdo()->prepare('SELECT name FROM users WHERE id = ? LIMIT 1');
+            $stmt->execute([$userId]);
+            $name = $stmt->fetchColumn();
+        } catch (\Throwable) {
+            return '';
+        }
+
+        return $this->nonEmptyString($name) ?? '';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if (!is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function loadLiveSupplier(int $supplierId): array
+    {
+        if ($supplierId <= 0) {
+            return [];
+        }
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT s.*, co.iso2 AS country_iso2, co.name_cs AS country_name_cs, co.name_en AS country_name_en
+               FROM supplier s
+               JOIN countries co ON co.id = s.country_id
+              WHERE s.id = ?'
+        );
+        $stmt->execute([$supplierId]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        return is_array($row) ? $row : [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function loadLiveClient(int $clientId): array
+    {
+        if ($clientId <= 0) {
+            return [];
+        }
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT c.*, co.iso2 AS country_iso2, co.name_cs AS country_name_cs, co.name_en AS country_name_en
+               FROM clients c
+               JOIN countries co ON co.id = c.country_id
+              WHERE c.id = ?'
+        );
+        $stmt->execute([$clientId]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        return is_array($row) ? $row : [];
+    }
+
+    private function nonEmptyString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $string = trim((string) $value);
+        return $string !== '' ? $string : null;
+    }
+}

--- a/api/src/Service/Export/IsdocExporter.php
+++ b/api/src/Service/Export/IsdocExporter.php
@@ -87,11 +87,15 @@ final class IsdocExporter
      */
     private float $exportRate = 1.0;
     private bool $exportForeign = false;
+    private readonly InvoiceExportDataResolver $dataResolver;
 
     public function __construct(
         private readonly InvoiceRepository $repo,
         private readonly Connection $db,
-    ) {}
+        ?InvoiceExportDataResolver $dataResolver = null,
+    ) {
+        $this->dataResolver = $dataResolver ?? new InvoiceExportDataResolver($db);
+    }
 
     /**
      * @param int[] $invoiceIds
@@ -479,80 +483,17 @@ final class IsdocExporter
 
     private function resolveSupplier(array $invoice): array
     {
-        // Live data ze supplier tabulky (defenzivní base — pro legacy faktury s prázdným
-        // snapshotem a pro chybějící klíče v starších snapshotech). Snapshot vyhrává nad
-        // live (zachovává historický stav vystavené faktury).
-        $live = $this->loadLiveSupplier((int) ($invoice['supplier_id'] ?? 0));
-        if (!empty($invoice['supplier_snapshot'])) {
-            $snap = is_string($invoice['supplier_snapshot']) ? json_decode($invoice['supplier_snapshot'], true) : $invoice['supplier_snapshot'];
-            if (is_array($snap)) {
-                return array_merge($live, $snap);
-            }
-        }
-        return $live;
+        return $this->dataResolver->supplier($invoice);
     }
 
     private function resolveClient(array $invoice): array
     {
-        $live = $this->loadLiveClient((int) ($invoice['client_id'] ?? 0));
-        if (!empty($invoice['client_snapshot'])) {
-            $snap = is_string($invoice['client_snapshot']) ? json_decode($invoice['client_snapshot'], true) : $invoice['client_snapshot'];
-            if (is_array($snap)) {
-                return array_merge($live, $snap);
-            }
-        }
-        // Final fallback: invoice repo joinuje basic client fields (legacy data bez clients
-        // záznamu — např. smazaný klient).
-        if (empty($live)) {
-            return [
-                'company_name' => $invoice['client_company_name'] ?? '',
-                'ic' => $invoice['client_ic'] ?? '',
-                'dic' => $invoice['client_dic'] ?? '',
-                'main_email' => $invoice['client_main_email'] ?? '',
-                'country_iso2' => 'CZ',
-            ];
-        }
-        return $live;
-    }
-
-    private function loadLiveSupplier(int $supplierId): array
-    {
-        if ($supplierId <= 0) return [];
-        $stmt = $this->db->pdo()->prepare(
-            'SELECT s.*, co.iso2 AS country_iso2, co.name_cs AS country_name_cs, co.name_en AS country_name_en
-               FROM supplier s JOIN countries co ON co.id = s.country_id WHERE s.id = ?'
-        );
-        $stmt->execute([$supplierId]);
-        return $stmt->fetch(\PDO::FETCH_ASSOC) ?: [];
-    }
-
-    private function loadLiveClient(int $clientId): array
-    {
-        if ($clientId <= 0) return [];
-        $stmt = $this->db->pdo()->prepare(
-            'SELECT c.*, co.iso2 AS country_iso2, co.name_cs AS country_name_cs, co.name_en AS country_name_en
-               FROM clients c JOIN countries co ON co.id = c.country_id WHERE c.id = ?'
-        );
-        $stmt->execute([$clientId]);
-        return $stmt->fetch(\PDO::FETCH_ASSOC) ?: [];
+        return $this->dataResolver->client($invoice);
     }
 
     private function resolveBank(array $invoice): ?array
     {
-        if (!empty($invoice['bank_snapshot'])) {
-            $snap = is_string($invoice['bank_snapshot']) ? json_decode($invoice['bank_snapshot'], true) : $invoice['bank_snapshot'];
-            if (is_array($snap)) return $snap;
-        }
-        if (!empty($invoice['bank_account_number']) || !empty($invoice['bank_iban'])) {
-            return [
-                'account_number' => $invoice['bank_account_number'] ?? null,
-                'bank_code'      => $invoice['bank_code'] ?? null,
-                'bank_name'      => $invoice['bank_name'] ?? null,
-                'iban'           => $invoice['bank_iban'] ?? null,
-                'bic'            => $invoice['bank_bic'] ?? null,
-            ];
-        }
-        return null;
+        return $this->dataResolver->bank($invoice);
     }
 
     private function el(\DOMDocument $dom, \DOMElement $parent, string $name, string $value): \DOMElement

--- a/api/src/Service/Export/PohodaXmlExporter.php
+++ b/api/src/Service/Export/PohodaXmlExporter.php
@@ -43,11 +43,16 @@ final class PohodaXmlExporter
     public const NS_INV = 'http://www.stormware.cz/schema/version_2/invoice.xsd';
     public const NS_TYP = 'http://www.stormware.cz/schema/version_2/type.xsd';
 
+    private readonly InvoiceExportDataResolver $dataResolver;
+
     public function __construct(
         private readonly InvoiceRepository $repo,
         private readonly Connection $db,
         private readonly TaxConstantsRepository $taxConstants,
-    ) {}
+        ?InvoiceExportDataResolver $dataResolver = null,
+    ) {
+        $this->dataResolver = $dataResolver ?? new InvoiceExportDataResolver($db);
+    }
 
     /**
      * Hranice základní sazby (bucket high vs low) pro rok dokladu — z číselníku
@@ -353,39 +358,7 @@ final class PohodaXmlExporter
 
     private function resolveClient(array $invoice): array
     {
-        // Live data ze clients tabulky jako defensive base (pro legacy faktury
-        // s prázdným snapshotem nebo snapshoty bez všech polí — chybějící
-        // street/city/zip/country v Pohoda XML by jinak vyrobilo prázdný
-        // partner address). Snapshot vyhrává nad live (zachovává historický
-        // stav vystavené faktury). Stejný pattern jako v IsdocExporter.
-        $live = $this->loadLiveClient((int) ($invoice['client_id'] ?? 0));
-        if (!empty($invoice['client_snapshot'])) {
-            $snap = is_string($invoice['client_snapshot']) ? json_decode($invoice['client_snapshot'], true) : $invoice['client_snapshot'];
-            if (is_array($snap)) {
-                return array_merge($live, $snap);
-            }
-        }
-        if (empty($live)) {
-            return [
-                'company_name' => $invoice['client_company_name'] ?? '',
-                'ic' => $invoice['client_ic'] ?? '',
-                'dic' => $invoice['client_dic'] ?? '',
-                'main_email' => $invoice['client_main_email'] ?? '',
-                'country_iso2' => 'CZ',
-            ];
-        }
-        return $live;
-    }
-
-    private function loadLiveClient(int $clientId): array
-    {
-        if ($clientId <= 0) return [];
-        $stmt = $this->db->pdo()->prepare(
-            'SELECT c.*, co.iso2 AS country_iso2, co.name_cs AS country_name_cs, co.name_en AS country_name_en
-               FROM clients c JOIN countries co ON co.id = c.country_id WHERE c.id = ?'
-        );
-        $stmt->execute([$clientId]);
-        return $stmt->fetch(\PDO::FETCH_ASSOC) ?: [];
+        return $this->dataResolver->client($invoice);
     }
 
     private function fmt(float $value): string

--- a/api/src/Service/Export/StereoVatTypeResolver.php
+++ b/api/src/Service/Export/StereoVatTypeResolver.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Export;
+
+/**
+ * Resolves MyInvoice VAT classification codes to Stereo TypeOfVAT metadata.
+ *
+ * First iteration is intentionally hard-coded. The source of truth is the
+ * invoice item classification; invoice header and conservative sale defaults
+ * are used only as fallbacks.
+ */
+final class StereoVatTypeResolver
+{
+    /** @var array<string, string> */
+    private const TYPE_OF_VAT_BY_CLASSIFICATION_CODE = [
+        '1' => 'U',      // Tuzemské plnění, základní sazba
+        '2' => 'U',      // Tuzemské plnění, snížená sazba
+        '3' => 'UO',     // Tuzemské osvobozené plnění
+        '20' => 'IDZ',   // Dodání zboží do jiného členského státu
+        '22' => 'UVSP',  // Poskytnutí služby s místem plnění mimo tuzemsko
+        '25S' => 'URP',  // Tuzemský režim přenesení daňové povinnosti
+        '26' => 'UV',    // Vývoz zboží
+    ];
+
+    /** @var list<string> */
+    private const EU_COUNTRIES = [
+        'AT', 'BE', 'BG', 'HR', 'CY', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU',
+        'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI',
+        'ES', 'SE',
+    ];
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @param array<string,mixed> $item
+     * @return array{classification_code:?string,type_of_vat:?string,process_vat:bool,reverse_charge:bool}
+     */
+    public function resolveRow(array $invoice, array $item): array
+    {
+        $classificationCode = $this->classificationCode($invoice, $item);
+        $normalizedCode = $classificationCode !== null ? $this->normalizeCode($classificationCode) : null;
+
+        return [
+            'classification_code' => $classificationCode,
+            'type_of_vat' => $normalizedCode !== null ? $this->typeOfVat($normalizedCode) : null,
+            'process_vat' => false,
+            'reverse_charge' => $this->isReverseCharge($normalizedCode),
+        ];
+    }
+
+    /**
+     * Stereo TypeOfVAT is a document-wide setting. Prefer the invoice header
+     * classification when present; otherwise require all rows to resolve to the
+     * same Stereo type.
+     *
+     * @param array<string,mixed> $invoice
+     * @param list<array{classification_code:?string,type_of_vat:?string,process_vat:bool,reverse_charge:bool}> $rowResolutions
+     * @return array{classification_code:?string,type_of_vat:string,process_vat:bool,reverse_charge:bool}|null
+     */
+    public function resolveDocument(array $invoice, array $rowResolutions): ?array
+    {
+        $headerCode = $this->nonEmptyString($invoice['vat_classification_code'] ?? null);
+        if ($headerCode !== null) {
+            $normalizedCode = $this->normalizeCode($headerCode);
+            $typeOfVat = $this->typeOfVat($normalizedCode);
+            if ($typeOfVat !== null) {
+                $reverseCharge = $this->isReverseCharge($normalizedCode);
+                return [
+                    'classification_code' => $headerCode,
+                    'type_of_vat' => $typeOfVat,
+                    'process_vat' => false,
+                    'reverse_charge' => $reverseCharge,
+                ];
+            }
+        }
+
+        if ($rowResolutions === []) {
+            return null;
+        }
+
+        $byType = [];
+        $unresolvedCodes = [];
+        foreach ($rowResolutions as $resolution) {
+            $type = $resolution['type_of_vat'] ?? null;
+            if ($type === null) {
+                $unresolvedCodes[] = $resolution['classification_code'] ?? '?';
+                continue;
+            }
+            $byType[$type] ??= [
+                'classification_code' => $resolution['classification_code'] ?? null,
+                'type_of_vat' => $type,
+                'process_vat' => false,
+                'reverse_charge' => !empty($resolution['reverse_charge']),
+            ];
+            $byType[$type]['reverse_charge'] = $byType[$type]['reverse_charge'] || !empty($resolution['reverse_charge']);
+        }
+
+        if ($unresolvedCodes !== [] || count($byType) > 1) {
+            throw new \RuntimeException(sprintf(
+                'Stereo XML vyžaduje jeden Typ DPH pro celý doklad %s. Nalezené typy: %s%s.',
+                $this->documentLabel($invoice),
+                implode(', ', array_keys($byType)) ?: '-',
+                $unresolvedCodes !== [] ? '; nepřeložené kódy: ' . implode(', ', array_unique($unresolvedCodes)) : '',
+            ));
+        }
+
+        if ($byType === []) {
+            return null;
+        }
+
+        /** @var array{classification_code:?string,type_of_vat:string,process_vat:bool,reverse_charge:bool} */
+        return reset($byType);
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @param array{type_of_vat:string}|null $documentResolution
+     */
+    public function documentProcessVat(array $invoice, ?array $documentResolution): ?bool
+    {
+        if ($documentResolution === null) {
+            return null;
+        }
+
+        return (string) ($invoice['invoice_type'] ?? '') !== 'proforma';
+    }
+
+    /**
+     * @param array{reverse_charge:bool}|null $documentResolution
+     */
+    public function documentReverseCharge(?array $documentResolution): ?bool
+    {
+        if ($documentResolution === null) {
+            return null;
+        }
+
+        return !empty($documentResolution['reverse_charge']);
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @param array<string,mixed> $item
+     */
+    private function classificationCode(array $invoice, array $item): ?string
+    {
+        return $this->nonEmptyString($item['vat_classification_code'] ?? null)
+            ?? $this->nonEmptyString($invoice['vat_classification_code'] ?? null)
+            ?? $this->defaultSaleClassificationCode(
+                (float) ($item['vat_rate_snapshot'] ?? 0),
+                !empty($invoice['reverse_charge']),
+                $this->clientCountryIso2($invoice),
+            );
+    }
+
+    private function defaultSaleClassificationCode(float $vatRate, bool $reverseCharge, string $clientCountryIso2): string
+    {
+        $rate = (int) round($vatRate);
+        $country = strtoupper($clientCountryIso2) ?: 'CZ';
+        $isForeign = $country !== 'CZ';
+        $isEu = in_array($country, self::EU_COUNTRIES, true);
+
+        if ($reverseCharge && !$isForeign) {
+            return '25s';
+        }
+        if ($isForeign && $rate === 0) {
+            return $isEu ? '22' : '26';
+        }
+        if ($rate >= 21) {
+            return '1';
+        }
+        if ($rate >= 5 && $rate <= 15) {
+            return '2';
+        }
+
+        return '3';
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    private function clientCountryIso2(array $invoice): string
+    {
+        $snapshot = $this->snapshot($invoice['client_snapshot'] ?? null);
+        $country = $this->nonEmptyString($snapshot['country_iso2'] ?? null)
+            ?? $this->nonEmptyString($invoice['client_country_iso2'] ?? null)
+            ?? 'CZ';
+
+        return strtoupper($country);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if (!is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function nonEmptyString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $string = trim((string) $value);
+        return $string !== '' ? $string : null;
+    }
+
+    private function normalizeCode(string $code): string
+    {
+        return strtoupper(trim($code));
+    }
+
+    private function typeOfVat(string $normalizedCode): ?string
+    {
+        return self::TYPE_OF_VAT_BY_CLASSIFICATION_CODE[$normalizedCode] ?? null;
+    }
+
+    private function isReverseCharge(?string $normalizedCode): bool
+    {
+        return $normalizedCode === '25S';
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    private function documentLabel(array $invoice): string
+    {
+        $label = $this->nonEmptyString($invoice['varsymbol'] ?? null)
+            ?? $this->nonEmptyString($invoice['id'] ?? null)
+            ?? '?';
+
+        return '#' . $label;
+    }
+}

--- a/api/src/Service/Export/StereoXmlExporter.php
+++ b/api/src/Service/Export/StereoXmlExporter.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Export;
+
+use DOMDocument;
+use DOMElement;
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Repository\InvoiceRepository;
+
+/**
+ * Stereo for Windows DocumentPack exporter for issued invoices.
+ *
+ * The format uses "net" in the accounting sense: line base without VAT. Keep
+ * LineNet tied to invoice_items.total_without_vat, not to total_with_vat.
+ */
+final class StereoXmlExporter
+{
+    private readonly InvoiceExportDataResolver $dataResolver;
+    private readonly StereoVatTypeResolver $vatTypeResolver;
+
+    public function __construct(
+        private readonly InvoiceRepository $repo,
+        Connection $db,
+        ?InvoiceExportDataResolver $dataResolver = null,
+        ?StereoVatTypeResolver $vatTypeResolver = null,
+    ) {
+        $this->dataResolver = $dataResolver ?? new InvoiceExportDataResolver($db);
+        $this->vatTypeResolver = $vatTypeResolver ?? new StereoVatTypeResolver();
+    }
+
+    /**
+     * @param int[] $invoiceIds
+     * @return array{filename:string, content:string, mime:string}
+     */
+    public function export(array $invoiceIds, string $periodLabel = ''): array
+    {
+        $invoices = [];
+        foreach ($invoiceIds as $id) {
+            $invoice = $this->repo->find((int) $id);
+            if ($invoice !== null && !empty($invoice['items']) && is_array($invoice['items'])) {
+                $invoices[] = $invoice;
+            }
+        }
+
+        if ($invoices === []) {
+            throw new \RuntimeException('Žádné faktury s položkami k exportu do Stereo XML.');
+        }
+
+        $base = 'stereo-' . ($periodLabel !== '' ? $periodLabel : date('Y-m-d'));
+        return [
+            'filename' => "$base.xml",
+            'content' => $this->buildXml($invoices),
+            'mime' => 'application/xml',
+        ];
+    }
+
+    /**
+     * @param list<array<string,mixed>> $invoices
+     */
+    public function buildXml(array $invoices): string
+    {
+        $xml = new DOMDocument('1.0', 'UTF-8');
+        $xml->preserveWhiteSpace = false;
+        $xml->formatOutput = true;
+
+        $root = $xml->appendChild($xml->createElement('DocumentPack'));
+        $header = $root->appendChild($xml->createElement('HEADER'));
+        $source = $header->appendChild($xml->createElement('Source'));
+        $this->el($xml, $source, 'SoftwareVendor', 'myinvoice.cz');
+        $this->el($xml, $source, 'SoftwareProduct', 'myinvoice.cz');
+        $this->el($xml, $source, 'SoftwareVersion', date('YmdHis'));
+
+        $root->appendChild($xml->createElement('PARAMETERS'));
+        $documents = $root->appendChild($xml->createElement('DOCUMENTS'));
+
+        foreach ($invoices as $invoice) {
+            $documents->appendChild($this->documentNode($xml, $invoice));
+        }
+
+        return $xml->saveXML() ?: '';
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    private function documentNode(DOMDocument $xml, array $invoice): DOMElement
+    {
+        $document = $xml->createElement('Document');
+
+        $header = $document->appendChild($xml->createElement('DocumentHeader'));
+        $this->el($xml, $header, 'DocumentID', (string) ($invoice['varsymbol'] ?? $invoice['id'] ?? ''));
+        $this->el($xml, $header, 'TypeOfDocument', 'Invoice');
+        $this->el($xml, $header, 'DocumentCaption', $this->documentCaption((string) ($invoice['invoice_type'] ?? 'invoice')));
+
+        $supplier = $this->supplierData($invoice);
+        if ($supplier !== []) {
+            $document->appendChild($this->partyNode($xml, 'Suplier', $supplier, true));
+        }
+
+        $client = $this->clientData($invoice);
+        $document->appendChild($this->partyNode($xml, 'Buyer', $client, false));
+
+        $issue = $document->appendChild($xml->createElement('Issue'));
+        $this->el($xml, $issue, 'IssuePerson', $this->issuePerson($invoice));
+        $this->el($xml, $issue, 'IssueDate', $this->dateTime((string) ($invoice['issue_date'] ?? '')));
+
+        $bank = $this->bankData($invoice);
+        $currencyIso = $this->currencyIso($invoice);
+        $currency = $this->stereoCurrencyCode($invoice);
+
+        $payment = $document->appendChild($xml->createElement('Payment'));
+        $this->el($xml, $payment, 'PaymentType', $this->paymentType((string) ($invoice['payment_method'] ?? '')));
+        $this->el($xml, $payment, 'DueDate', $this->date((string) ($invoice['due_date'] ?? $invoice['issue_date'] ?? '')));
+        $this->el($xml, $payment, 'CurrencyCode', $currency);
+        $this->el($xml, $payment, 'BankAccount', (string) ($bank['account_number'] ?? ''));
+        $this->el($xml, $payment, 'BankCode', (string) ($bank['bank_code'] ?? ''));
+        if (!empty($bank['iban'])) {
+            $this->el($xml, $payment, 'IBAN', (string) $bank['iban']);
+        }
+        if (!empty($bank['bic'])) {
+            $this->el($xml, $payment, 'Swift', (string) $bank['bic']);
+        }
+        $this->el($xml, $payment, 'VariableSymbol', (string) ($invoice['varsymbol'] ?? ''));
+        $this->el($xml, $payment, 'ConstantSymbol', (string) ($invoice['constant_symbol'] ?? ''));
+        if (!empty($bank['bank_name'])) {
+            $this->el($xml, $payment, 'BankName', (string) $bank['bank_name']);
+        }
+        if (!empty($invoice['exchange_rate']) && $currencyIso !== 'CZK') {
+            $this->el($xml, $payment, 'CurrencyRate', $this->fmt((float) $invoice['exchange_rate']));
+            $this->el($xml, $payment, 'CurrencyAmount', '1.00');
+        }
+
+        $this->appendVatTotalsAndRows($xml, $document, $invoice);
+
+        return $document;
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    private function appendVatTotalsAndRows(DOMDocument $xml, DOMElement $document, array $invoice): void
+    {
+        $currency = $this->currencyCode($invoice);
+        $vatRates = [];
+        $lineCount = 0;
+        $items = [];
+        $rowVatResolutions = [];
+
+        foreach (($invoice['items'] ?? []) as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $items[] = $item;
+            $rowVatResolutions[] = $this->vatTypeResolver->resolveRow($invoice, $item);
+        }
+
+        $documentVatResolution = $this->vatTypeResolver->resolveDocument($invoice, $rowVatResolutions);
+        $documentProcessVat = $this->vatTypeResolver->documentProcessVat($invoice, $documentVatResolution);
+        $documentReverseCharge = $this->vatTypeResolver->documentReverseCharge($documentVatResolution);
+
+        $vatInfo = $document->appendChild($xml->createElement('VatInfo'));
+        if ($documentVatResolution !== null) {
+            $this->el($xml, $vatInfo, 'TypeOfVAT', $documentVatResolution['type_of_vat']);
+        }
+        $this->el($xml, $vatInfo, 'VatDate', $this->date((string) ($invoice['tax_date'] ?? $invoice['issue_date'] ?? '')));
+        $this->el($xml, $vatInfo, 'TaxVoucher', (($invoice['invoice_type'] ?? '') === 'proforma') ? 'false' : 'true');
+        $this->el($xml, $vatInfo, 'VatSource', 'TaxableValue');
+
+        $documentTotals = $document->appendChild($xml->createElement('DocumentTotals'));
+        $rows = $xml->createElement('Rows');
+
+        foreach ($items as $item) {
+            $lineCount++;
+            $rate = $this->fmt((float) ($item['vat_rate_snapshot'] ?? 0));
+            $lineBase = (float) ($item['total_without_vat'] ?? 0);
+            $lineVat = (float) ($item['total_vat'] ?? 0);
+            $lineTotal = (float) ($item['total_with_vat'] ?? ($lineBase + $lineVat));
+
+            $vatRates[$rate] ??= [
+                'rate' => (float) ($item['vat_rate_snapshot'] ?? 0),
+                'taxable' => 0.0,
+                'vat' => 0.0,
+                'total' => 0.0,
+            ];
+            $vatRates[$rate]['taxable'] += $lineBase;
+            $vatRates[$rate]['vat'] += $lineVat;
+            $vatRates[$rate]['total'] += $lineTotal;
+
+            $quantity = (float) ($item['quantity'] ?? 1);
+            $unitPrice = (!empty($invoice['prices_include_vat']) && $quantity != 0.0)
+                ? round($lineBase / $quantity, 2)
+                : (float) ($item['unit_price_without_vat'] ?? 0);
+
+            $row = $rows->appendChild($xml->createElement('Row'));
+            $this->el($xml, $row, 'LineText', (string) ($item['description'] ?? ''));
+            $this->el($xml, $row, 'Quantity', $this->fmt($quantity));
+            $this->el($xml, $row, 'UnitOfMeasure', (string) ($item['unit'] ?? 'ks'));
+            $this->el($xml, $row, 'UnitPrice', $this->fmt($unitPrice));
+            $this->el($xml, $row, 'LineNet', $this->fmt($lineBase));
+            $this->el($xml, $row, 'LineVATRate', $this->fmt((float) ($item['vat_rate_snapshot'] ?? 0)));
+            $this->el($xml, $row, 'LineVAT', $this->fmt($lineVat));
+            $this->el($xml, $row, 'CurrencyCode', $currency);
+            if ($documentVatResolution !== null) {
+                $this->el($xml, $row, 'TypeOfVAT', $documentVatResolution['type_of_vat']);
+                $this->el($xml, $row, 'ProcessVAT', $documentVatResolution['process_vat'] ? 'true' : 'false');
+                $this->el($xml, $row, 'ReverseCharge', $documentVatResolution['reverse_charge'] ? 'true' : 'false');
+            }
+        }
+
+        foreach ($vatRates as $rate) {
+            $vatRow = $vatInfo->appendChild($xml->createElement('VATTableRow'));
+            $this->el($xml, $vatRow, 'VATRate', $this->fmt($rate['rate']));
+            $this->el($xml, $vatRow, 'TotalTaxableAtRate', $this->fmt($rate['taxable']));
+            $this->el($xml, $vatRow, 'VATAtRate', $this->fmt($rate['vat']));
+            $this->el($xml, $vatRow, 'TotalWithVAT', $this->fmt($rate['total']));
+        }
+
+        $taxableTotal = array_sum(array_column($vatRates, 'taxable'));
+        $vatTotal = array_sum(array_column($vatRates, 'vat'));
+        $netTotal = array_sum(array_column($vatRates, 'total'));
+        $advance = (float) ($invoice['advance_paid_amount'] ?? 0);
+        $rounding = (float) ($invoice['rounding'] ?? ($invoice['totals']['rounding'] ?? 0));
+        $amountToPay = array_key_exists('amount_to_pay', $invoice) && $invoice['amount_to_pay'] !== null
+            ? (float) $invoice['amount_to_pay']
+            : $netTotal - $advance + $rounding;
+
+        $this->el($xml, $documentTotals, 'NumberOfLines', (string) $lineCount);
+        $this->el($xml, $documentTotals, 'NumberOfVATRates', (string) count($vatRates));
+        $this->el($xml, $documentTotals, 'TaxableTotal', $this->fmt($taxableTotal));
+        $this->el($xml, $documentTotals, 'VatTotal', $this->fmt($vatTotal));
+        $this->el($xml, $documentTotals, 'NetTotal', $this->fmt($netTotal));
+        $this->el($xml, $documentTotals, 'AdvancePaymentTotal', $this->fmt($advance));
+        $this->el($xml, $documentTotals, 'NetPaymentTotal', $this->fmt($amountToPay - $rounding));
+        $this->el($xml, $documentTotals, 'NetPaymentTotalRounding', $this->fmt($rounding));
+        $this->el($xml, $documentTotals, 'NetPaymentTotalRounded', $this->fmt($amountToPay));
+        if ($documentProcessVat !== null) {
+            $this->el($xml, $documentTotals, 'ProcessVAT', $documentProcessVat ? 'true' : 'false');
+        }
+        if ($documentReverseCharge !== null) {
+            $this->el($xml, $documentTotals, 'ReverseCharge', $documentReverseCharge ? 'true' : 'false');
+        }
+
+        $document->appendChild($rows);
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function partyNode(DOMDocument $xml, string $name, array $data, bool $supplier): DOMElement
+    {
+        $node = $xml->createElement($name);
+
+        $person = $node->appendChild($xml->createElement('Person'));
+        if (!empty($data['first_name'])) {
+            $this->el($xml, $person, 'FirstName', (string) $data['first_name']);
+        }
+        $this->el($xml, $person, 'LastName', (string) ($data['last_name'] ?? ''));
+        if (!empty($data['main_email']) || !empty($data['email'])) {
+            $this->el($xml, $person, 'Email', (string) ($data['main_email'] ?? $data['email']));
+        }
+
+        $address = $node->appendChild($xml->createElement('Address'));
+        $this->el($xml, $address, 'Street', (string) ($data['street'] ?? ''));
+        $this->el($xml, $address, 'City', (string) ($data['city'] ?? ''));
+        $this->el($xml, $address, 'PostalCode', (string) ($data['zip'] ?? ''));
+        if (!empty($data['country_iso2'])) {
+            $this->el($xml, $address, 'Country', (string) $data['country_iso2']);
+        }
+
+        $company = $node->appendChild($xml->createElement('Company'));
+        $this->el($xml, $company, 'Company', (string) ($data['company_name'] ?? $data['display_name'] ?? ''));
+        $this->el($xml, $company, 'CompanyRegistrationNo', (string) ($data['ic'] ?? ''));
+        $this->el($xml, $company, 'CompanyTaxRegistrationNo', (string) ($data['dic'] ?? ''));
+        $isVatPayer = $supplier
+            ? (!array_key_exists('is_vat_payer', $data) || (bool) $data['is_vat_payer'])
+            : ((string) ($data['dic'] ?? '') !== '');
+        $this->el($xml, $company, 'VATPayer', $isVatPayer ? 'true' : 'false');
+
+        return $node;
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @return array<string,mixed>
+     */
+    private function clientData(array $invoice): array
+    {
+        return $this->dataResolver->client($invoice);
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @return array<string,mixed>
+     */
+    private function supplierData(array $invoice): array
+    {
+        return $this->dataResolver->supplier($invoice);
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     * @return array<string,mixed>
+     */
+    private function bankData(array $invoice): array
+    {
+        return $this->dataResolver->bank($invoice) ?? [];
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    private function issuePerson(array $invoice): string
+    {
+        return $this->dataResolver->issuePerson($invoice);
+    }
+
+    private function documentCaption(string $invoiceType): string
+    {
+        return match ($invoiceType) {
+            'proforma' => 'ZÁLOHOVÁ FAKTURA',
+            'credit_note' => 'DOBROPIS',
+            'cancellation' => 'STORNO',
+            default => 'FAKTURA - daňový doklad',
+        };
+    }
+
+    private function paymentType(string $paymentMethod): string
+    {
+        return match ($paymentMethod) {
+            'bank_transfer' => 'BankTransfer',
+            'cash' => 'Cash',
+            'card' => 'CreditCard',
+            default => 'Other',
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    private function currencyCode(array $invoice): string
+    {
+        return $this->stereoCurrencyCode($invoice);
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    private function stereoCurrencyCode(array $invoice): string
+    {
+        $code = $this->currencyIso($invoice);
+
+        return $code === 'CZK' ? 'Kč' : $code;
+    }
+
+    /**
+     * @param array<string,mixed> $invoice
+     */
+    private function currencyIso(array $invoice): string
+    {
+        $code = strtoupper((string) ($invoice['currency'] ?? 'CZK'));
+        return preg_match('/^[A-Z]{3}$/', $code) ? $code : 'CZK';
+    }
+
+    private function date(string $date): string
+    {
+        return preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) ? $date : date('Y-m-d');
+    }
+
+    private function dateTime(string $date): string
+    {
+        return $this->date($date) . 'T00:00:00.00';
+    }
+
+    private function fmt(mixed $value): string
+    {
+        return number_format((float) $value, 2, '.', '');
+    }
+
+    private function el(DOMDocument $xml, DOMElement $parent, string $name, string $value): DOMElement
+    {
+        $element = $xml->createElement($name);
+        $element->appendChild($xml->createTextNode($value));
+        $parent->appendChild($element);
+
+        return $element;
+    }
+}

--- a/api/tests/Unit/Service/Export/StereoXmlExporterTest.php
+++ b/api/tests/Unit/Service/Export/StereoXmlExporterTest.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Export;
+
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Service\Export\StereoXmlExporter;
+use PHPUnit\Framework\TestCase;
+
+final class StereoXmlExporterTest extends TestCase
+{
+    private StereoXmlExporter $exporter;
+
+    protected function setUp(): void
+    {
+        /** @var InvoiceRepository $repo */
+        $repo = (new \ReflectionClass(InvoiceRepository::class))->newInstanceWithoutConstructor();
+        /** @var Connection $db */
+        $db = (new \ReflectionClass(Connection::class))->newInstanceWithoutConstructor();
+        $this->exporter = new StereoXmlExporter($repo, $db);
+    }
+
+    public function testLineNetUsesTaxableBaseWithoutVat(): void
+    {
+        $xml = $this->exporter->buildXml([$this->invoice([
+            'items' => [
+                $this->item([
+                    'description' => 'Programatorske prace A',
+                    'quantity' => 7.0,
+                    'unit_price_without_vat' => 1000.0,
+                    'total_without_vat' => 7000.0,
+                    'total_vat' => 1470.0,
+                    'total_with_vat' => 8470.0,
+                ]),
+                $this->item([
+                    'description' => 'Programatorske prace B',
+                    'quantity' => 4.0,
+                    'unit_price_without_vat' => 1000.0,
+                    'total_without_vat' => 4000.0,
+                    'total_vat' => 840.0,
+                    'total_with_vat' => 4840.0,
+                ]),
+            ],
+            'total_without_vat' => 11000.0,
+            'total_vat' => 2310.0,
+            'total_with_vat' => 13310.0,
+            'amount_to_pay' => 13310.0,
+            'totals' => ['rounding' => 0.0],
+        ])]);
+
+        self::assertSame('7000.00', $this->xpathOne($xml, '//Rows/Row[1]/LineNet'));
+        self::assertSame('1470.00', $this->xpathOne($xml, '//Rows/Row[1]/LineVAT'));
+        self::assertSame('4000.00', $this->xpathOne($xml, '//Rows/Row[2]/LineNet'));
+        self::assertSame('840.00', $this->xpathOne($xml, '//Rows/Row[2]/LineVAT'));
+
+        self::assertSame('11000.00', $this->xpathOne($xml, '//DocumentTotals/TaxableTotal'));
+        self::assertSame('2310.00', $this->xpathOne($xml, '//DocumentTotals/VatTotal'));
+        self::assertSame('13310.00', $this->xpathOne($xml, '//DocumentTotals/NetTotal'));
+        self::assertSame('13310.00', $this->xpathOne($xml, '//DocumentTotals/NetPaymentTotalRounded'));
+        self::assertSame('11000.00', $this->xpathOne($xml, '//VatInfo/VATTableRow/TotalTaxableAtRate'));
+        self::assertSame('2310.00', $this->xpathOne($xml, '//VatInfo/VATTableRow/VATAtRate'));
+        self::assertSame('13310.00', $this->xpathOne($xml, '//VatInfo/VATTableRow/TotalWithVAT'));
+        self::assertSame('Vaclavske namesti 1', $this->xpathOne($xml, '//Buyer/Address/Street'));
+        self::assertSame('Praha 1', $this->xpathOne($xml, '//Buyer/Address/City'));
+        self::assertSame('11000', $this->xpathOne($xml, '//Buyer/Address/PostalCode'));
+        self::assertSame('Kč', $this->xpathOne($xml, '//Payment/CurrencyCode'));
+        self::assertSame('Kč', $this->xpathOne($xml, '//Rows/Row[1]/CurrencyCode'));
+        self::assertSame('U', $this->xpathOne($xml, '//VatInfo/TypeOfVAT'));
+        self::assertSame('U', $this->xpathOne($xml, '//Rows/Row[1]/TypeOfVAT'));
+        self::assertSame('false', $this->xpathOne($xml, '//Rows/Row[1]/ProcessVAT'));
+        self::assertSame('false', $this->xpathOne($xml, '//Rows/Row[1]/ReverseCharge'));
+        self::assertSame('true', $this->xpathOne($xml, '//DocumentTotals/ProcessVAT'));
+        self::assertSame('false', $this->xpathOne($xml, '//DocumentTotals/ReverseCharge'));
+    }
+
+    public function testNonCzkCurrencyCodeUsesIsoAndMissingConstantSymbolIsEmpty(): void
+    {
+        $xml = $this->exporter->buildXml([$this->invoice(['currency' => 'EUR'])]);
+
+        self::assertSame('EUR', $this->xpathOne($xml, '//Payment/CurrencyCode'));
+        self::assertSame('EUR', $this->xpathOne($xml, '//Rows/Row/CurrencyCode'));
+        self::assertSame('', $this->xpathOne($xml, '//Payment/ConstantSymbol'));
+        self::assertSame('Jan Novak', $this->xpathOne($xml, '//Issue/IssuePerson'));
+        self::assertSame('myinvoice.cz', $this->xpathOne($xml, '//HEADER/Source/SoftwareVendor'));
+        self::assertSame('myinvoice.cz', $this->xpathOne($xml, '//HEADER/Source/SoftwareProduct'));
+        self::assertNull($this->xpathOne($xml, '//DocumentTotals/TypeOfOperation'));
+        self::assertNull($this->xpathOne($xml, '//Rows/Row/TypeOfOperation'));
+    }
+
+    public function testDomesticReverseChargeMapsToStereoUrp(): void
+    {
+        $xml = $this->exporter->buildXml([$this->invoice([
+            'reverse_charge' => true,
+            'items' => [
+                $this->item([
+                    'vat_classification_code' => '25s',
+                    'vat_rate_snapshot' => 21.0,
+                    'total_without_vat' => 5000.0,
+                    'total_vat' => 0.0,
+                    'total_with_vat' => 5000.0,
+                ]),
+            ],
+            'amount_to_pay' => 5000.0,
+        ])]);
+
+        self::assertSame('URP', $this->xpathOne($xml, '//VatInfo/TypeOfVAT'));
+        self::assertNull($this->xpathOne($xml, '//DocumentTotals/TypeOfOperation'));
+        self::assertNull($this->xpathOne($xml, '//Rows/Row/TypeOfOperation'));
+        self::assertSame('URP', $this->xpathOne($xml, '//Rows/Row/TypeOfVAT'));
+        self::assertSame('false', $this->xpathOne($xml, '//Rows/Row/ProcessVAT'));
+        self::assertSame('true', $this->xpathOne($xml, '//Rows/Row/ReverseCharge'));
+        self::assertSame('true', $this->xpathOne($xml, '//DocumentTotals/ProcessVAT'));
+        self::assertSame('true', $this->xpathOne($xml, '//DocumentTotals/ReverseCharge'));
+    }
+
+    public function testInvoiceVatClassificationMakesStereoVatTypeConsistentAcrossWholeDocument(): void
+    {
+        $xml = $this->exporter->buildXml([$this->invoice([
+            'vat_classification_code' => '22',
+            'items' => [
+                $this->item([
+                    'description' => 'Tuzemska sluzba',
+                    'vat_classification_code' => '1',
+                    'total_without_vat' => 1000.0,
+                    'total_vat' => 210.0,
+                    'total_with_vat' => 1210.0,
+                ]),
+                $this->item([
+                    'description' => 'Sluzba do EU',
+                    'vat_classification_code' => '22',
+                    'vat_rate_snapshot' => 0.0,
+                    'total_without_vat' => 2000.0,
+                    'total_vat' => 0.0,
+                    'total_with_vat' => 2000.0,
+                ]),
+            ],
+            'amount_to_pay' => 3210.0,
+        ])]);
+
+        self::assertSame('UVSP', $this->xpathOne($xml, '//VatInfo/TypeOfVAT'));
+        self::assertSame('UVSP', $this->xpathOne($xml, '//Rows/Row[1]/TypeOfVAT'));
+        self::assertSame('UVSP', $this->xpathOne($xml, '//Rows/Row[2]/TypeOfVAT'));
+        self::assertSame('true', $this->xpathOne($xml, '//DocumentTotals/ProcessVAT'));
+        self::assertSame('false', $this->xpathOne($xml, '//DocumentTotals/ReverseCharge'));
+    }
+
+    public function testMixedStereoVatTypesWithoutInvoiceClassificationFailExport(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Stereo XML vyžaduje jeden Typ DPH pro celý doklad #2026001.');
+
+        $this->exporter->buildXml([$this->invoice([
+            'items' => [
+                $this->item(['vat_classification_code' => '1']),
+                $this->item([
+                    'vat_classification_code' => '22',
+                    'vat_rate_snapshot' => 0.0,
+                    'total_without_vat' => 2000.0,
+                    'total_vat' => 0.0,
+                    'total_with_vat' => 2000.0,
+                ]),
+            ],
+        ])]);
+    }
+
+    private function xpathOne(string $xml, string $expr): ?string
+    {
+        $dom = new \DOMDocument();
+        self::assertTrue($dom->loadXML($xml), 'Stereo XML neni well-formed.');
+        $xp = new \DOMXPath($dom);
+        $node = $xp->query($expr)->item(0);
+
+        return $node?->textContent;
+    }
+
+    /**
+     * @param array<string,mixed> $overrides
+     * @return array<string,mixed>
+     */
+    private function invoice(array $overrides = []): array
+    {
+        return array_merge([
+            'id' => 1,
+            'invoice_type' => 'invoice',
+            'varsymbol' => '2026001',
+            'issue_date' => '2026-05-04',
+            'tax_date' => '2026-05-04',
+            'due_date' => '2026-05-18',
+            'currency' => 'CZK',
+            'payment_method' => 'bank_transfer',
+            'created_by' => 7,
+            'created_by_name' => 'Jan Novak',
+            'advance_paid_amount' => 0.0,
+            'amount_to_pay' => 3049.2,
+            'rounding' => 0.0,
+            'client_snapshot' => [
+                'company_name' => 'Odberatel a.s.',
+                'street' => 'Vaclavske namesti 1',
+                'city' => 'Praha 1',
+                'zip' => '11000',
+                'country_iso2' => 'CZ',
+                'ic' => '27140130',
+                'dic' => 'CZ27140130',
+            ],
+            'supplier_snapshot' => [
+                'company_name' => 'Dodavatel s.r.o.',
+                'street' => 'Kardinala Berana 1104/36',
+                'city' => 'Plzen',
+                'zip' => '30100',
+                'country_iso2' => 'CZ',
+                'ic' => '01698401',
+                'dic' => 'CZ01698401',
+                'is_vat_payer' => true,
+            ],
+            'bank_snapshot' => [
+                'account_number' => '1000000005',
+                'bank_code' => '0100',
+                'bank_name' => 'Komercni banka',
+            ],
+            'items' => [$this->item()],
+            'totals' => ['rounding' => 0.0],
+        ], $overrides);
+    }
+
+    /**
+     * @param array<string,mixed> $overrides
+     * @return array<string,mixed>
+     */
+    private function item(array $overrides = []): array
+    {
+        return array_merge([
+            'description' => 'Vyvoj systemu',
+            'quantity' => 1.0,
+            'unit' => 'ks',
+            'unit_price_without_vat' => 2520.0,
+            'vat_rate_snapshot' => 21.0,
+            'total_without_vat' => 2520.0,
+            'total_vat' => 529.2,
+            'total_with_vat' => 3049.2,
+        ], $overrides);
+    }
+}

--- a/manual/01_Uvod.md
+++ b/manual/01_Uvod.md
@@ -117,7 +117,7 @@ a aplikace platby spáruje sama:
 
 ## 1.8 Exporty pro účetní
 
-Tři standardní formáty pro předání dokladů externí kanceláři nebo internímu
+Čtyři standardní formáty pro předání dokladů externí kanceláři nebo internímu
 účetnímu oddělení:
 
 - **PDF ZIP po měsících** — klasická archivace, název souboru
@@ -126,6 +126,7 @@ Tři standardní formáty pro předání dokladů externí kanceláři nebo inte
   podporují ho všechny větší české účetní programy
 - **Pohoda XML** (Stormware data package) — přímý import do Pohody bez
   ručního opisu
+- **Stereo XML** — DocumentPack XML pro import vydaných faktur do Stereo
 - Filtrování exportu podle období, typu dokladu (faktury / zálohové /
   dobropisy) a stavu (vystavené / zaplacené / vše)
 

--- a/manual/15_Exporty.md
+++ b/manual/15_Exporty.md
@@ -1,6 +1,6 @@
-# 15. Exporty (PDF ZIP, ISDOC, Pohoda XML)
+# 15. Exporty (PDF ZIP, ISDOC, Pohoda XML, Stereo XML)
 
-Pro účetní (interní oddělení nebo externí kancelář) nabízí MyInvoice tři
+Pro účetní (interní oddělení nebo externí kancelář) nabízí MyInvoice čtyři
 formáty hromadného exportu **vystavených faktur** a per-faktura export
 **přijatých faktur** (ISDOC / Pohoda / naše PDF rekonstrukce — viz [Export přijatých faktur](18_Export_prijatych.md)).
 
@@ -16,6 +16,7 @@ formáty hromadného exportu **vystavených faktur** a per-faktura export
 | **PDF ZIP** | Klasická archivace | Všechna PDF za zvolené období v ZIP archivu |
 | **ISDOC 6.0.2** | Český národní standard pro B2B výměnu faktur | XML soubor pro každou fakturu, balené v ZIP |
 | **Pohoda XML** | Stormware Pohoda — přímý import bez ručního opisu | Sloučený dataPack XML soubor |
+| **Stereo XML** | Stereo for Windows — import vydaných faktur | Sloučený DocumentPack XML soubor |
 
 ## 15.1 Obrazovka exportů
 
@@ -27,7 +28,7 @@ Formulář:
 
 | Pole | Význam |
 |---|---|
-| Formát | `PDF ZIP` / `ISDOC` / `Pohoda XML` |
+| Formát | `PDF ZIP` / `ISDOC` / `Pohoda XML` / `Stereo XML` |
 | Období | Měsíc-rok (např. „Duben 2026") nebo celé čtvrtletí (`Q1` až `Q4`) |
 | Filtrovat podle | Datum vystavení nebo DUZP (u DUZP se při prázdné hodnotě použije datum vystavení) |
 | Typ | Všechny / Faktury / Zálohové / Dobropisy |
@@ -217,12 +218,51 @@ MyInvoice mapuje DPH sazby na **Pohoda kódy klasifikace**:
 
 Pokud klient potřebuje přesně tvoji PDF verzi, použij paralelně **PDF ZIP**.
 
-## 15.5 Faktury v cizí měně (EUR / USD / …) — kurz CZK v exportu
+## 15.5 Stereo XML
+
+Stereo XML export vytváří jeden `DocumentPack` soubor pro vydané faktury za
+zvolené období. Je určený pro import do **Kastner Stereo** přes volbu
+**Import faktury (XML)**. Výstup používá:
+
+- `SoftwareVendor` a `SoftwareProduct` = `myinvoice.cz`,
+- `Payment/CurrencyCode` a `Rows/Row/CurrencyCode` s legacy Stereo mapováním
+  `CZK → Kč`; ostatní měny zůstávají jako ISO kód (`EUR`, ...),
+- `Payment/ConstantSymbol` jako prázdný element, pokud faktura konstantní symbol
+  neobsahuje.
+
+DPH se skládá z řádkových součtů uložených na faktuře. `LineNet` je základ řádku
+bez DPH (`total_without_vat`), `LineVAT` je DPH řádku a `LineNet + LineVAT`
+odpovídá částce řádku s DPH. Souhrny `TaxableTotal`, `VatTotal` a `NetTotal`
+jsou součty těchto hodnot přes všechny položky.
+
+Export v první iteraci zapisuje pevné mapování DPH klasifikací MyInvoice do
+Stereo `TypeOfVAT`. Stereo vyžaduje jeden typ DPH pro celý doklad, proto se
+stejná hodnota zapisuje do `VatInfo/TypeOfVAT` i do všech řádků dokladu. Pokud
+má faktura vyplněný hlavičkový `vat_classification_code`, použije se jako
+autoritativní typ pro celý Stereo doklad; jinak musí všechny položky vycházet na
+stejný Stereo typ. Smíšené typy bez hlavičkové klasifikace export zastaví
+s validační chybou.
+
+| MyInvoice `vat_classification_code` | Stereo `TypeOfVAT` |
+| --- | --- |
+| `1`, `2` | `U` |
+| `3` | `UO` |
+| `20` | `IDZ` |
+| `22` | `UVSP` |
+| `25s` | `URP` |
+| `26` | `UV` |
+
+Volitelné účetní klasifikace Stereo jako `TypeOfOperation`, `Stredisko`, `Vykon`
+nebo `Zakazka` se zatím nezapisují. `TypeOfOperation` není podle XSD povinné a
+u tuzemského režimu přenesení daňové povinnosti může import Sterea odmítnout,
+pokud hodnota neodpovídá lokálnímu číselníku.
+
+## 15.6 Faktury v cizí měně (EUR / USD / …) — kurz CZK v exportu
 
 Pro faktury v jiné měně než CZK MyInvoice automaticky přidává do exportů
 **kurz ČNB** zafixovaný na faktuře — viz [§ 10.4.2](10_Faktura_editor.md#1042-faktura-v-cizi-mene-eur-usd-prepocet-do-czk).
 
-### 15.5.1 ISDOC — `LocalCurrencyCode` + `CurrencyCode` + `CurrRate`
+### 15.6.1 ISDOC — `LocalCurrencyCode` + `CurrencyCode` + `CurrRate`
 
 ISDOC export pro EUR fakturu obsahuje:
 
@@ -238,7 +278,7 @@ si CZK ekvivalent dopočítá z `CurrRate`. Pokud faktura nemá zafixovaný kurz
 (starší data před verzí 1.4 nebo selhal fetch z ČNB), `CurrRate=1` — uživatel
 musí v účetním softu kurz ručně doplnit.
 
-### 15.5.2 Pohoda XML — `inv:foreignCurrency` + `inv:homeCurrency`
+### 15.6.2 Pohoda XML — `inv:foreignCurrency` + `inv:homeCurrency`
 
 Pohoda XML pro EUR fakturu obsahuje **oba** bloky v `<inv:invoiceSummary>`:
 
@@ -262,7 +302,7 @@ Položky (`<inv:invoiceItem>`) pro non-CZK fakturu používají `<inv:foreignCur
 místo `<inv:homeCurrency>` — Pohoda po importu položkové CZK hodnoty dopočítá
 z globálního kurzu.
 
-### 15.5.3 Tipy
+### 15.6.3 Tipy
 
 - **Konzultuj kurz s účetní** — některé účetní software (zejm. Pohoda) má
   vlastní kurzovní lístek a může při importu kurz přepsat. Pokud chceš mít
@@ -271,7 +311,7 @@ z globálního kurzu.
   ho automaticky doplní (cache → ČNB → poslední známý). Když ČNB nedostupné
   a žádný kurz není, v ISDOC dostaneš `CurrRate=1` s varováním.
 
-## 15.6 Filtrování
+## 15.7 Filtrování
 
 | Volba | Použití |
 |---|---|
@@ -279,7 +319,7 @@ z globálního kurzu.
 | Stav = Zaplacené | Pro výplatu DPH (jen reálně přijaté) |
 | Typ = Dobropisy | Pro samostatnou agendu oprav |
 
-## 15.7 Tipy
+## 15.8 Tipy
 
 - **Měsíční rytmus** — exportuj 1. den následujícího měsíce za ten skončený
   měsíc.
@@ -288,9 +328,10 @@ z globálního kurzu.
   [Hromadný export (ZIP)](32_Hromadny_export.md) v sekci Daně —
   vyřeší zařazení do období daňově korektně a roztřídí vše do pojmenovaných
   složek.
-- **ISDOC i Pohoda** — pokud si nejsi jistý, který formát použít, **ISDOC**
-  je univerzální (otevřený standard, fungují různé softwary). Pohoda XML jen
-  když víš, že příjemce má Pohodu.
+- **ISDOC, Pohoda, Stereo** — pokud si nejsi jistý, který formát použít,
+  **ISDOC** je univerzální (otevřený standard, fungují různé softwary).
+  Pohoda XML nebo Stereo XML použij jen když víš, že příjemce používá daný
+  účetní software.
 - **Stáhni i PDF ZIP jako backup** — XML formáty obsahují data, ale ne grafiku
   PDF. Pokud archivuješ pro daňové účely, mít originální PDF je nutné.
 - **Před prvním exportem do Pohody** → konzultuj s účetní, jaké chce kódy

--- a/manual/26_Fakturujeme.md
+++ b/manual/26_Fakturujeme.md
@@ -198,7 +198,7 @@ Aby bylo úplně jasno, kde je hranice:
 - Upomínání po splatnosti
 - Bankovní importy (FIO, KB, ČSOB) a párování plateb podle VS
 - ARES + VIES lookup (autocomplete IČO/DIČ)
-- Export pro účetní: **Pohoda XML, ISDOC, PDF ZIP**
+- Export pro účetní: **Pohoda XML, Stereo XML, ISDOC, PDF ZIP**
 - XML pro EPO portál MFČR: **DPH přiznání (DPHDP3), kontrolní hlášení,
   souhrnné hlášení** — jako pomůcka k ověření s účetní
 
@@ -213,7 +213,7 @@ Aby bylo úplně jasno, kde je hranice:
 - Insolvenční registr, registr ekonomických subjektů
 
 Standardní tok je: **MyInvoice vystaví doklady → vygeneruje výkazy DPH →
-uživatel/účetní jednou měsíčně exportuje (Pohoda XML / ISDOC) → účetní
+uživatel/účetní jednou měsíčně exportuje (Pohoda XML / Stereo XML / ISDOC) → účetní
 doklady zaúčtuje a ověřené výkazy podá**. Aplikace primárně **eviduje,
 podává a generuje výkazy** z dokladů, neúčtuje je.
 

--- a/source/00-README.md
+++ b/source/00-README.md
@@ -12,7 +12,7 @@ Multi-supplier fakturační systém (jedna instalace = N dodavatelů / IČO s iz
 - **Mail:** Symfony Mailer 8 (SMTP + DKIM)
 - **Grafy:** Chart.js 4 + vue-chartjs 5
 - **Build / testy:** Composer 2, pnpm 10 + Node.js 22+, PHPUnit 13, PHPStan 2, vue-tsc 2
-- **Exporty pro účetní:** PDF ZIP, **ISDOC 6.0.2**, **Pohoda XML** (Stormware data package)
+- **Exporty pro účetní:** PDF ZIP, **ISDOC 6.0.2**, **Pohoda XML** (Stormware data package), **Stereo XML**
 - **Hosting:** IIS i Apache (oba podporované)
 - **Konfigurace:** `cfg.php` v rootu repa (+ `cfg.local.php` pro per-env override)
 - **Logy:** `log/` v rootu, denní rotace 90 dní
@@ -33,7 +33,7 @@ Multi-supplier fakturační systém (jedna instalace = N dodavatelů / IČO s iz
 11. **Email s PDF přílohou** přes Twig šablony + per-dodavatel `From:` jméno a `Reply-To:` adresa
 12. **Upomínky** — manuální tlačítko, hromadná akce, nebo cron `cron-send-reminders.php`
 13. **GPC import** bankovních výpisů (KB/FIO/ČSOB/RB/ČS) s SHA256 dedupe + auto-matching
-14. **Exporty pro účetní:** PDF ZIP po měsících, **ISDOC 6.0.2**, **Pohoda XML** (per-dodavatel kódy: středisko, činnost, předkontace)
+14. **Exporty pro účetní:** PDF ZIP po měsících, **ISDOC 6.0.2**, **Pohoda XML** (per-dodavatel kódy: středisko, činnost, předkontace), **Stereo XML**
 15. Reverse charge přepínatelný per klient
 16. Číselník DPH s validitou v čase, měny **CZK + EUR** (rozšiřitelný), per-dodavatel bankovní účty
 17. **Brute-force ochrana** přes Redis (fallback MariaDB MEMORY) + **TOTP 2FA**
@@ -100,4 +100,3 @@ Multi-supplier fakturační systém (jedna instalace = N dodavatelů / IČO s iz
 | 7 | Vystavení daňového dokladu z proformy | Ano, s odečtem zaplacené zálohy |
 | 8 | First-run setup | Wizard při prvním spuštění (admin + dodavatel) |
 | 9 | IP allowlist | Volitelný, IPv4 i IPv6 + CIDR prefixy |
-

--- a/source/04-api.md
+++ b/source/04-api.md
@@ -110,7 +110,7 @@ POST /api/bank-transactions/{id}/ignore
 - **Email šablony (M9):** plná CRUD nad `/api/admin/email-templates/{code}/{locale}` (locale = `cs|en`).
 - **Reminders:** `/api/invoices/{id}/reminder`, `reminder-test` a `bulk-reminder` (po splatnosti).
 - **PDF historie:** `/api/invoices/{id}/pdfs` listuje archivované PDF, `/{archiveId}` stahuje konkrétní snapshot.
-- **Generic export/import (M6/M7):** `/api/admin/export?format=pdf-zip|isdoc|pohoda&month=YYYY-MM` nebo `period=quarterly&year=YYYY&quarter=1..4`, `/api/admin/import` (Pohoda XML / ISDOC, single i ZIP).
+- **Generic export/import (M6/M7):** `/api/admin/export?format=pdf-zip|isdoc|pohoda|stereo&month=YYYY-MM` nebo `period=quarterly&year=YYYY&quarter=1..4`, `/api/admin/import` (Pohoda XML / ISDOC, single i ZIP).
 - **TOTP/2FA:** `/api/auth/totp/*` pro nastavení a aktivaci.
 - **IP allowlist a další security policies** se konfigurují v `cfg.php` (resp. v DB přes setup), **nikoli** přes API. Endpointy `/admin/security/*`, `/admin/smtp/test`, `/admin/sessions` neexistují.
 
@@ -673,6 +673,7 @@ Generic export. Query:
 - `?format=pdf-zip&month=YYYY-MM` — ZIP s PDF faktur za měsíc (legacy zkratka)
 - `?format=isdoc&period=monthly&year=YYYY&month=M` — ZIP s ISDOC XML za měsíc
 - `?format=pohoda&period=quarterly&year=YYYY&quarter=1..4` — Pohoda XML za celé čtvrtletí
+- `?format=stereo&period=quarterly&year=YYYY&quarter=1..4` — Stereo DocumentPack XML za celé čtvrtletí
 
 Společné volitelné parametry:
 - `type=invoice|proforma|credit_note` — omezení typu vystaveného dokladu

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -2548,6 +2548,8 @@
     "format_pdf_zip_hint": "PDF každé faktury v ZIPu — pro účetní/archiv.",
     "format_pohoda": "Pohoda XML",
     "format_pohoda_hint": "XML data package pro import do Stormware Pohoda.",
+    "format_stereo": "Stereo XML",
+    "format_stereo_hint": "DocumentPack XML pro import vydaných faktur do Stereo.",
     "format_isdoc": "ISDOC",
     "format_isdoc_hint": "Standardní česká XML faktura (ISDOC 6.0.x), single-invoice nebo ZIP s více ISDOC.",
     "format_fakturoid": "Fakturoid",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -2548,6 +2548,8 @@
     "format_pdf_zip_hint": "Each invoice as a PDF inside one ZIP — for accounting/archive.",
     "format_pohoda": "Pohoda XML",
     "format_pohoda_hint": "XML data package for import into Stormware Pohoda.",
+    "format_stereo": "Stereo XML",
+    "format_stereo_hint": "DocumentPack XML for importing issued invoices into Stereo.",
     "format_isdoc": "ISDOC",
     "format_isdoc_hint": "Czech standard XML invoice (ISDOC 6.0.x), single or ZIP with multiple ISDOC.",
     "format_fakturoid": "Fakturoid",

--- a/web/src/pages/admin/Export.vue
+++ b/web/src/pages/admin/Export.vue
@@ -3,9 +3,9 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useYearOptions } from '@/composables/useYearOptions'
 
-const { t } = useI18n()
+const { t, tm, rt } = useI18n()
 
-type Format = 'pdf-zip' | 'isdoc' | 'pohoda'
+type Format = 'pdf-zip' | 'isdoc' | 'pohoda' | 'stereo'
 type PeriodType = 'monthly' | 'quarterly'
 
 // Default = předchozí měsíc: export se dělá po uzávěrce právě skončeného měsíce,
@@ -77,7 +77,7 @@ async function downloadExport() {
     const blob = await resp.blob()
     const dispo = resp.headers.get('Content-Disposition') || ''
     const m = dispo.match(/filename="?([^"]+)"?/)
-    const ext = format.value === 'pohoda' ? 'xml' : (format.value === 'isdoc' ? 'isdoc' : 'zip')
+    const ext = ['pohoda', 'stereo'].includes(format.value) ? 'xml' : (format.value === 'isdoc' ? 'isdoc' : 'zip')
     const filename = m ? m[1] : `myinvoice-${periodFileLabel.value}.${ext}`
 
     const a = document.createElement('a')
@@ -96,8 +96,9 @@ async function downloadExport() {
 
 const monthLabel = (m: string): string => {
   const [y, mm] = m.split('-')
-  const months = t('common.months_long') as unknown as string[]
-  return `${months[Number(mm) - 1] || mm} ${y}`
+  const months = tm('common.months_long') as string[]
+  const label = months[Number(mm) - 1]
+  return `${label ? rt(label) : mm} ${y}`
 }
 </script>
 
@@ -113,12 +114,13 @@ const monthLabel = (m: string): string => {
       <!-- Formát výběr -->
       <div>
         <label class="block text-sm font-medium text-neutral-700 mb-2">{{ t('export.format') }}</label>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-2">
+        <div class="grid grid-cols-1 sm:grid-cols-4 gap-2">
           <label
             v-for="opt in [
               { val: 'pdf-zip' as Format, label: t('export.format_pdf_zip'), hint: t('export.format_pdf_zip_hint') },
               { val: 'isdoc' as Format,   label: t('export.format_isdoc'),   hint: t('export.format_isdoc_hint') },
               { val: 'pohoda' as Format,  label: t('export.format_pohoda'),  hint: t('export.format_pohoda_hint') },
+              { val: 'stereo' as Format,  label: t('export.format_stereo'),  hint: t('export.format_stereo_hint') },
             ]"
             :key="opt.val"
             class="cursor-pointer block p-3 border rounded-md transition"
@@ -133,7 +135,7 @@ const monthLabel = (m: string): string => {
                 <path fill="#ffffff" opacity="0.35" d="M20 2v8h8z"/>
                 <text x="16" y="26" fill="#ffffff" font-family="Arial,Helvetica,sans-serif" font-size="8" font-weight="700" text-anchor="middle" letter-spacing="0.3">PDF</text>
               </svg>
-              <svg v-else-if="opt.val === 'pohoda'" class="w-5 h-5 text-warning-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414"/></svg>
+              <svg v-else-if="opt.val === 'pohoda' || opt.val === 'stereo'" class="w-5 h-5 text-warning-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414"/></svg>
               <svg v-else class="w-5 h-5 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 11H5m14 0a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2"/></svg>
               <span class="text-sm font-medium">{{ opt.label }}</span>
             </div>

--- a/web/src/pages/purchase-invoices/Export.vue
+++ b/web/src/pages/purchase-invoices/Export.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { purchaseInvoicesApi } from '@/api/purchaseInvoices'
 import { useYearOptions } from '@/composables/useYearOptions'
 
-const { t } = useI18n()
+const { t, tm, rt } = useI18n()
 
 type Format = 'pdf-zip' | 'pohoda' | 'isdoc'
 type DateBy = 'tax' | 'issue' | 'received'
@@ -38,9 +38,10 @@ const monthParts = computed(() => {
 
 const selectedPeriodLabel = computed(() => {
   if (periodType.value === 'quarterly') return `Q${quarter.value} ${year.value}`
-  const months = t('common.months_long') as unknown as string[]
+  const months = tm('common.months_long') as string[]
   const m = monthParts.value.month
-  return `${months[m - 1] || String(m).padStart(2, '0')} ${monthParts.value.year}`
+  const label = months[m - 1]
+  return `${label ? rt(label) : String(m).padStart(2, '0')} ${monthParts.value.year}`
 })
 
 const exportPeriod = computed(() => {


### PR DESCRIPTION
- doplňuje formát Stereo XML do administrace exportů
- přidává exporter pro DocumentPack XML a sdílený resolver exportních dat
- doplňuje testy pro částky, měny, PDP režim a XSD kompatibilní výstup
- rozšiřuje dokumentaci o import do Kastner Stereo přes „Import faktury (XML)“