### PR TITLE
feat(tax): hlídání limitu sociálního pojištění u vedlejší činnosti (#134)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4363,6 +4363,7 @@ components:
         - health_assessment_pct
         - social_min_base_main
         - social_min_base_secondary
+        - social_secondary_participation_threshold
         - health_min_base
         - mortgage_cap
         - pension_cap
@@ -4387,6 +4388,7 @@ components:
         health_assessment_pct: { type: number }
         social_min_base_main: { type: number }
         social_min_base_secondary: { type: number }
+        social_secondary_participation_threshold: { type: number, description: Rozhodná částka (zisk) pro povinnou účast na důch. pojištění u vedlejší SVČ }
         health_min_base: { type: number }
         mortgage_cap: { type: number, description: Strop odpočtu úroků z hypotéky }
         pension_cap: { type: number }

--- a/api/src/Service/Tax/TaxConstants.php
+++ b/api/src/Service/Tax/TaxConstants.php
@@ -72,6 +72,9 @@ final class TaxConstants
             'health_assessment_pct' => 0.50, // zdravotní: 50 % zisku
             'social_min_base_main'      => 195540, // 35 % × 46 557 × 12
             'social_min_base_secondary' => 61476,  // min. roční zákl. vedlejší činnost
+            // Rozhodná částka (daňový základ / zisk) pro povinnou účast na důchodovém
+            // pojištění u vedlejší SVČ — pod ní se sociální pojištění neplatí (ČSSZ).
+            'social_secondary_participation_threshold' => 111736, // 2025
             'health_min_base'           => 279342, // 50 % × 46 557 × 12
             // Výdajové paušály — strop uplatnitelných výdajů dle sazby
             'expense_caps' => [30 => 600000, 40 => 800000, 60 => 1200000, 80 => 1600000],
@@ -106,6 +109,7 @@ final class TaxConstants
             'health_assessment_pct' => 0.50,
             'social_min_base_main'      => 235044, // 40 % × 48 967 × 12
             'social_min_base_secondary' => 64644,  // min. roční zákl. vedlejší činnost
+            'social_secondary_participation_threshold' => 117521, // 2026 (ČSSZ)
             'health_min_base'           => 293802, // 50 % × 48 967 × 12
             'expense_caps' => [30 => 600000, 40 => 800000, 60 => 1200000, 80 => 1600000],
             'mortgage_cap' => 150000,

--- a/api/src/Service/Tax/TaxOptimizer.php
+++ b/api/src/Service/Tax/TaxOptimizer.php
@@ -218,6 +218,30 @@ final class TaxOptimizer
         $rate = (int) ($profile['activity_rate'] ?? 40);
         $declared = (string) ($profile['flat_tax_band'] ?? 'none');
 
+        // Projekce ZISKU (příjmy − výdaje) pro limit vedlejší činnosti. Výdaje dle
+        // profilu: skutečné (roční odhad), nebo výdajový paušál % se stropem — stejně
+        // jako computeRegular(). Rozhodná částka se měří proti zisku, ne příjmu.
+        $useActual = !empty($profile['use_actual_expenses']);
+        $projectedExpenses = $useActual
+            ? max(0.0, (float) ($profile['actual_expenses'] ?? 0))
+            : min($projected * $rate / 100, (float) ($c['expense_caps'][$rate] ?? PHP_INT_MAX));
+        $projectedProfit = max(0.0, $projected - $projectedExpenses);
+
+        // Vedlejší SVČ: rozhodná částka pro povinnou účast na důchodovém pojištění.
+        // Měsíc dopočítáme z rovnoměrného tempa zisku (nepotřebuje YTD výdaje).
+        $secondarySocial = null;
+        if (!empty($profile['is_secondary']) && isset($c['social_secondary_participation_threshold'])) {
+            $threshold = (float) $c['social_secondary_participation_threshold'];
+            $willCross = $projectedProfit >= $threshold;
+            $profitRunRate = $projectedProfit / 12;
+            $secondarySocial = [
+                'threshold'        => $threshold,
+                'projected_profit' => round($projectedProfit, 0),
+                'will_cross'       => $willCross,
+                'month'            => $willCross && $profitRunRate > 0 ? (int) ceil($threshold / $profitRunRate) : null,
+            ];
+        }
+
         $thresholds = [];
         if ($declared !== 'none' && isset($c['band_ceilings'][$rate][$declared])) {
             $thresholds[] = ['key' => 'band_ceiling', 'label' => 'strop pásma ' . $declared, 'value' => (float) $c['band_ceilings'][$rate][$declared]];
@@ -258,7 +282,9 @@ final class TaxOptimizer
             'months_elapsed' => $monthsElapsed,
             'run_rate'       => round($runRate, 0),
             'projected'      => round($projected, 0),
+            'projected_profit' => round($projectedProfit, 0),
             'crossings'      => $crossings,
+            'secondary_social' => $secondarySocial,
             'defer_advice'   => $defer,
         ];
     }

