### PR TITLE
fix(dph): pořízení z JČS / RC — zaokrouhlení daně ze základu v Kč + ř.43/46 v přiznání

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to MyInvoice.cz are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Kontrolní hlášení a přiznání DPH u pořízení z EU / reverse charge — správné zaokrouhlení a řádky.** U dokladů v cizí měně se samovyměřená daň (pořízení zboží z JČS, přijetí služby, dovoz) nově počítá **ze základu přepočteného na Kč × sazba** (§ 37/1) místo z cizoměnové daně přenásobené kurzem. Dvojí zaokrouhlení dřív rozcházelo daň v **oddílu A.2 kontrolního hlášení** oproti přiznání o haléře (např. základ 100,05 € × kurz 25,00 = 2 501,25 Kč → daň 525,26 Kč, ne 525,25 Kč jako zaokrouhlení v eurech). V **přiznání (DPHDP3)** se navíc opravil řádek **43** (nárok na odpočet ze samovyměřených plnění) — plnil se do atributů řádku 45 (korekce odpočtu dle §75/§77/§79), takže portál EPO mohl hlásit chybu — a doplnil se chybějící součtový řádek **46** (odpočet daně celkem). Ověřeno proti referenčnímu schématu i výstupu EPO MF ČR.
+
 ## [4.31.0] — 2026-06-15
 
 ### Added

--- a/api/src/Service/Report/DphPriznaniBuilder.php
+++ b/api/src/Service/Report/DphPriznaniBuilder.php
@@ -145,7 +145,13 @@ final class DphPriznaniBuilder
         //   ř.40 pln23/odp_tuz23_nar     = tuzemsko 21 %
         //   ř.41 pln5/odp_tuz5_nar       = tuzemsko 12 %
         //   ř.42 dov_cu/odp_cu_nar       = dovoz CÚ
-        //   ř.43 odp_rezim/odp_rez_nar   = RC mirror odpočet (z ř. 3-13)
+        //   ř.43 nar_zdp23/od_zdp23      = odpočet ze samovyměřených plnění (ř. 3-13)
+        //                                  ve sloupci „V plné výši", sazba 21 %.
+        //                                  POZOR: odp_rezim/odp_rez_nar je ř.45 (korekce
+        //                                  odpočtu dle §75/§77/§79 — registrace, vyrovnání),
+        //                                  NE ř.43. Číselník nemá 12% RC kód (kódy 5/23/24/25
+        //                                  nesou 21 %), takže 21% sloupec pokryje celý mirror.
+        //   ř.46 odp_sum_nar             = součtový řádek odpočtu (ř.40-45, „V plné výši")
         //   ř.47 nar_maj/—               = hodnota pořízeného majetku
         //                                  (doplňující údaj, jen základ; XSD má
         //                                  jediný atribut, daň se neuvádí)
@@ -183,7 +189,7 @@ final class DphPriznaniBuilder
             '40' => ['veta' => 4, 'base' => 'pln23',      'vat' => 'odp_tuz23_nar'],
             '41' => ['veta' => 4, 'base' => 'pln5',       'vat' => 'odp_tuz5_nar'],
             '42' => ['veta' => 4, 'base' => 'dov_cu',     'vat' => 'odp_cu_nar'],
-            '43' => ['veta' => 4, 'base' => 'odp_rezim',  'vat' => 'odp_rez_nar'],
+            '43' => ['veta' => 4, 'base' => 'nar_zdp23',  'vat' => 'od_zdp23'],
             '47' => ['veta' => 4, 'base' => 'nar_maj',    'vat' => null],
         ];
 
