### PR TITLE
fix(pohoda-export): emit classificationVAT as structured XSD element

### DIFF
--- a/api/src/Service/Export/PohodaXmlExporter.php
+++ b/api/src/Service/Export/PohodaXmlExporter.php
@@ -31,11 +31,14 @@ use MyInvoice\Repository\TaxConstantsRepository;
  *   pohoda_activity_code → <inv:activity><typ:ids>...</typ:ids></inv:activity>
  *   pohoda_contract_code → <inv:contract><typ:ids>...</typ:ids></inv:contract>
  *
- * VAT classification (`<inv:classificationVAT>`) hardcoded podle vat_rate_snapshot:
- *   21 %  → UDA5     (tuzemské plnění základní)
- *   12 %  → UDA5_12  (snížené)
- *    0 %  → UNX      (osvobozeno)
- *   reverse_charge → PNAR (přenesená daňová povinnost)
+ * VAT classification (`<inv:classificationVAT>`) — Pohoda schema vyžaduje STRUKTUROVANÉ
+ * dítě `<typ:ids>` + `<typ:classificationVATType>` ({inland, nonSubsume}), NE prostý text
+ * (validation error: "typ Text v tomto kontextu elementu classificationVAT není povolen").
+ * Mapování podle vat_rate_snapshot:
+ *   21 %  → UDA5    + inland     (tuzemské plnění základní)
+ *   12 %  → UDA5_12 + inland     (snížené)
+ *    0 %  → UNX     + nonSubsume (osvobozeno)
+ *   reverse_charge → PNAR + nonSubsume (přenesená daňová povinnost)
  */
 final class PohodaXmlExporter
 {
@@ -155,9 +158,13 @@ final class PohodaXmlExporter
             }
             $this->el($dom, $hdr, self::NS_INV, 'inv:dateDue', (string) $invoice['due_date']);
 
-            // Klasifikace DPH (per-faktura — vezme se první VAT rate z položek; v praxi mix se řeší per-položka v invoiceItem)
+            // Klasifikace DPH (per-faktura — vezme se nejvyšší VAT rate z položek; mix se v praxi
+            // řeší per-položka v invoiceItem). Pohoda vyžaduje strukturované dítě, ne prostý text.
             $defaultVatClass = $this->classifyVat($invoice);
-            $this->el($dom, $hdr, self::NS_INV, 'inv:classificationVAT', $defaultVatClass);
+            $classEl = $dom->createElementNS(self::NS_INV, 'inv:classificationVAT');
+            $this->el($dom, $classEl, self::NS_TYP, 'typ:ids', $defaultVatClass['ids']);
+            $this->el($dom, $classEl, self::NS_TYP, 'typ:classificationVATType', $defaultVatClass['type']);
+            $hdr->appendChild($classEl);
 
             // Číslo objednávky / poznámka
             if (!empty($invoice['note_above_items'])) {
@@ -342,18 +349,25 @@ final class PohodaXmlExporter
         return $el;
     }
 
-    private function classifyVat(array $invoice): string
+    /**
+     * @return array{ids:string, type:string}  ids = zkratka členění v Pohodě, type = enum {inland, nonSubsume}
+     */
+    private function classifyVat(array $invoice): array
     {
-        if (!empty($invoice['reverse_charge'])) return 'PNAR';
+        if (!empty($invoice['reverse_charge'])) {
+            return ['ids' => 'PNAR', 'type' => 'nonSubsume'];
+        }
         $bd = $invoice['vat_breakdown'] ?? [];
-        if (empty($bd)) return 'UDA5';
+        if (empty($bd)) {
+            return ['ids' => 'UDA5', 'type' => 'inland'];
+        }
         $maxRate = 0.0;
         foreach ($bd as $b) {
             if ((float) $b['rate'] > $maxRate) $maxRate = (float) $b['rate'];
         }
-        if ($maxRate >= $this->highBoundary($invoice)) return 'UDA5';
-        if ($maxRate >= 11.5) return 'UDA5_12';
-        return 'UNX';
+        if ($maxRate >= $this->highBoundary($invoice)) return ['ids' => 'UDA5',    'type' => 'inland'];
+        if ($maxRate >= 11.5)                          return ['ids' => 'UDA5_12', 'type' => 'inland'];
+        return ['ids' => 'UNX', 'type' => 'nonSubsume'];
     }
 
     private function resolveClient(array $invoice): array


### PR DESCRIPTION
## Problem

Pohoda mServer rejects every invoice exported by this codebase with:

```
ERROR  Nepodařila se validace dokumentu podle schématu.
<inv:classificationVAT>UNX</inv:classificationVAT>
Podle definice DTD nebo schématu není typ Text v tomto kontextu
elementu classificationVAT povolen.
```

Confirmed against the official [Stormware type.xsd](https://www.stormware.cz/xml/schema/version_2/type.xsd) — `classificationVATType` is a complex type with `<xsd:all>` children (`id` / `ids` / `classificationVATType`), not text content. Affects every invoice (`UDA5`, `UDA5_12`, `UNX`, `PNAR` all fail validation), blocking imports entirely.

## Fix

`classifyVat()` returns `['ids' => …, 'type' => 'inland'|'nonSubsume']` and the invoice-header builder emits two children:

```xml
<inv:classificationVAT>
  <typ:ids>UDA5</typ:ids>
  <typ:classificationVATType>inland</typ:classificationVATType>
</inv:classificationVAT>
```

XSD enum only has `inland` and `nonSubsume`, so reverse charge and 0 % exempt both map to `nonSubsume`; differentiation happens via `typ:ids` matching the user's *Členění DPH* record.

`PohodaXmlParser` already handles the new shape — its `textContent`-based read picks up the nested `<typ:ids>` and the `str_starts_with('PN')` reverse-charge detection still works on `"PNAR  nonSubsume"`.

## Test plan

- [x] Re-export May invoices from a real install — Pohoda accepts the document without the validation error.
- [x] `php -l` clean on the modified file.
- [ ] Importing the export back via `PohodaXmlParser` round-trips `reverse_charge` correctly.