--- a/api/tests/Unit/Tax/TaxConstantsTest.php
+++ b/api/tests/Unit/Tax/TaxConstantsTest.php
@@ -22,6 +22,7 @@ final class TaxConstantsTest extends TestCase
         self::assertSame(0.50, $c['health_assessment_pct']);     // ← zdravotní 50 %, ne 55 %
         self::assertSame(195540, $c['social_min_base_main']);    // 35 % × 46 557 × 12
         self::assertSame(61476, $c['social_min_base_secondary']);
+        self::assertSame(111736, $c['social_secondary_participation_threshold']); // rozhodná částka vedlejší SVČ (ČSSZ)
         self::assertSame(279342, $c['health_min_base']);         // 50 % × 46 557 × 12
         self::assertSame([15204, 22320, 27840], $c['child_credits']);
     }
@@ -34,6 +35,7 @@ final class TaxConstantsTest extends TestCase
         self::assertSame(0.50, $c['health_assessment_pct']);
         self::assertSame(235044, $c['social_min_base_main']);    // 40 % × 48 967 × 12
         self::assertSame(64644, $c['social_min_base_secondary']);
+        self::assertSame(117521, $c['social_secondary_participation_threshold']); // rozhodná částka vedlejší SVČ 2026 (ČSSZ)
         self::assertSame(293802, $c['health_min_base']);         // 50 % × 48 967 × 12
     }
 

--- a/api/tests/Unit/Tax/TaxOptimizerTest.php
+++ b/api/tests/Unit/Tax/TaxOptimizerTest.php
@@ -143,4 +143,24 @@ final class TaxOptimizerTest extends TestCase
         self::assertSame(12, $vatLow['month']);
         self::assertNotNull($pred['defer_advice']);
     }
+
+    /** Vedlejší limit jen při is_secondary; měří se proti ZISKU (60 % paušál → zisk 40 %). */
+    public function testPredictSecondarySocialThreshold(): void
+    {
+        // Bez vedlejší činnosti se blok vůbec nepočítá.
+        $pred = $this->opt->predict($this->profile(), 150_000, 6, $this->c);
+        self::assertNull($pred['secondary_social']);
+
+        // Vedlejší + 60 % paušál: projekce 300k příjmu → zisk 120k ≥ 111 736 → překročí.
+        $cross = $this->opt->predict($this->profile(['is_secondary' => true]), 150_000, 6, $this->c);
+        self::assertSame(120000.0, $cross['secondary_social']['projected_profit']); // 300k − 60 %
+        self::assertSame(111736.0, $cross['secondary_social']['threshold']);
+        self::assertTrue($cross['secondary_social']['will_cross']);
+        self::assertSame(12, $cross['secondary_social']['month']); // ceil(111 736 / 10 000)
+
+        // Nízký zisk (projekce 100k → zisk 40k) zůstane pod limitem.
+        $under = $this->opt->predict($this->profile(['is_secondary' => true]), 50_000, 6, $this->c);
+        self::assertFalse($under['secondary_social']['will_cross']);
+        self::assertNull($under['secondary_social']['month']);
+    }
 }

