### PR TITLE
fix(import): fetch issued-invoice PDFs from iDoklad v2 GetPdf (base64), not v3 /Document

### DIFF
--- a/api/src/Service/Import/IdokladClient.php
+++ b/api/src/Service/Import/IdokladClient.php
@@ -310,19 +310,37 @@ final class IdokladClient
 
     /**
      * Stáhne PDF pro vydanou fakturu (rendered iDoklad PDF). Endpoint:
-     *   GET /v3/IssuedInvoices/{id}/Document  (application/pdf bytes).
+     *   GET /v2/IssuedInvoices/{id}/GetPdf  (Accept: application/json).
+     *
+     * Pozn.: PDF render je dostupný JEN na v2 API — v3 vrací UnsupportedApiVersion,
+     * a cesta je /GetPdf, ne /Document (/Document 404). Tělo je bare base64 JSON
+     * string (celé tělo je "JVBERi0..."), tj. json_decode → base64 → %PDF bajty.
      */
     public function downloadIssuedPdf(int $supplierId, int $idokladInvoiceId): ?string
     {
         $token = $this->getToken($supplierId);
-        $url = self::API_BASE . '/IssuedInvoices/' . $idokladInvoiceId . '/Document';
+        $url = str_replace('/v3', '/v2', self::API_BASE) . '/IssuedInvoices/' . $idokladInvoiceId . '/GetPdf';
         $this->throttle($supplierId);
         $resp = $this->http->get($url, [
-            'headers' => ['Authorization' => 'Bearer ' . $token, 'Accept' => 'application/pdf'],
+            'headers' => ['Authorization' => 'Bearer ' . $token, 'Accept' => 'application/json'],
         ]);
         if ($resp->getStatusCode() !== 200) return null;
-        $body = (string) $resp->getBody();
-        return str_starts_with($body, '%PDF') ? $body : null;
+        return self::decodeIssuedPdfBody((string) $resp->getBody());
+    }
+
+    /**
+     * Rozbalí tělo v2 GetPdf odpovědi (JSON string literal s base64 PDF) na surové
+     * PDF bajty. Vrátí null, pokud tělo není validní base64 PDF dokument.
+     */
+    public static function decodeIssuedPdfBody(string $body): ?string
+    {
+        $b64 = json_decode($body, true);
+        if (!is_string($b64) || $b64 === '') {
+            return null;
+        }
+        $pdf = base64_decode($b64, true);
+
+        return ($pdf !== false && str_starts_with($pdf, '%PDF')) ? $pdf : null;
     }
 
     /**

--- a/api/tests/Unit/Service/Import/IdokladIssuedPdfDecodeTest.php
+++ b/api/tests/Unit/Service/Import/IdokladIssuedPdfDecodeTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Import;
+
+use MyInvoice\Service\Import\IdokladClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * iDoklad v2 GetPdf vrací PDF jako bare base64 JSON string — celé tělo je
+ * "JVBERi0..." (NE objekt s polem Data). Dřív se PDF stahovalo z neexistujícího
+ * v3 /Document endpointu (404 → null), takže vydaným fakturám se nikdy
+ * nearchivovalo PDF (imported_pdf_path zůstalo NULL, bez chyby).
+ */
+final class IdokladIssuedPdfDecodeTest extends TestCase
+{
+    public function testDecodesBareBase64JsonStringToPdf(): void
+    {
+        $pdf  = "%PDF-1.4\n%\xC2\xA3\ntest body\n%%EOF";
+        $body = json_encode(base64_encode($pdf)); // "JVBERi0..."
+
+        self::assertSame($pdf, IdokladClient::decodeIssuedPdfBody((string) $body));
+    }
+
+    public function testRejectsJsonObjectInsteadOfString(): void
+    {
+        // Kdyby přišel envelope { "Data": "..." } místo bare stringu.
+        $body = json_encode(['Data' => base64_encode('%PDF-1.4 x')]);
+
+        self::assertNull(IdokladClient::decodeIssuedPdfBody((string) $body));
+    }
+
+    public function testRejectsValidBase64ThatIsNotPdf(): void
+    {
+        $body = json_encode(base64_encode('not a pdf at all'));
+
+        self::assertNull(IdokladClient::decodeIssuedPdfBody((string) $body));
+    }
+
+    public function testRejectsNonJsonBody(): void
+    {
+        self::assertNull(IdokladClient::decodeIssuedPdfBody('<html>404</html>'));
+    }
+
+    public function testRejectsEmptyBody(): void
+    {
+        self::assertNull(IdokladClient::decodeIssuedPdfBody(''));
+        self::assertNull(IdokladClient::decodeIssuedPdfBody('""'));
+    }
+}


### PR DESCRIPTION
Fixes #171.

`IdokladClient::downloadIssuedPdf()` requested `GET {v3}/IssuedInvoices/{id}/Document` with `Accept: application/pdf`. Verified live against the iDoklad API, that is wrong three ways:

| Request | Result |
|---|---|
| `{v3}/IssuedInvoices/{id}/Document` | **404** |
| `{v3}/IssuedInvoices/{id}/GetPdf` (`Accept: application/json`) | **400** `UnsupportedApiVersion` |
| `{v2}/IssuedInvoices/{id}/GetPdf` (`Accept: application/pdf`) | **406** |
| `{v2}/IssuedInvoices/{id}/GetPdf` (`Accept: application/json`) | **200** ✅ |

So the call always 404'd → returned `null` → `archiveIssuedPdf()` silently skipped every issued PDF (`imported_pdf_path` stayed NULL, `failed_count=0`, no error surfaced).

### Change
- Point this one call at `{v2}/IssuedInvoices/{id}/GetPdf` with `Accept: application/json`. The body is a **bare base64 JSON string** (the whole body is `"JVBERi0…"`), so `json_decode` → `base64_decode` → `%PDF` bytes.
- Extract the decode into a pure `IdokladClient::decodeIssuedPdfBody()` helper with a unit test (valid base64-string PDF, JSON-object envelope, non-PDF base64, non-JSON, empty).
- The rest of the client keeps using v3.

Same class of bug as the already-fixed #80 (a wrong v3 iDoklad endpoint in the importer), different endpoint. Backend-only; no `dist/` / OpenAPI changes.