@@ -235,6 +241,12 @@ final class DphPriznaniBuilder
             $dphdp3->appendChild($veta3);
         }
         if (!empty($veta4Attrs)) {
+            // ř.46 (odp_sum_nar) = součtový řádek 40-45 ve sloupci „V plné výši" =
+            // celkový nárok na odpočet. Bez něj EPO portál hlásí propustnou chybu
+            // („Odpočet daně celkem nevyplněn"). Rovná se ř.63 (odp_zocelk) — proto
+            // používáme totéž $totalDanOdpocitatelne, které ř.47 (doplňující údaj
+            // k majetku) správně nezapočítává.
+            $veta4Attrs['odp_sum_nar'] = $this->formatAmount($totalDanOdpocitatelne);
             $veta4 = $dom->createElement('Veta4');
             foreach ($veta4Attrs as $k => $v) $veta4->setAttribute($k, $v);
             $dphdp3->appendChild($veta4);

--- a/api/src/Service/Report/VatLedgerService.php
+++ b/api/src/Service/Report/VatLedgerService.php
@@ -280,9 +280,10 @@ final class VatLedgerService
         if ($source === 'purchase' && $isRc && $vatRate == 0.0 && (float) ($clsf['vat_rate'] ?? 0) > 0) {
             $vatRate = (float) $clsf['vat_rate'];
         }
-        if ($source === 'purchase' && $vatRaw == 0.0 && $isRc && $vatRate > 0) {
-            $vatRaw = round($baseRaw * $vatRate / 100, 2);
-        }
+        // RC samovyměření: dodavatel fakturuje bez DPH (daň 0) → daň si dopočítá příjemce.
+        // POZOR: daň se NEpočítá tady z cizoměnového základu, ale až níže ze základu
+        // přepočteného na CZK (vat_czk) — viz komentář tam. Tady jen příznak.
+        $rcSelfAssess = $source === 'purchase' && $vatRaw == 0.0 && $isRc && $vatRate > 0;
 
         // §75 poměrný odpočet — u přijatých s 'proportional' se odpočet (základ i daň)
         // uplatní jen v poměrné výši (vat_deduction_percent). Zbytek je nedaňová část
@@ -294,6 +295,17 @@ final class VatLedgerService
             $vatRaw  = round($vatRaw * $pct, 2);
             $isPartialDeduction = true;
         }
+
+        $baseCzk = round($baseRaw * $rate, 2);
+        // Daň u RC samovyměření = ZÁKLAD přepočtený na CZK × sazba (§ 37 odst. 1:
+        // „daň se vypočte ze základu daně" — a základem je hodnota v Kč). Počítat ji
+        // z cizoměnové daně přenásobené kurzem by dvojím zaokrouhlením rozešlo KH
+        // oddíl A.2 a přiznání ř.3/43 o haléře (např. 305 312,26 × 21 % = 64 115,57 Kč,
+        // ne 64 115,67 Kč jako round(EUR daň) × kurz). U běžných tuzemských dokladů
+        // bereme skutečnou daň z dokladu přepočtenou kurzem (zpravidlo se neuplatní).
+        $vatCzk = $rcSelfAssess
+            ? round($baseCzk * $vatRate / 100, 2)
+            : round($vatRaw * $rate, 2);
 
         return [
             'source'                => $source,
@@ -319,8 +331,8 @@ final class VatLedgerService
             'vat_deduction_partial' => $isPartialDeduction,
             'vat_rate'              => $vatRate,
             'currency'              => (string) $r['currency'],
-            'base_czk'              => round($baseRaw * $rate, 2),
-            'vat_czk'               => round($vatRaw * $rate, 2),
+            'base_czk'              => $baseCzk,
+            'vat_czk'               => $vatCzk,
             'total_with_vat_czk'    => round((float) $r['inv_total'] * $rate, 2),
             'is_fixed_asset'        => (bool) $r['is_fixed_asset'],
             'exchange_rate'         => $rate,

--- a/api/tests/Integration/Report/IdentifiedPersonDphTest.php
+++ b/api/tests/Integration/Report/IdentifiedPersonDphTest.php
@@ -185,7 +185,8 @@ final class IdentifiedPersonDphTest extends TestCase
         $result = $this->dph->build($this->supplierId, self::YEAR, self::MONTH, 'monthly');
         $dp = (new \SimpleXMLElement($result['xml']))->DPHDP3;
         self::assertSame('P', (string) $dp->VetaD['typ_platce']);
-        self::assertSame('8000', (string) $dp->Veta4['odp_rezim'], 'plátce má zrcadlový odpočet ř.43');
+        self::assertSame('8000', (string) $dp->Veta4['nar_zdp23'], 'plátce má zrcadlový odpočet ř.43 (nar_zdp23, ne odp_rezim)');
+        self::assertSame('1680', (string) $dp->Veta4['odp_sum_nar'], 'plátce má ř.46 součtový odpočet = ř.43');
     }
 
     // ── helpers (vzor KhDphTaxScenariosTest) ─────────────────────────────────