--- a/manual/32_Danovy_optimalizator.md
+++ b/manual/32_Danovy_optimalizator.md
@@ -38,6 +38,15 @@ hlídá překročení limitů:
 Když překročení 2 M hrozí na konci roku, poradí **odložit prosincové faktury do
 ledna** a zůstat pod limitem.
 
+Při zaškrtnuté **vedlejší činnosti** přibude pod teploměrem ještě řádek
+**rozhodné částky pro povinnou účast na důchodovém (sociálním) pojištění**
+(2025 = 111 736 Kč, 2026 = 117 521 Kč dle ČSSZ). Na rozdíl od limitů výše se
+měří proti **projektovanému zisku** (příjmy − výdaje dle zvoleného paušálu /
+skutečných výdajů), ne proti příjmu — proto je samostatným řádkem mimo teploměr.
+Ukáže, zda zisk zůstane pod limitem (sociální pojištění z vedlejší činnosti se
+neplatí), nebo limit překročíš a v kterém měsíci. Částku lze pro daný rok upravit
+v `Nastavení → Číselníky → Daňové konstanty`.
+
 ## Profil (per rok)
 
 Nastav jednou, dopočítá se automaticky. Uloží se k danému roku:
@@ -47,7 +56,7 @@ Nastav jednou, dopočítá se automaticky. Uloží se k danému roku:
 | Typ činnosti | Výdajový paušál 40 / 60 / 80 % (dle živnosti) |
 | Výdaje | **Paušál %** nebo **Skutečné** (reálné roční výdaje z daňové evidence) |
 | Pásmo paušální daně | Přihlášené pásmo (none / 1. / 2. / 3.) |
-| Vedlejší činnost | Jiná minima pojistného |
+| Vedlejší činnost | Jiná minima pojistného; v běžícím roce přidá na teploměr i hlídání rozhodné částky pro účast na sociálním pojištění |
 | Slevy / odpočty | Manžel/ka, počet dětí, úroky hypotéky, penzijní/životní, dary |
 
 ## Dashboard

--- a/web/src/api/tax.ts
+++ b/web/src/api/tax.ts
@@ -34,6 +34,8 @@ export interface TaxConstantsData {
   health_assessment_pct: number
   social_min_base_main: number
   social_min_base_secondary: number
+  /** Rozhodná částka (zisk) pro povinnou účast na důch. pojištění u vedlejší SVČ */
+  social_secondary_participation_threshold: number
   health_min_base: number
   expense_caps: Record<string, number>
   mortgage_cap: number

--- a/web/src/composables/useTaxEngine.ts
+++ b/web/src/composables/useTaxEngine.ts
@@ -104,8 +104,10 @@ export function compare(p: EngineProfile, income: number, c: TaxConstantsData): 
 }
 
 export interface Crossing { key: string; val: number; will: boolean; month: number | null }
