### PR TITLE
fix(import): spawn worker with PHP CLI, not php-fpm

### DIFF
--- a/api/src/Service/PhpCliLocator.php
+++ b/api/src/Service/PhpCliLocator.php
@@ -7,11 +7,12 @@ namespace MyInvoice\Service;
 /**
  * Najde CLI `php` binárku pro spouštění detached workerů (import, cron).
  *
- * Pod IIS / FastCGI je `PHP_BINARY` typicky `php-cgi.exe`, který CLI skripty
- * (`if (PHP_SAPI !== 'cli') exit;`) spustí špatně, a `php` často NENÍ na PATH
- * procesu w3wp.exe. Holé `php` ve spawn příkazu proto tiše selže a worker se
- * nikdy nespustí (job zůstane navždy „queued"). Tento helper vrátí skutečnou
- * cestu k CLI php.exe (sibling vedle php-cgi, běžné instalační cesty, …).
+ * Pod IIS / FastCGI je `PHP_BINARY` typicky `php-cgi.exe`, a pod **php-fpm**
+ * (oficiální Docker image) je `PHP_BINARY` přímo binárka `php-fpm` — obojí CLI
+ * skripty (`if (PHP_SAPI !== 'cli') exit;`) spustí špatně. php-fpm navíc CLI
+ * argumenty/skript nepochopí, vypíše usage a skončí, takže worker se nikdy
+ * nespustí (job zůstane navždy „queued"). Tento helper takové ne-CLI SAPI
+ * binárky přeskočí a vrátí skutečnou cestu k CLI php (sibling, běžné cesty, …).
  */
 final class PhpCliLocator
 {
@@ -38,9 +39,8 @@ final class PhpCliLocator
         }
 
         foreach ($candidates as $c) {
-            $name = strtolower(basename($c));
-            // Vyhneme se php-cgi.exe / php-win.exe / phpdbg.exe — chceme jen CLI.
-            if ($name === 'php-cgi.exe' || $name === 'php-cgi' || $name === 'php-win.exe' || str_starts_with($name, 'phpdbg')) {
+            // Vyhneme se ne-CLI SAPI binárkám (php-cgi, php-win, phpdbg, php-fpm) — chceme jen CLI.
+            if (self::isNonCliSapiName(basename($c))) {
                 continue;
             }
             if (str_contains($c, DIRECTORY_SEPARATOR) || str_contains($c, '/')) {
@@ -54,5 +54,20 @@ final class PhpCliLocator
         }
 
         return null;
+    }
+
+    /**
+     * Je `$name` (basename binárky) ne-CLI SAPI, kterou nelze použít pro spuštění
+     * CLI workeru? Pokrývá php-cgi / php-win / phpdbg a — klíčové pod php-fpm —
+     * `php-fpm` (tam je `PHP_BINARY` právě tato binárka).
+     */
+    public static function isNonCliSapiName(string $name): bool
+    {
+        $name = strtolower($name);
+
+        return $name === 'php-cgi.exe' || $name === 'php-cgi'
+            || $name === 'php-win.exe'
+            || str_starts_with($name, 'phpdbg')
+            || str_starts_with($name, 'php-fpm');
     }
 }

--- a/api/tests/Unit/Service/PhpCliLocatorTest.php
+++ b/api/tests/Unit/Service/PhpCliLocatorTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service;
+
+use MyInvoice\Service\PhpCliLocator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Worker se pod php-fpm (oficiální Docker image) spouštěl s binárkou `php-fpm`
+ * místo CLI php — php-fpm CLI skript nepochopí, vypíše usage a skončí, takže
+ * import zůstal navždy „queued". `PhpCliLocator` proto musí ne-CLI SAPI binárky
+ * (php-fpm, php-cgi, php-win, phpdbg) odmítnout.
+ */
+final class PhpCliLocatorTest extends TestCase
+{
+    /** @return list<array{string}> */
+    public static function nonCliNames(): array
+    {
+        return [
+            ['php-fpm'],
+            ['php-fpm8'],
+            ['php-fpm8.5'],
+            ['/usr/local/sbin/php-fpm'],
+            ['php-cgi'],
+            ['php-cgi.exe'],
+            ['php-win.exe'],
+            ['phpdbg'],
+            ['phpdbg.exe'],
+            ['PHP-FPM'], // case-insensitivní
+        ];
+    }
+
+    #[DataProvider('nonCliNames')]
+    public function testRejectsNonCliSapiBinaries(string $path): void
+    {
+        self::assertTrue(
+            PhpCliLocator::isNonCliSapiName(basename($path)),
+            "$path má být odmítnuto jako ne-CLI SAPI"
+        );
+    }
+
+    /** @return list<array{string}> */
+    public static function cliNames(): array
+    {
+        return [
+            ['php'],
+            ['php.exe'],
+            ['php8.5'],
+            ['/usr/local/bin/php'],
+            ['C:\\Program Files\\PHP\\php.exe'],
+        ];
+    }
+
+    #[DataProvider('cliNames')]
+    public function testAcceptsCliBinaries(string $path): void
+    {
+        self::assertFalse(
+            PhpCliLocator::isNonCliSapiName(basename($path)),
+            "$path má být přijato jako CLI php"
+        );
+    }
+
+    public function testResolveNeverReturnsNonCliBinary(): void
+    {
+        $resolved = PhpCliLocator::resolve();
+        if ($resolved === null) {
+            self::markTestSkipped('Žádné php nenalezeno v tomto prostředí.');
+        }
+        self::assertFalse(
+            PhpCliLocator::isNonCliSapiName(basename($resolved)),
+            "resolve() nesmí vrátit ne-CLI SAPI binárku, vráceno: $resolved"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #170.

Under the official php-fpm Docker image, `PHP_BINARY` is the **php-fpm** binary, and `PhpCliLocator::resolve()` returned it because the SAPI skip-list covered `php-cgi` / `php-win` / `phpdbg` but **not `php-fpm`**. The worker was launched as `php-fpm import-worker.php --job-id=N`, which prints usage and exits — so every background import (iDoklad/Fakturoid, PDF AI) sat `queued` and was later marked `failed` ("worker neodpovídá").

### Change
- Add `php-fpm` to the non-CLI SAPI skip-list in `PhpCliLocator`, so `resolve()` falls through to the real CLI php (`/usr/local/bin/php`).
- Extract the name check into a pure `PhpCliLocator::isNonCliSapiName()` helper.
- Add `PhpCliLocatorTest` covering php-fpm/php-cgi/php-win/phpdbg rejection, CLI acceptance, and that `resolve()` never returns a non-CLI binary.

Backend-only; no `dist/` / OpenAPI changes. Verified live: the queued job runs correctly when launched with the CLI php (`docker compose exec -u www-data app php …/import-worker.php --job-id=N`).
