### PR TITLE
Oprava: ověření DIČ přes VIES odmítá zahraniční formáty s písmenem (NL, AT, ES, FR, IE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to MyInvoice.cz are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Zahraniční DIČ s písmenem (např. nizozemské `NL123456789B01`) nešlo ověřit přes VIES.** Validace povolovala po prefixu země jen číslice (`/^[A-Z]{2}\d{4,12}$/`), takže DIČ s písmenem padalo na „DIČ musí mít prefix země a 4-12 číslic". Týkalo se i Rakouska (`ATU…`), Španělska, Francie a Irska. Nově se po prefixu země povolí 2-12 alfanumerických znaků, takže projdou všechny formáty DIČ ze systému VIES.
+
 ## [4.20.1] — 2026-06-09
 
 ### Fixed

--- a/api/src/Action/AresVies/ViesLookupAction.php
+++ b/api/src/Action/AresVies/ViesLookupAction.php
@@ -18,11 +18,22 @@ final class ViesLookupAction
         $body = (array) ($request->getParsedBody() ?? []);
         $vatId = strtoupper(trim((string) ($body['vat_id'] ?? '')));
 
-        if (!preg_match('/^[A-Z]{2}\d{4,12}$/', $vatId)) {
-            return Json::error($response, 'invalid_vat_id', 'DIČ musí mít prefix země a 4-12 číslic (např. CZ12345678).', 400);
+        if (!$this->isValidVatId($vatId)) {
+            return Json::error($response, 'invalid_vat_id', 'DIČ musí mít prefix země a 2-12 znaků (např. CZ12345678, NL123456789B01).', 400);
         }
 
         $result = $this->vies->lookup($vatId);
         return Json::ok($response, $result);
+    }
+
+    /**
+     * Formát DIČ pro VIES: 2-písmenný kód země + 2-12 alfanumerických znaků.
+     * Jen číslice NESTAČÍ — řada zemí EU má v DIČ písmeno (NL …B01, AT U…,
+     * ES, FR, IE). Znaky + a * pokrývají starší irské formáty; normalizaci
+     * (strtoupper, ořez mezer) řeší volající výše.
+     */
+    private function isValidVatId(string $vatId): bool
+    {
+        return (bool) preg_match('/^[A-Z]{2}[A-Z0-9+*]{2,12}$/', $vatId);
     }
 }

--- a/api/src/I18n/ErrorCatalog.php
+++ b/api/src/I18n/ErrorCatalog.php
@@ -25,7 +25,7 @@ final class ErrorCatalog
         'Chybí project_id.' => 'Missing project_id.',
         'Chybí title.' => 'Missing title.',
         'Chyba konfigurace serveru.' => 'Server configuration error.',
-        'DIČ musí mít prefix země a 4-12 číslic (např. CZ12345678).' => 'VAT ID must have a country prefix and 4–12 digits (e.g. CZ12345678).',
+        'DIČ musí mít prefix země a 2-12 znaků (např. CZ12345678, NL123456789B01).' => 'VAT ID must have a country prefix and 2–12 characters (e.g. CZ12345678, NL123456789B01).',
         'Dobropis ani storno nelze stornovat.' => 'Credit note and cancellation cannot be cancelled.',
         'Email je už registrovaný.' => 'Email is already registered.',
         'Email se nepodařilo odeslat: ' => 'Failed to send email: ',