+export interface SecondarySocial { threshold: number; profit: number; will: boolean; month: number | null }
 export interface PredictResult {
-  run: number; proj: number; cross: Crossing[]; deferMonth: number | null; ytd: number; months: number
+  run: number; proj: number; profit: number; cross: Crossing[]
+  secondary: SecondarySocial | null; deferMonth: number | null; ytd: number; months: number
 }
 
 export function predict(p: EngineProfile, ytd: number, months: number, c: TaxConstantsData): PredictResult {
@@ -128,5 +130,21 @@ export function predict(p: EngineProfile, ytd: number, months: number, c: TaxCon
   const v = cross.find(x => x.key === 'vatLow')
   const deferMonth = v && v.will && v.month! >= 11 && v.month! <= 12 ? v.month : null
 
-  return { run, proj, cross, deferMonth, ytd, months }
+  // Projekce ZISKU (příjmy − výdaje) pro limit vedlejší činnosti — výdaje dle profilu,
+  // stejně jako regular(). Rozhodná částka se měří proti zisku, ne proti příjmu.
+  const projExpenses = p.use_actual_expenses
+    ? Math.max(0, p.actual_expenses || 0)
+    : Math.min(proj * p.activity_rate / 100, c.expense_caps[p.activity_rate])
+  const profit = Math.max(0, proj - projExpenses)
+
+  // Vedlejší SVČ: rozhodná částka pro povinnou účast na důchodovém pojištění.
+  let secondary: SecondarySocial | null = null
+  const threshold = c.social_secondary_participation_threshold
+  if (p.is_secondary && threshold) {
+    const will = profit >= threshold
+    const profitRun = profit / 12
+    secondary = { threshold, profit, will, month: will && profitRun > 0 ? Math.ceil(threshold / profitRun) : null }
+  }
+
+  return { run, proj, profit, cross, secondary, deferMonth, ytd, months }
 }

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -2637,6 +2637,7 @@
     "tax_f_health_pct": "Zdrav. základ (% zisku)",
     "tax_f_social_min_main": "Min. základ soc. (hlavní)",
     "tax_f_social_min_sec": "Min. základ soc. (vedlejší)",
+    "tax_f_social_sec_threshold": "Rozhodná částka soc. (vedlejší)",
     "tax_f_health_min": "Min. základ zdrav.",
     "tax_f_credit_taxpayer": "Sleva na poplatníka",
     "tax_f_credit_spouse": "Sleva na manžela/ku",
@@ -3553,6 +3554,9 @@
     "limit_vatHigh": "Okamžitý plátce DPH",
     "will_cross_in": "překročíš v {month}",
     "wont_cross": "letos nepřekročíš",
+    "limit_social_secondary": "Limit soc. pojištění (vedlejší činnost)",
+    "social_secondary_cross": "projekce zisku {profit} ho překročí v {month} — budeš platit sociální pojištění",
+    "social_secondary_ok": "projekce zisku {profit} zůstává pod limitem — sociální pojištění neplatíš",
     "defer_tip": "Limit 2 M překročíš až {month}. Posunutím prosincových faktur do ledna zůstaneš pod limitem (neplátce + paušál).",
     "disclaimer": "Orientační výpočet dle aktuálních konstant — nenahrazuje daňové poradenství. Příjmy z vystavených (zaplacených) faktur."
   },

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -2637,6 +2637,7 @@
     "tax_f_health_pct": "Health base (% profit)",
     "tax_f_social_min_main": "Min. social base (main)",
     "tax_f_social_min_sec": "Min. social base (secondary)",
+    "tax_f_social_sec_threshold": "Decisive amount soc. (secondary)",
     "tax_f_health_min": "Min. health base",
     "tax_f_credit_taxpayer": "Taxpayer credit",
     "tax_f_credit_spouse": "Spouse credit",
@@ -3553,6 +3554,9 @@
     "limit_vatHigh": "Immediate VAT payer",
     "will_cross_in": "crossing in {month}",
     "wont_cross": "not crossing this year",
+    "limit_social_secondary": "Social insurance limit (secondary activity)",
+    "social_secondary_cross": "projected profit {profit} crosses it in {month} — you will pay social insurance",
+    "social_secondary_ok": "projected profit {profit} stays below — no social insurance",
     "defer_tip": "You will cross 2 M in {month}. Deferring December invoices to January keeps you under the limit (non-VAT + flat tax).",
     "disclaimer": "Indicative calculation per current constants — not tax advice. Income from issued (paid) invoices."
   },