--- a/api/tests/Integration/Report/KhDphTaxScenariosTest.php
+++ b/api/tests/Integration/Report/KhDphTaxScenariosTest.php
@@ -246,9 +246,14 @@ final class KhDphTaxScenariosTest extends TestCase
         $this->assertSame('53000', (string) $v4['pln23'], 'ř.40 základ = 10000+2000+15000+11000−25000+40000');
         $this->assertSame('11130', (string) $v4['odp_tuz23_nar']);
 
-        // ř.43 RC mirror odpočet = A.2 (P4) + B.1 (P5)
-        $this->assertSame('17000', (string) $v4['odp_rezim'], 'ř.43 = 8000 (P4) + 9000 (P5)');
-        $this->assertSame('3570',  (string) $v4['odp_rez_nar']);
+        // ř.43 RC mirror odpočet = A.2 (P4) + B.1 (P5). Atributy nar_zdp23/od_zdp23
+        // (sloupec „V plné výši", 21 %) — NE odp_rezim/odp_rez_nar (to je ř.45 korekce §75/§77/§79).
+        $this->assertSame('17000', (string) $v4['nar_zdp23'], 'ř.43 základ = 8000 (P4) + 9000 (P5)');
+        $this->assertSame('3570',  (string) $v4['od_zdp23'], 'ř.43 odpočet = 1680 + 1890');
+        $this->assertSame('', (string) $v4['odp_rezim'], 'ř.45 (korekce) se NESMÍ plést s ř.43 (mirror odpočet)');
+
+        // ř.46 součtový řádek odpočtu (ř.40-45 „V plné výši") = ř.40 (11130) + ř.43 (3570)
+        $this->assertSame('14700', (string) $v4['odp_sum_nar'], 'ř.46 = 11130 (ř.40) + 3570 (ř.43)');
 
         // ř.47 hodnota pořízeného majetku (P8)
         $this->assertSame('40000', (string) $v4['nar_maj'], 'ř.47 = 40000 (P8 majetek)');
@@ -467,7 +472,7 @@ final class KhDphTaxScenariosTest extends TestCase
         // ── DPHDP3 květen: ř.3 + ř.43 + KH A.2 ──
         $dpMay = (new \SimpleXMLElement($this->dph->build($this->supplierId, self::YEAR, 5, 'monthly')['xml']))->DPHDP3;
         $this->assertSame('305312', (string) $dpMay->Veta1['p_zb23'], 'DPHDP3/05 ř.3 základ');
-        $this->assertSame('305312', (string) $dpMay->Veta4['odp_rezim'], 'DPHDP3/05 ř.43 mirror');
+        $this->assertSame('305312', (string) $dpMay->Veta4['nar_zdp23'], 'DPHDP3/05 ř.43 mirror');
 
         $khMay = new \SimpleXMLElement($this->kh->build($this->supplierId, self::YEAR, 5)['xml']);
         $this->assertCount(1, $khMay->DPHKH1->VetaA2, 'KH/05 A.2: pořízení z JČS');