--- a/api/src/Service/Ares/ViesClient.php
+++ b/api/src/Service/Ares/ViesClient.php
@@ -37,7 +37,7 @@ final class ViesClient
     public function lookup(string $vatId): array
     {
         $vatId = strtoupper(preg_replace('/[\s\-]/', '', $vatId) ?? '');
-        if (!preg_match('/^([A-Z]{2})(\d{4,12})$/', $vatId, $m)) {
+        if (!preg_match('/^([A-Z]{2})([A-Z0-9+*]{2,12})$/', $vatId, $m)) {
             return ['valid' => false, 'source' => 'error'];
         }
         $country = $m[1];

--- a/api/tests/Unit/Action/ViesLookupVatFormatTest.php
+++ b/api/tests/Unit/Action/ViesLookupVatFormatTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Action;
+
+use MyInvoice\Action\AresVies\ViesLookupAction;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Regrese: VIES validace DIČ povolovala po prefixu země jen číslice
+ * (/^[A-Z]{2}\d{4,12}$/), takže DIČ s písmenem padalo na "DIČ musí mít prefix
+ * země a …". Reálný případ: nizozemské NL…B01 (9 číslic + "B" + 2 číslice).
+ * Stejně tak AT (U…), ES, FR, IE. Oprava povoluje i písmena (znaky + a * = starší IE).
+ *
+ * Čistě unit — predikát nesahá na DB ani VIES, takže action instancujeme bez
+ * konstruktoru a privátní isValidVatId() voláme přes reflexi.
+ */
+final class ViesLookupVatFormatTest extends TestCase
+{
+    private function isValid(string $vatId): bool
+    {
+        $action = (new ReflectionClass(ViesLookupAction::class))->newInstanceWithoutConstructor();
+        $m = new \ReflectionMethod($action, 'isValidVatId');
+        /** @var bool $r */
+        $r = $m->invoke($action, $vatId);
+        return $r;
+    }
+
+    public function testAcceptsDutchVatWithLetter(): void
+    {
+        // NL = 9 číslic + "B" + 2 číslice; dřív padalo na "jen číslice".
+        self::assertTrue($this->isValid('NL123456789B01'));
+    }
+
+    public function testAcceptsOtherEuFormatsWithLetters(): void
+    {
+        self::assertTrue($this->isValid('ATU12345678')); // Rakousko (U + 8 číslic)
+        self::assertTrue($this->isValid('ESX1234567X')); // Španělsko
+        self::assertTrue($this->isValid('IE1234567FA')); // Irsko
+    }
+
+    public function testStillAcceptsPlainNumericVat(): void
+    {
+        self::assertTrue($this->isValid('CZ12345678'));
+        self::assertTrue($this->isValid('SK2022638992'));
+    }
+
+    public function testRejectsInvalidInput(): void
+    {
+        self::assertFalse($this->isValid(''));                   // prázdné
+        self::assertFalse($this->isValid('12345678'));           // chybí prefix země
+        self::assertFalse($this->isValid('NL123456789B01XYZ'));  // moc dlouhé (>12)
+        self::assertFalse($this->isValid('N1868351246B01'));     // špatný prefix
+    }
+}


### PR DESCRIPTION
## Problém

Při přidávání dodavatele se zahraničním DIČ (ověření přes VIES) systém odmítne každé DIČ, které po prefixu země obsahuje písmeno. Příklad: nizozemské `NL123456789B01` (formát NL = 9 číslic + „B" + 2 číslice) skončí chybou „DIČ musí mít prefix země a 4-12 číslic (např. CZ12345678).". Týká se to i Rakouska (`ATU…`), Španělska, Francie a Irska.

## Příčina

Validační regex povoluje po dvoupísmenném kódu země jen číslice — `^[A-Z]{2}\d{4,12}$` v `ViesLookupAction.php` a `^([A-Z]{2})(\d{4,12})$` v `ViesClient.php`.

## Oprava

Po prefixu země se nově povolí 2-12 alfanumerických znaků — `^[A-Z]{2}[A-Z0-9+*]{2,12}$` (`+`/`*` kvůli starším irským DIČ). Tuzemská i slovenská DIČ procházejí beze změny.

- `ViesLookupAction.php` – validace + přesnější chybová hláška
- `ViesClient.php` – stejný regex (zachytává kód země a číslo pro VIES dotaz)
- `ErrorCatalog.php` – sladěný CZ→EN překlad hlášky
- nový unit test `ViesLookupVatFormatTest`
- záznam v `CHANGELOG.md`

## Test

`cd api && php vendor/bin/phpunit --filter ViesLookupVatFormat`
