### PR TITLE
feat(pdf): PDF/A-3b pro všechny PDF výstupy + podpis zachovává konformitu

### DIFF
--- a/api/src/Service/Pdf/MpdfFontConfig.php
+++ b/api/src/Service/Pdf/MpdfFontConfig.php
@@ -64,6 +64,14 @@ final class MpdfFontConfig
         ];
 
         return [
+            // PDF/A-3b (ISO 19005-3) — archivní formát pro VŠECHNY PDF výstupy.
+            // Tuto sdílenou konfiguraci spreadují všechny renderery (Invoice,
+            // PurchaseInvoice, WorkReport, DphBook, 3× Logbook), takže PDF/A se
+            // zapne jedním místem. mPDF doplní sRGB OutputIntent + XMP pdfaid;
+            // CMYK obrázky PDFAauto převede do sRGB (jeden OutputIntent).
+            'PDFA'             => true,
+            'PDFAversion'      => '3-B',
+            'PDFAauto'         => true,
             'fontDir'          => array_merge($defCfg['fontDir'], [self::fontDir()]),
             'fontdata'         => $fontData,
             'default_font'     => self::DEFAULT_FONT,

--- a/api/src/Service/Pdf/PdfSigner.php
+++ b/api/src/Service/Pdf/PdfSigner.php
@@ -204,7 +204,11 @@ final class PdfSigner
         $newSize = $size + 2;
         $xrefOffset = strlen($base) + strlen($body);
         $xref = $this->buildXref($offsets);
-        $trailerOut = "trailer\n<< /Size $newSize /Root $rootNum 0 R /Prev $prevXref >>\n"
+        // PDF/A vyžaduje /ID v traileru (ISO 19005-3 clause 6.1.3). Inkrementální
+        // update musí původní /ID zachovat, jinak podepsané PDF přestane být PDF/A
+        // (ověřeno veraPDF). Přeneseme /ID z posledního traileru vstupního PDF.
+        $id = preg_match('~/ID\s*\[\s*<[^>]*>\s*<[^>]*>\s*\]~', $trailer, $m) ? ' ' . $m[0] : '';
+        $trailerOut = "trailer\n<< /Size $newSize /Root $rootNum 0 R /Prev $prevXref$id >>\n"
                     . "startxref\n$xrefOffset\n%%EOF\n";
 
         return $base . $body . $xref . $trailerOut;

--- a/manual/11_Faktura_PDF.md
+++ b/manual/11_Faktura_PDF.md
@@ -116,6 +116,27 @@ Pokud je faktura starší a nemá zafixovaný kurz (legacy data), MyInvoice ho
 **doplní automaticky** při příštím otevření detailu nebo PDF (cache → ČNB →
 poslední známý). Detail viz [§ 10.4.2 Faktura v cizí měně](10_Faktura_editor.md#1042-faktura-v-cizi-mene-eur-usd-prepocet-do-czk).
 
+### 11.2.2 PDF/A-3b (archivní formát)
+
+Všechna generovaná PDF (faktury, přijaté faktury, výkazy práce, Kniha DPH,
+Kniha jízd) jsou ve formátu **PDF/A-3b** (ISO 19005-3) — standardu pro
+**dlouhodobou archivaci**. Dokument je soběstačný a vykreslí se stejně na
+každém zařízení i tiskárně, dnes i za 20 let.
+
+- **Vložené fonty** — písmo je součástí souboru, takže text jde vyhledávat
+  a kopírovat a nikde nedojde k záměně fontu.
+- **Barevný profil** — dokument nese barevný profil **sRGB**. Logo nebo obrázek
+  v jiném barevném prostoru (CMYK) se **automaticky převede** na sRGB, aby
+  archiv zůstal konzistentní (PDF/A nepovoluje míchání barevných prostorů).
+- **ISDOC příloha** — strukturovaná data faktury jsou vložená přímo v PDF jako
+  příloha, viz [§ 15.3.5](15_Exporty.md).
+- **Elektronický podpis** — PAdES podpis archivní konformitu **zachová**,
+  viz [§ 37](37_Elektronicke_podpisy.md).
+
+> 🔎 **Ověření konformity.** Výstup je validován referenčním ISO validátorem
+> **veraPDF** (ISO 19005-3, flavour `3b`). Procházejí všechny varianty — faktury
+> i přijaté faktury, s logem (RGB i CMYK) i bez, podepsané i nepodepsané.
+
 ## 11.3 QR platba
 
 ![QR platba na PDF](img/10_qr_platba.webp)

--- a/manual/15_Exporty.md
+++ b/manual/15_Exporty.md
@@ -123,10 +123,11 @@ zakázka se podle `project_number` najde nebo automaticky vytvoří.
 
 ### 15.3.5 ISDOC v PDF příloze (3.6.2+)
 
-Při generování PDF faktury se ISDOC XML přibalí jako PDF/A-3 attachment
-(`/Names /EmbeddedFiles` + `/AF` v catalog). Účetní programy si data
-extrahují přímo z PDF — stačí přeposlat jediný soubor. Pod variabilním
-symbolem se v PDF zobrazí vizuální `ISDOC` badge.
+Samotné PDF je konformní **PDF/A-3b** (ISO 19005-3, viz
+[§ 11.2.2](11_Faktura_PDF.md#1122-pdfa-3b-archivni-format)). Při generování se
+do něj ISDOC XML přibalí jako příloha (PDF/A-3 associated file). Účetní
+programy si data extrahují přímo z PDF — stačí přeposlat jediný soubor. Pod
+variabilním symbolem se v PDF zobrazí vizuální `ISDOC` badge.
 
 - Vkládá se jen pro **CZK faktury s přiděleným VS**.
 - Lze vypnout per-dodavatel v *Nastavení → Dodavatel → Vkládat ISDOC XML

--- a/manual/37_Elektronicke_podpisy.md
+++ b/manual/37_Elektronicke_podpisy.md
@@ -27,6 +27,11 @@ nastaveným TSA serverem o **PAdES-T**. Odchozí e-mail se podepisuje jako
 **S/MIME** zpráva. S/MIME podpis potvrzuje odesílatele a integritu zprávy,
 ale e-mail nešifruje.
 
+> 📁 **Podpis zachovává archivní formát.** Faktury se generují jako PDF/A-3b
+> ([§ 11.2.2](11_Faktura_PDF.md#1122-pdfa-3b-archivni-format)) a elektronický
+> podpis tuto archivní konformitu **zachová** — podepsaný dokument je stále
+> validní PDF/A-3b (ověřeno nástrojem veraPDF).
+
 ## 37.1 Základní pojmy
 
 | Pojem | Význam |


### PR DESCRIPTION
## Shrnutí
Všechny generované PDF (faktury, přijaté faktury, výkazy práce, Kniha DPH, Kniha jízd) jsou nově konformní **PDF/A-3b** (ISO 19005-3) — formát pro dlouhodobou archivaci. Dosud šlo o obyčejné PDF 1.4 (i když dokumentace ho u ISDOC přílohy označovala jako „PDF/A-3").

## Změny

### Kód
1. **`MpdfFontConfig::options()`** — zapnut PDF/A-3b režim mPDF (`'PDFA' => true, 'PDFAversion' => '3-B', 'PDFAauto' => true`). Tuto sdílenou konfiguraci spreadují **všechny renderery** (Invoice, PurchaseInvoice, WorkReport, DphBook, 3× Logbook), takže PDF/A se zapne jedním místem. mPDF doplní sRGB OutputIntent + XMP pdfaid; fonty už byly embedded subset; ISDOC associated file zůstává.

2. **`PdfSigner`** — zachování `/ID` v inkrementálním traileru. PAdES podpis dosud nepřenášel `/ID` z původního traileru, což porušovalo PDF/A (ISO 19005-3 **clause 6.1.3** — trailer musí obsahovat /ID). Oprava přenese původní /ID → podepsané PDF zůstává validní PDF/A-3b.

### Dokumentace (uživatelská)
- **§ 11.2.2** (nová) — PDF/A-3b: vložené fonty, barevný profil sRGB + automatická konverze CMYK, ISDOC příloha, podpis, ověření veraPDF.
- **§ 15.3.5** — ISDOC je příloha v konformním PDF/A-3b.
- **§ 37** — podpis zachovává archivní konformitu.

## Barevné profily
PDF/A povoluje jen jeden OutputIntent → použit **sRGB**. RGB obsah (text, RGB obrázky) je pokrytý. **CMYK obrázky** (logo) mPDF `PDFAauto` automaticky převede do sRGB — barevné prostory se nemíchají, per-image ICC profily nejsou potřeba.

## Testy konformity
Validováno referenčním ISO validátorem **veraPDF 1.30.2** (flavour `3b`), na MyInvoice 4.30.1:

| Varianta | PDF/A-3b |
|---|---|
| Faktura — bez loga | ✅ PASS |
| Faktura — RGB logo | ✅ PASS |
| Faktura — CMYK logo | ✅ PASS |
| Přijatá faktura | ✅ PASS |
| Podepsané (PAdES-B) | ✅ PASS |

> Pozn.: DynaPDF `CheckConformance` je **konvertor, ne preflight validátor** (z jeho dokumentace: *„CheckConformance() is no preflight function … not possible to check whether a file is already a valid PDF/A"*), proto se validuje veraPDF (ISO referenční verifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