@@ -501,7 +506,7 @@ final class KhDphTaxScenariosTest extends TestCase
         $this->assertNotSame('', (string) $dp->Veta1['dan_pzb23'], 'ř.3 daň NESMÍ být prázdná');
         $this->assertNotSame('0', (string) $dp->Veta1['dan_pzb23'], 'ř.3 daň NESMÍ být 0 (issue #116)');
         // ř.43 mirror odpočet
-        $this->assertSame('12546', (string) $dp->Veta4['odp_rezim'], 'ř.43 mirror základ');
+        $this->assertSame('12546', (string) $dp->Veta4['nar_zdp23'], 'ř.43 mirror základ');
 
         // KH A.2 — základ i daň v bucketu 21 % (efektivní sazba z klasifikace)
         $kh = new \SimpleXMLElement($this->kh->build($this->supplierId, self::YEAR, self::MONTH)['xml']);
@@ -515,6 +520,48 @@ final class KhDphTaxScenariosTest extends TestCase
         foreach ($book['sections'] as $s) $sec[$s['key']] = $s;
         $this->assertArrayHasKey('43.003', $sec);
         $this->assertEqualsWithDelta(2634.66, $sec['43.003']['subtotal_vat'], 0.01, 'Kniha: samovyměření z classification rate');
+    }
+
+    /**
+     * Zaokrouhlení samovyměřené daně u cizoměnového RC (pořízení z JČS v EUR).
+     *
+     * Daň se MUSÍ počítat ze ZÁKLADU přepočteného na CZK (§ 37/1), ne z cizoměnové
+     * daně přenásobené kurzem — jinak dvojí zaokrouhlení rozejde KH A.2 a přiznání
+     * o haléře. Typický případ pořízení vozidla z JČS: zaokrouhlení EUR-first
+     * dávalo o 0,01 Kč jinou daň než zákonný postup ze základu v Kč.
+     *
+     *   základ 100,05 EUR × kurz 25,00 = 2 501,25 Kč → daň 2 501,25 × 21 % = 525,2625 → 525,26 Kč
+     *   (chybně EUR-first: round(100,05 × 21 %)=21,01 EUR × 25 = 525,25 Kč)
+     */
+    public function testForeignCurrencyRcSelfAssessmentRoundsFromCzkBase(): void
+    {
+        $pdo = $this->db->pdo();
+        $eurId = (int) ($pdo->query("SELECT id FROM currencies WHERE code = 'EUR' ORDER BY id LIMIT 1")->fetchColumn() ?: 0);
+        if ($eurId === 0) {
+            $pdo->exec("INSERT INTO currencies (code, name) VALUES ('EUR', 'Euro')");
+            $eurId = (int) $pdo->lastInsertId();
+        }
+
+        $d = fn (int $day) => sprintf('%04d-%02d-%02d', self::YEAR, self::MONTH, $day);
+        $euVend = $this->client('EU dodavatel EUR', $this->deId, 'DE333333333', vendor: true);
+
+        // Kód 23 (pořízení z JČS), RC, základ 100,05 EUR, kurz 25,00.
+        $this->purchase('P-2099-EUR', $euVend, '23', true, 'invoice', $d(10), $d(10), [[100.05, 0, 21]],
+            currencyId: $eurId, exchangeRate: 25.00);
+
+        // ── KH A.2: základ i daň ze základu přepočteného na CZK ──
+        $kh = new \SimpleXMLElement($this->kh->build($this->supplierId, self::YEAR, self::MONTH)['xml']);
+        $this->assertCount(1, $kh->DPHKH1->VetaA2, 'A.2: EUR pořízení z JČS');
+        $this->assertSame('2501.25', (string) $kh->DPHKH1->VetaA2[0]['zakl_dane1'], 'A.2 základ = 100,05 × 25');
+        $this->assertSame('525.26', (string) $kh->DPHKH1->VetaA2[0]['dan1'],
+            'A.2 daň ze ZÁKLADU v CZK (525,26), NE EUR-first (525,25)');
+
+        // ── Kniha DPH: stejná daň (sdílený VatLedgerService) ──
+        $book = $this->book->build($this->supplierId, self::YEAR, self::MONTH);
+        $sec = [];
+        foreach ($book['sections'] as $s) $sec[$s['key']] = $s;
+        $this->assertArrayHasKey('43.003', $sec);
+        $this->assertEqualsWithDelta(525.26, $sec['43.003']['subtotal_vat'], 0.001, 'Kniha: daň ze základu v CZK');
     }
 
     /**
@@ -605,8 +652,10 @@ final class KhDphTaxScenariosTest extends TestCase
         $this->assertSame('10000', (string) $dp->Veta1['p_sl23_z'], 'ř.12 základ dovoz služby');
         $this->assertSame('2100',  (string) $dp->Veta1['dan_psl23_z'], 'ř.12 daň samovyměřena z kódu (ne z flagu)');
         // ř.43 zrcadlový odpočet
-        $this->assertSame('10000', (string) $dp->Veta4['odp_rezim'], 'ř.43 mirror základ');
-        $this->assertSame('2100',  (string) $dp->Veta4['odp_rez_nar'], 'ř.43 mirror odpočet');
+        $this->assertSame('10000', (string) $dp->Veta4['nar_zdp23'], 'ř.43 mirror základ');
+        $this->assertSame('2100',  (string) $dp->Veta4['od_zdp23'], 'ř.43 mirror odpočet');
+        // ř.46 součtový odpočet = jen ř.43 (žádný tuzemský odpočet) = 2100
+        $this->assertSame('2100',  (string) $dp->Veta4['odp_sum_nar'], 'ř.46 = ř.43 (2100)');
 
         // Kniha DPH — sekce 43.012 (dovoz služby, RC pár pod členěním 43) a 43.043 (mirror)
         $book = $this->book->build($this->supplierId, self::YEAR, self::MONTH);
@@ -714,6 +763,8 @@ final class KhDphTaxScenariosTest extends TestCase
         $this->assertSame('4200',  (string) $dp->Veta6['odp_zocelk'], 'ř.63 odpočet celkem');
         $this->assertSame('6300',  (string) $dp->Veta6['dano_da'], 'ř.64 vlastní daňová povinnost');
         $this->assertSame('',      (string) $dp->Veta6['dano_no'], 'ř.66 nadměrný odpočet nesmí být vyplněn');
+        // ř.46 (odp_sum_nar) musí existovat a rovnat se ř.63 (odp_zocelk) — zde jen ř.40.
+        $this->assertSame('4200',  (string) $dp->Veta4['odp_sum_nar'], 'ř.46 součtový odpočet = ř.63');
     }
 
     /**
@@ -981,20 +1032,20 @@ final class KhDphTaxScenariosTest extends TestCase
     /**
      * @param list<array{0:float,1:float,2:float}> $items [base, vat, vat_rate_snapshot]
      */