--- a/web/src/pages/admin/Codebooks.vue
+++ b/web/src/pages/admin/Codebooks.vue
@@ -1209,6 +1209,8 @@ watch(tab, (newTab) => {
               <input v-model.number="taxModel.social_min_base_main" type="number" class="mt-0.5 h-8 w-full px-2 border border-neutral-300 rounded text-sm font-mono" /></label>
             <label class="block"><span class="text-xs text-neutral-500">{{ t('codebooks.tax_f_social_min_sec') }}</span>
               <input v-model.number="taxModel.social_min_base_secondary" type="number" class="mt-0.5 h-8 w-full px-2 border border-neutral-300 rounded text-sm font-mono" /></label>
+            <label class="block"><span class="text-xs text-neutral-500">{{ t('codebooks.tax_f_social_sec_threshold') }}</span>
+              <input v-model.number="taxModel.social_secondary_participation_threshold" type="number" class="mt-0.5 h-8 w-full px-2 border border-neutral-300 rounded text-sm font-mono" /></label>
             <label class="block"><span class="text-xs text-neutral-500">{{ t('codebooks.tax_f_health_min') }}</span>
               <input v-model.number="taxModel.health_min_base" type="number" class="mt-0.5 h-8 w-full px-2 border border-neutral-300 rounded text-sm font-mono" /></label>
           </div>

--- a/web/src/pages/tax/TaxOptimizer.vue
+++ b/web/src/pages/tax/TaxOptimizer.vue
@@ -337,6 +337,19 @@ async function save() {
                   {{ x.will ? t('tax.will_cross_in', { month: monthLabel(x.month) }) : t('tax.wont_cross') }}
                 </div>
               </div>
+
+              <!-- Vedlejší činnost: rozhodná částka pro placení sociálního pojištění (měří se proti zisku) -->
+              <div v-if="pred.secondary"
+                class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm border"
+                :class="pred.secondary.will ? 'bg-danger-50 border-danger-500/30 text-danger-600' : 'bg-success-50 border-success-600/20 text-success-700'">
+                <span>{{ pred.secondary.will ? '⚠' : '✓' }}</span>
+                <div>
+                  <b>{{ t('tax.limit_social_secondary') }}</b> · {{ formatMoney(pred.secondary.threshold, 'CZK') }} —
+                  {{ pred.secondary.will
+                    ? t('tax.social_secondary_cross', { month: monthLabel(pred.secondary.month), profit: formatMoney(pred.secondary.profit, 'CZK') })
+                    : t('tax.social_secondary_ok', { profit: formatMoney(pred.secondary.profit, 'CZK') }) }}
+                </div>
+              </div>
             </div>
 
             <!-- tip -->


### PR DESCRIPTION
## Co to řeší

Closes #134. V teploměru daňového optimalizátoru přibude při zaškrtnuté **vedlejší činnosti** řádek, který hlídá blízkost k **rozhodné částce pro povinnou účast na důchodovém (sociálním) pojištění**. Pod ní se z vedlejší SVČ sociální pojištění neplatí.

Hodnoty dle ČSSZ (admin-editovatelné v číselníku):
- **2025:** 111 736 Kč
- **2026:** 117 521 Kč

## Klíčový detail výpočtu

Rozhodná částka se měří proti **zisku** (příjmy − výdaje), ne proti příjmu jako ostatní limity na teploměru. Proto:
- projekce počítá zisk podle profilu (výdajový paušál se stropem / skutečné výdaje, stejně jako standardní režim),
- limit je **samostatný textový řádek** mimo příjmově škálovaný proužek teploměru — aby uživatele nemátlo, kde leží (na příjmové ose by seděl na špatném místě).

## Změny

**Backend**
- `TaxConstants` — nová konstanta `social_secondary_participation_threshold` (2025/2026).
- `TaxOptimizer::predict()` — projekce zisku + blok `secondary_social` (jen při `is_secondary`).
- `openapi.yaml` — doplněn klíč do `TaxConstantsInput`.

**Frontend**
- `useTaxEngine.predict()` — zrcadlí backend (projekce zisku, secondary).
- `TaxOptimizer.vue` — nový řádek varování (defenzivně přes `v-if`).
- `Codebooks.vue` — editace konstanty v číselníku.
- i18n `cs`/`en`.

**Dokumentace**
- `manual/32_Danovy_optimalizator.md` — sekce „Běžící rok".

## Testy
- `TaxConstantsTest` — hodnoty 2025/2026.
- `TaxOptimizerTest` — `secondary_social` jen při `is_secondary`, měří se proti zisku, správný měsíc překročení.
- Zelené: `phpunit --filter 'TaxConstantsTest|TaxOptimizerTest'` (14 testů), `vue-tsc --noEmit` čistý.

## Poznámky k nasazení
- **Žádná DB migrace** — konstanty jsou JSON override, nový klíč se automaticky doplní z výchozích hodnot.
- Ověřeno na produkci.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