-    private function purchase(string $number, int $vendorId, ?string $code, bool $rc, string $kind, string $issue, ?string $tax, array $items, bool $isFixedAsset = false, string $vatDeduction = 'full', float $vatDeductionPercent = 100.0): void
+    private function purchase(string $number, int $vendorId, ?string $code, bool $rc, string $kind, string $issue, ?string $tax, array $items, bool $isFixedAsset = false, string $vatDeduction = 'full', float $vatDeductionPercent = 100.0, ?int $currencyId = null, ?float $exchangeRate = null): void
     {
         [$base, $vat, $with] = $this->sumItems($items);
         $stmt = $this->db->pdo()->prepare(
             'INSERT INTO purchase_invoices
                 (supplier_id, vendor_id, vendor_invoice_number, document_kind, issue_date, tax_date,
-                 due_date, received_at, currency_id, reverse_charge, vendor_snapshot,
+                 due_date, received_at, currency_id, exchange_rate, reverse_charge, vendor_snapshot,
                  total_without_vat, total_vat, total_with_vat, status, vat_classification_code,
                  is_fixed_asset, vat_deduction, vat_deduction_percent, created_by)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "{}", ?, ?, ?, "received", ?, ?, ?, ?, ?)'
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "{}", ?, ?, ?, "received", ?, ?, ?, ?, ?)'
         );
         $stmt->execute([
             $this->supplierId, $vendorId, $number, $kind, $issue, $tax, $issue, $issue,
-            $this->currencyId, $rc ? 1 : 0, $base, $vat, $with, $code, $isFixedAsset ? 1 : 0, $vatDeduction, $vatDeductionPercent, $this->userId,
+            $currencyId ?? $this->currencyId, $exchangeRate, $rc ? 1 : 0, $base, $vat, $with, $code, $isFixedAsset ? 1 : 0, $vatDeduction, $vatDeductionPercent, $this->userId,
         ]);
         $id = (int) $this->db->pdo()->lastInsertId();
         $this->purchaseIds[] = $id;


### PR DESCRIPTION
## Problém

U **cizoměnového reverse charge** (pořízení zboží z JČS, přijetí služby, dovoz) se samovyměřená daň počítala z **cizoměnové daně přenásobené kurzem**. Dvojí zaokrouhlení rozcházelo daň v **oddílu A.2 kontrolního hlášení** oproti přiznání o haléře. Navíc **DPHDP3** plnil řádek 43 do špatných atributů a vynechával součtový řádek 46 → portál EPO mohl hlásit chyby.

## Příčina + oprava

**1. Zaokrouhlení daně (`VatLedgerService::normalize`)**
Daň u RC samovyměření se nově počítá ze **základu přepočteného na CZK × sazba** (§ 37/1: daň se vypočte ze základu daně, a tím je hodnota v Kč), ne z cizoměnové daně × kurz. Sjednoceno na jednom místě → KH i přiznání sedí.

```
základ 100,05 € × kurz 25,00 = 2 501,25 Kč → daň 2 501,25 × 21 % = 525,26 Kč
(dříve EUR-first: round(100,05 × 21 %) = 21,01 € × 25 = 525,25 Kč → o haléř míň)
```
Tuzemské doklady (kurz 1) i CZK RC zůstávají beze změny.

**2. Přiznání DPHDP3 řádek 43 (`DphPriznaniBuilder` lineMap)**
ř.43 (nárok na odpočet ze samovyměřených plnění ř.3–13) se plnil do atributů `odp_rezim`/`odp_rez_nar` — to je ale **ř.45** (korekce odpočtu dle §75/§77/§79). Opraveno na **`nar_zdp23`/`od_zdp23`** (sloupec „V plné výši", 21 %). Číselník `vat_classifications` nemá 12% RC kód (všech 5 RC kódů nese 21 %), takže 21% sloupec pokrývá celý mirror.

**3. Přiznání DPHDP3 řádek 46**
Doplněn chybějící součtový řádek **`odp_sum_nar`** (ř.40–45 „V plné výši"); rovná se ř.63 (`odp_zocelk`).

Body 2+3 odpovídají výstupu, který pro pořízení vozidla z JČS generuje sám **EPO MF ČR / Money S3** (`nar_zdp23`/`od_zdp23` + `odp_sum_nar`, `odp_rezim`=0 jako separátní ř.45).

## Testy

- Nový scénář `testForeignCurrencyRcSelfAssessmentRoundsFromCzkBase` (cizoměnové RC, kontroluje daň ze základu v Kč).
- Upraveny aserce 3 existujících scénářů na `nar_zdp23`/`od_zdp23` + nová kontrola `odp_sum_nar`.
- Helper `purchase()` rozšířen o měnu + kurz.
- **23/23 testů v `tests/Integration/Report` zelených.**

## Validace

Ověřeno proti referenčnímu XSD i proti **výstupu portálu EPO MF ČR** — vygenerované přiznání i KH portál převzal hodnotu po hodnotě bez přepočtu, bez chyb.