### PR TITLE
feat(import): archivace strojového zdroje přijaté faktury (source_*) — #175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Uchování strojového zdroje přijaté faktury (ISDOC/ISDOCX) — důkazní stopa.** Při importu přijaté faktury ze strukturovaného zdroje (`.isdoc`, `.isdocx`, nebo ISDOC vložený v PDF/A-3) se nově **trvale archivuje originální strojově čitelný doklad** vedle vizuálního PDF. Originál (často digitálně podepsaný) má pro audit a kontrolu z FÚ při 10leté archivační lhůtě vyšší hodnotu než PDF render a umožňuje zpětnou rekonstrukci dat. V detailu přijaté faktury přibyla akce **„Zdrojový doklad (ISDOC)"** ke stažení (jen je-li zdroj uložený). Bajty se ukládají as-is — `.isdocx` se NErozbaluje (zachová podpis ZIP obálky), embedded ISDOC v PDF se uloží jako vytažené XML. Zápis je write-once (originál se nikdy nepřepíše). Pokrývá dávkový import i nahrání přes dropzone/AI. Formát-agnostické (`source_format`), takže příští zdroje (Pohoda XML / iDoklad / Fakturoid) půjdou doplnit bez další migrace. (migrace 0123)
+
 ### Fixed
 
 - **Import ISDOC u dokladů se zaokrouhlením — „k úhradě" nově sedí na doklad.** Přijatá faktura z ISDOC se zaokrouhlením „k úhradě" (typicky e-faktury z e-shopů) se dosud naimportovala s částkou k úhradě = přesný součet položek, takže `K úhradě` bylo o haléře vedle skutečné částky na dokladu (a nepárovalo se přesně s platbou v bance). Import nově čte z ISDOC `<LegalMonetaryTotal>/<PayableAmount>` a haléřový rozdíl uloží jako zaokrouhlení — stejně jako už dělá rozpoznávání z PDF přes AI. Příklad: doklad se základem+DPH 999,99 a zaokrouhlením +0,01 se nově naimportuje tak, že `K úhradě` = 1 000,00. Základ a DPH zůstávají nezměněné (správně pro přiznání DPH a kontrolní hlášení). Sémantika `amount_to_pay` se nemění — zaokrouhlení se i nadále vede mimo něj (pole *Zaokrouhlení*) a do „k úhradě" se promítá stejnou cestou jako u AI importu (QR, platební příkaz, PDF, UI).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6549,6 +6549,12 @@ components:
         pdf_size_bytes: { type: integer, nullable: true }
         pdf_original_name: { type: string, nullable: true }
         pdf_uploaded_at: { type: string, format: date-time, nullable: true }
+        source_path: { type: string, nullable: true, description: "Relative path to machine-readable source artifact within archive_storage (sources/ subtree)" }
+        source_hash: { type: string, nullable: true, description: "SHA-256 hex of source artifact" }
+        source_size_bytes: { type: integer, nullable: true }
+        source_original_name: { type: string, nullable: true }
+        source_format: { type: string, nullable: true, enum: [isdoc, isdocx, pdf, pohoda_xml, idoklad_json, fakturoid_json], description: "Format of the archived authoritative source document" }
+        source_uploaded_at: { type: string, format: date-time, nullable: true }
         vat_classification_code: { type: string, nullable: true }
         vat_overrides:
           type: array

--- a/api/src/Action/PurchaseInvoice/DownloadPurchaseInvoiceSourceAction.php
+++ b/api/src/Action/PurchaseInvoice/DownloadPurchaseInvoiceSourceAction.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Action\PurchaseInvoice;
+
+use MyInvoice\Http\Json;
+use MyInvoice\Http\SupplierGuard;
+use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Infrastructure\Config\RuntimePaths;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Repository\PurchaseInvoiceRepository;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\IpMatcher;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * GET /api/purchase-invoices/{id}/source
+ *
+ * Stáhne archivovaný ZDROJOVÝ artefakt (strojově čitelný originál — ISDOC/ISDOCX/Pohoda
+ * XML/…), pokud existuje. Bajty se vrací AS-IS (u .isdocx nerozbalené). Stream přes PHP,
+ * soubor je MIMO webroot; path traversal je zabaleno přes realpath() check vůči archive
+ * rootu — shodně s {@see DownloadPurchaseInvoicePdfAction}.
+ *
+ * Pokud faktura nemá source_path → 404.
+ */
+final class DownloadPurchaseInvoiceSourceAction
+{
+    /** source_format → Content-Type pro stažení. */
+    private const FORMAT_MIME = [
+        'isdoc'          => 'application/xml',
+        'isdocx'         => 'application/zip',
+        'pdf'            => 'application/pdf',
+        'pohoda_xml'     => 'application/xml',
+        'idoklad_json'   => 'application/json',
+        'fakturoid_json' => 'application/json',
+    ];
+
+    public function __construct(
+        private readonly PurchaseInvoiceRepository $repo,
+        private readonly Config $config,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
+    ) {}
+
+    public function __invoke(Request $request, Response $response, array $args): Response
+    {
+        $id = (int) ($args['id'] ?? 0);
+        if ($id <= 0) {
+            return Json::error($response, 'invalid_id', 'Neplatné ID', 400);
+        }
+
+        $supplierId = SupplierGuard::currentId($request);
+        $invoice = $this->repo->find($id, $supplierId);
+        if ($invoice === null) {
+            return Json::error($response, 'not_found', 'Přijatá faktura nenalezena.', 404);
+        }
+
+        $relativePath = (string) ($invoice['source_path'] ?? '');
+        if ($relativePath === '') {
+            return Json::error($response, 'no_source', 'K této faktuře není archivovaný zdrojový doklad.', 404);
+        }
+
+        $archiveRoot = $this->resolveArchiveRoot();
+        $archiveRootReal = realpath($archiveRoot);
+        if ($archiveRootReal === false) {
+            return Json::error($response, 'storage_unavailable', 'Archiv nelze nalézt.', 500);
+        }
+
+        // Path traversal guard (shodně s PDF download action).
+        $fullPath = $archiveRootReal . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+        $fullPathReal = realpath($fullPath);
+        if ($fullPathReal === false || !is_file($fullPathReal)) {
+            return Json::error($response, 'file_missing', 'Archivovaný zdroj nebyl na disku nalezen.', 404);
+        }
+        $isWindows = DIRECTORY_SEPARATOR === '\\';
+        $haystack = ($isWindows ? strtolower($fullPathReal) : $fullPathReal);
+        $needle   = ($isWindows ? strtolower($archiveRootReal) : $archiveRootReal) . DIRECTORY_SEPARATOR;
+        if (!str_starts_with($haystack, $needle)) {
+            return Json::error($response, 'forbidden', 'Cesta mimo archive root.', 403);
+        }
+
+        $size = filesize($fullPathReal);
+        if ($size === false) {
+            return Json::error($response, 'read_failed', 'Nelze přečíst velikost souboru.', 500);
+        }
+
+        $format = (string) ($invoice['source_format'] ?? '');
+        $mime   = self::FORMAT_MIME[$format] ?? 'application/octet-stream';
+        $downloadName = (string) ($invoice['source_original_name']
+            ?? ('zdroj-' . ($invoice['vendor_invoice_number'] ?? $id)));
+        $downloadName = preg_replace('/[\x00-\x1F"<>|*?:\\\\\/]/', '_', $downloadName) ?: 'source';
+
+        $stream = fopen($fullPathReal, 'rb');
+        if ($stream === false) {
+            return Json::error($response, 'read_failed', 'Nepodařilo se otevřít soubor.', 500);
+        }
+
+        $user = (array) $request->getAttribute(AuthMiddleware::ATTR_USER, []);
+        $ip = $this->ipMatcher->clientIpFromRequest($request->getServerParams());
+        $this->logger->log('purchase_invoice.source_downloaded', $user['id'] ?? null, 'purchase_invoice', $id,
+            ['size_bytes' => $size, 'format' => $format], $ip, $request->getHeaderLine('User-Agent'));
+
+        $body = $response->getBody();
+        while (!feof($stream)) {
+            $chunk = fread($stream, 65536);
+            if ($chunk === false) break;
+            $body->write($chunk);
+        }
+        fclose($stream);
+
+        // Zdroj je strojový artefakt — vždy attachment (na rozdíl od PDF náhledu).
+        return $response
+            ->withHeader('Content-Type', $mime)
+            ->withHeader('Content-Length', (string) $size)
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $downloadName . '"')
+            ->withHeader('Cache-Control', 'private, no-store')
+            ->withHeader('X-Content-Type-Options', 'nosniff');
+    }
+
+    private function resolveArchiveRoot(): string
+    {
+        $dir = (string) $this->config->get('purchase_invoice.archive_storage', '');
+        if ($dir !== '') return $dir;
+        $uploads = (string) $this->config->get('storage.uploads_dir', '');
+        if ($uploads !== '') return dirname($uploads) . '/purchase-invoices';
+        return RuntimePaths::storage('purchase-invoices');
+    }
+}

--- a/api/src/Repository/PurchaseInvoiceRepository.php
+++ b/api/src/Repository/PurchaseInvoiceRepository.php
@@ -1673,7 +1673,7 @@ final class PurchaseInvoiceRepository
     private function castInvoice(array $row): array
     {
         foreach (['id', 'supplier_id', 'vendor_id', 'currency_id', 'payment_currency_id',
-                  'created_by', 'pdf_size_bytes', 'expense_category_id',
+                  'created_by', 'pdf_size_bytes', 'source_size_bytes', 'expense_category_id',
                   'advance_purchase_invoice_id', 'advance_link_suggested_id'] as $f) {
             if (isset($row[$f]) && $row[$f] !== null) $row[$f] = (int) $row[$f];
         }

--- a/api/src/Repository/PurchaseInvoiceRepository.php
+++ b/api/src/Repository/PurchaseInvoiceRepository.php
@@ -1587,6 +1587,21 @@ final class PurchaseInvoiceRepository
     }
 
     /**
+     * Zápis metadat ZDROJOVÉHO artefaktu (strojový originál — ISDOC/ISDOCX/…).
+     * Write-once: `AND source_path IS NULL` zaručí, že re-import / re-extrakce
+     * nepřepíše evidenční stopu (kterou už jednou uloženou nesmíme měnit).
+     */
+    public function setSourceMetadata(int $id, int $supplierId, string $path, string $hash, int $size, ?string $originalName, string $format): void
+    {
+        $this->db->pdo()->prepare(
+            'UPDATE purchase_invoices
+                SET source_path = ?, source_hash = ?, source_size_bytes = ?, source_original_name = ?,
+                    source_format = ?, source_uploaded_at = NOW()
+              WHERE id = ? AND supplier_id = ? AND source_path IS NULL'
+        )->execute([$path, $hash, $size, $originalName, $format, $id, $supplierId]);
+    }
+
+    /**
      * Update totals na úrovni jedné položky (volá Calculator).
      */
     public function updateItemTotals(int $itemId, float $withoutVat, float $vatAmount, float $withVat): void

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -82,6 +82,7 @@ use MyInvoice\Action\PurchaseInvoice\DismissExtractionWarningAction;
 use MyInvoice\Action\PurchaseInvoice\LinkAdvancePurchaseInvoiceAction;
 use MyInvoice\Action\PurchaseInvoice\UnlinkAdvancePurchaseInvoiceAction;
 use MyInvoice\Action\PurchaseInvoice\DownloadPurchaseInvoicePdfAction;
+use MyInvoice\Action\PurchaseInvoice\DownloadPurchaseInvoiceSourceAction;
 use MyInvoice\Action\PurchaseInvoice\OurPdfPurchaseInvoiceAction;
 use MyInvoice\Action\PurchaseInvoice\ExportPurchaseInvoiceAction;
 use MyInvoice\Action\PurchaseInvoice\ExportPurchaseInvoicesAction;
@@ -337,6 +338,7 @@ final class Routes
         $app->delete ('/api/purchase-invoices/{id:[0-9]+}/advance-suggestion', DismissAdvanceSuggestionAction::class);
         $app->post   ('/api/purchase-invoices/{id:[0-9]+}/pdf',            UploadPurchaseInvoicePdfAction::class);
         $app->get    ('/api/purchase-invoices/{id:[0-9]+}/pdf',            DownloadPurchaseInvoicePdfAction::class);
+        $app->get    ('/api/purchase-invoices/{id:[0-9]+}/source',         DownloadPurchaseInvoiceSourceAction::class);
         $app->delete ('/api/purchase-invoices/{id:[0-9]+}/pdf',            DeletePurchaseInvoicePdfAction::class);
         // Our generated PDF + Pohoda/ISDOC export pro přijatou
         $app->get    ('/api/purchase-invoices/{id:[0-9]+}/our-pdf',        OurPdfPurchaseInvoiceAction::class);

--- a/api/src/Service/Import/AiPdfExtractor.php
+++ b/api/src/Service/Import/AiPdfExtractor.php
@@ -66,7 +66,8 @@ final class AiPdfExtractor
         if (IsdocxExtractor::isZip($pdfBytes)) {
             $pkg = (new IsdocxExtractor())->unwrap($pdfBytes);
             if ($pkg !== null) {
-                return $this->createFromIsdocx($pkg, $supplierId, $userId, $originalFilename);
+                // $pdfBytes = ORIGINÁLNÍ .isdocx (předáme dál k archivaci as-is).
+                return $this->createFromIsdocx($pkg, $supplierId, $userId, $originalFilename, $pdfBytes);
             }
         }
 
@@ -110,6 +111,13 @@ final class AiPdfExtractor
                     $r = $this->isdocMapper->map($parsed['invoices'][0], $supplierId, $userId);
                     // Attach PDF k vytvořené přijaté faktuře
                     $this->attachPdf((int) $r['purchase_invoice_id'], $supplierId, $pdfBytes, $originalFilename);
+                    // Zdrojový artefakt = vytažený ISDOC XML (embedded v PDF/A-3) — issue #175.
+                    $srcName = ($originalFilename !== null && $originalFilename !== '')
+                        ? preg_replace('/\.[^.\\/]+$/', '.isdoc', $originalFilename)
+                        : 'source.isdoc';
+                    $this->pdfArchiver->archiveSourceBytes(
+                        (int) $r['purchase_invoice_id'], $supplierId, $isdocXml, $srcName, 'isdoc',
+                    );
                     return [
                         'ok'                  => true,
                         'purchase_invoice_id' => $r['purchase_invoice_id'],
@@ -267,7 +275,7 @@ final class AiPdfExtractor
      * @param array{isdoc:string, isdoc_name:string, pdf:?string, pdf_name:?string} $pkg
      * @return array{ok:bool, purchase_invoice_id?:int, vendor_id?:int, source:string, error?:string, duplicate?:bool, message?:string}
      */
-    private function createFromIsdocx(array $pkg, int $supplierId, int $userId, ?string $originalFilename): array
+    private function createFromIsdocx(array $pkg, int $supplierId, int $userId, ?string $originalFilename, ?string $isdocxBytes = null): array
     {
         $innerPdf = $pkg['pdf'];
 
@@ -308,6 +316,15 @@ final class AiPdfExtractor
                     : null)
                 ?: 'isdocx-imported.pdf';
             $this->attachPdf((int) $r['purchase_invoice_id'], $supplierId, $innerPdf, $pdfName);
+        }
+
+        // Zdrojový artefakt = ORIGINÁLNÍ .isdocx as-is (NEROZBALENÉ — zachová podpis ZIP
+        // obálky). Write-once přes source_* (issue #175).
+        if ($isdocxBytes !== null && $isdocxBytes !== '') {
+            $this->pdfArchiver->archiveSourceBytes(
+                (int) $r['purchase_invoice_id'], $supplierId, $isdocxBytes,
+                $originalFilename ?: 'source.isdocx', 'isdocx',
+            );
         }
 
         return [

--- a/api/src/Service/Import/InvoiceImportService.php
+++ b/api/src/Service/Import/InvoiceImportService.php
@@ -93,6 +93,11 @@ final class InvoiceImportService
                         'content'  => $pkg['isdoc'],
                         'pdf'      => $pkg['pdf'],
                         'pdf_name' => $pkg['pdf_name'] ?? preg_replace('/\.isdocx?$/i', '.pdf', basename($f['name'])),
+                        // Zdrojový artefakt = ORIGINÁLNÍ .isdocx as-is (NEROZBALENÉ — zachová
+                        // podpis ZIP obálky; vnitřní .isdoc XML jde do `content` jen pro parsing).
+                        'source'        => $f['content'],
+                        'source_name'   => basename($f['name']),
+                        'source_format' => 'isdocx',
                     ];
                 } else {
                     // Nepodařilo se rozbalit → necháme na parseRaw čitelnou chybu.
@@ -117,6 +122,13 @@ final class InvoiceImportService
         foreach ($flat as $f) {
             $r = $this->parseRaw($f['name'], $f['content']);
             $entry = ['file' => $f['name']] + $r;
+            // Zdrojový artefakt: ISDOCX nese originál .isdocx z rozbalení (flat entry) —
+            // přebije `source` z parseRaw (ten viděl jen vnitřní .isdoc XML).
+            if (isset($f['source'])) {
+                $entry['source']        = $f['source'];
+                $entry['source_name']   = $f['source_name'] ?? null;
+                $entry['source_format'] = $f['source_format'] ?? null;
+            }
             $pdf     = $f['pdf'] ?? null;
             $pdfName = $f['pdf_name'] ?? null;
             if ($pdf === null && $this->isPdf($f['name'], $f['content']) && str_starts_with($f['content'], '%PDF')) {
@@ -163,7 +175,11 @@ final class InvoiceImportService
                     if ($route === 'issued') {
                         $r = $this->processOne($inv, $supplierId, $userId, $emailMap);
                     } elseif ($route === 'purchase') {
-                        $r = $this->processPurchase($inv, $supplierId, $userId, $entry['pdf'] ?? null, $entry['pdf_name'] ?? null);
+                        $r = $this->processPurchase(
+                            $inv, $supplierId, $userId,
+                            $entry['pdf'] ?? null, $entry['pdf_name'] ?? null,
+                            $entry['source'] ?? null, $entry['source_name'] ?? null, $entry['source_format'] ?? null,
+                        );
                     } else {
                         // 'reject' — ISDOC patří jinému plátci (neshoda IČO s tenantem)
                         $r = ['status' => 'failed', 'reason' => $route];
@@ -255,8 +271,16 @@ final class InvoiceImportService
      * @param string|null $pdfBytes Čitelné PDF k archivaci (ISDOCX balíček / nahrané PDF/A-3).
      * @return array<string,mixed>
      */
-    private function processPurchase(array $inv, int $supplierId, int $userId, ?string $pdfBytes = null, ?string $pdfName = null): array
-    {
+    private function processPurchase(
+        array $inv,
+        int $supplierId,
+        int $userId,
+        ?string $pdfBytes = null,
+        ?string $pdfName = null,
+        ?string $sourceBytes = null,
+        ?string $sourceName = null,
+        ?string $sourceFormat = null,
+    ): array {
         try {
             $r = $this->purchaseMapper->map($inv, $supplierId, $userId);
             // Čitelné PDF (z ISDOCX balíčku nebo nahraného PDF/A-3 s embedded ISDOC)
@@ -268,6 +292,17 @@ final class InvoiceImportService
                     $supplierId,
                     $pdfBytes,
                     $pdfName,
+                );
+            }
+            // Strojový ZDROJOVÝ artefakt (ISDOC/ISDOCX/Pohoda XML) → source_* (write-once,
+            // oddělený sources/ podstrom). Důkazní stopa s možností re-extrakce (issue #175).
+            if ($sourceBytes !== null && $sourceBytes !== '' && $sourceFormat !== null) {
+                $this->pdfArchiver->archiveSourceBytes(
+                    (int) $r['purchase_invoice_id'],
+                    $supplierId,
+                    $sourceBytes,
+                    $sourceName,
+                    $sourceFormat,
                 );
             }
             return [
@@ -290,6 +325,10 @@ final class InvoiceImportService
      */
     private function parseRaw(string $name, string $content): array
     {
+        // Zdrojový artefakt = originál nahraných bajtů as-is (ISDOCX přebije volající).
+        $sourceBytes  = $content;
+        $sourceName   = basename($name);
+        $sourceFormat = null;
         try {
             if ($this->isPdf($name, $content)) {
                 $extracted = $this->pdfIsdoc->extract($content);
@@ -297,11 +336,17 @@ final class InvoiceImportService
                     return ['error' => 'PDF neobsahuje ISDOC přílohu (PDF/A-3). Nahraj prosím .isdoc / .xml soubor, nebo PDF, který má ISDOC embed.'];
                 }
                 $content = $extracted;
+                // Embedded ISDOC v PDF/A-3 → zdroj je vytažený XML (PDF samotné jde do pdf_*).
+                $sourceBytes  = $extracted;
+                $sourceName   = preg_replace('/\.pdf$/i', '.isdoc', basename($name)) ?: basename($name);
+                $sourceFormat = 'isdoc';
             }
             $content = self::stripBom($content);
-            $parsed = self::looksLikeIsdoc($name, $content)
+            $isIsdoc = self::looksLikeIsdoc($name, $content);
+            $parsed = $isIsdoc
                 ? $this->isdoc->parse($content)
                 : $this->pohoda->parse($content);
+            $sourceFormat ??= ($isIsdoc ? 'isdoc' : 'pohoda_xml');
         } catch (\Throwable $e) {
             return ['error' => $e->getMessage()];
         }
@@ -316,7 +361,12 @@ final class InvoiceImportService
         }
         unset($inv);
 
-        return ['invoices' => $invoices];
+        return [
+            'invoices'      => $invoices,
+            'source'        => $sourceBytes,
+            'source_name'   => $sourceName,
+            'source_format' => $sourceFormat,
+        ];
     }
 
     /**

--- a/api/src/Service/Import/PurchaseInvoicePdfArchiver.php
+++ b/api/src/Service/Import/PurchaseInvoicePdfArchiver.php
@@ -43,9 +43,9 @@ final class PurchaseInvoicePdfArchiver
      * `supplier-{id}/{2}/{16}.pdf`. Jediný zdroj pravdy pro layout; používají ji VŠECHNY
      * cesty zapisující do purchase-invoices / invoices-imported úložiště.
      */
-    public static function shardedRelPath(int $supplierId, string $hash): string
+    public static function shardedRelPath(int $supplierId, string $hash, string $ext = 'pdf'): string
     {
-        return 'supplier-' . $supplierId . '/' . substr($hash, 0, 2) . '/' . substr($hash, 0, 16) . '.pdf';
+        return 'supplier-' . $supplierId . '/' . substr($hash, 0, 2) . '/' . substr($hash, 0, 16) . '.' . ltrim($ext, '.');
     }
 
     /**
@@ -118,6 +118,72 @@ final class PurchaseInvoicePdfArchiver
         } catch (\Throwable) {
             // Silent.
         }
+    }
+
+    /** Přípona souboru na disku pro daný source_format (strojový originál). */
+    private const SOURCE_EXT = [
+        'isdoc'          => 'isdoc',
+        'isdocx'         => 'isdocx',
+        'pdf'            => 'pdf',
+        'pohoda_xml'     => 'xml',
+        'idoklad_json'   => 'json',
+        'fakturoid_json' => 'json',
+    ];
+
+    /**
+     * Uloží ZDROJOVÝ artefakt (strojově čitelný originál — ISDOC/ISDOCX/Pohoda XML/…)
+     * přijaté faktury do odděleného `sources/` podstromu archivu + zapíše `source_*`
+     * metadata (write-once přes {@see PurchaseInvoiceRepository::setSourceMetadata}).
+     *
+     * Bajty se ukládají AS-IS — u `.isdocx` NEROZBALENÉ (zachová podpis ZIP obálky),
+     * u embedded ISDOC v PDF/A-3 vytažený XML. Magic-byte sanity check dle formátu,
+     * ať se neuloží podvržený obsah. Silent-fail jako PDF archivace (import přednější).
+     *
+     * @param string $format Hodnota ENUM `source_format` (isdoc/isdocx/pdf/pohoda_xml/…).
+     */
+    public function archiveSourceBytes(int $invoiceId, int $supplierId, string $bytes, ?string $originalName, string $format): void
+    {
+        $ext = self::SOURCE_EXT[$format] ?? null;
+        if ($bytes === '' || $ext === null || !self::sourceMagicOk($format, $bytes)) {
+            return;
+        }
+        try {
+            $contentSha = hash('sha256', $bytes);
+            $rel = 'sources/' . self::shardedRelPath($supplierId, $contentSha, $ext);
+            $abs = rtrim($this->archiveRoot(), '/\\') . DIRECTORY_SEPARATOR
+                 . str_replace('/', DIRECTORY_SEPARATOR, $rel);
+            $dir = dirname($abs);
+            if (!is_dir($dir)) {
+                @mkdir($dir, 0755, true);
+            }
+            if (!is_file($abs)) {
+                @file_put_contents($abs, $bytes);
+            }
+            $this->repo->setSourceMetadata(
+                $invoiceId,
+                $supplierId,
+                $rel,
+                $contentSha,
+                (int) @filesize($abs),
+                $originalName ?: ('source.' . $ext),
+                $format,
+            );
+        } catch (\Throwable) {
+            // Silent — úspěšný import faktury je důležitější než archivace zdroje.
+        }
+    }
+
+    /** Magic-byte sanity check podle formátu (ať se neuloží podvržený obsah). */
+    private static function sourceMagicOk(string $format, string $bytes): bool
+    {
+        $head = substr($bytes, 0, 64);
+        return match ($format) {
+            'isdoc', 'pohoda_xml'            => str_contains($head, '<'),
+            'isdocx'                         => str_starts_with($bytes, "PK\x03\x04"),
+            'pdf'                            => str_starts_with($bytes, '%PDF'),
+            'idoklad_json', 'fakturoid_json' => str_contains($head, '{') || str_contains($head, '['),
+            default                          => false,
+        };
     }
 
     /** Adresář archivu pro tenanta (vytvoří ho, pokud chybí). */

--- a/api/tests/Integration/PurchaseInvoice/PurchaseInvoiceSourceArchiveTest.php
+++ b/api/tests/Integration/PurchaseInvoice/PurchaseInvoiceSourceArchiveTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Integration\PurchaseInvoice;
+
+use MyInvoice\Bootstrap;
+use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Infrastructure\Config\RuntimePaths;
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Service\Import\InvoiceImportService;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Import přijaté faktury z ISDOC uloží ORIGINÁLNÍ zdrojový artefakt do source_* (issue #175):
+ * bajty as-is, oddělený sources/ podstrom, write-once.
+ */
+final class PurchaseInvoiceSourceArchiveTest extends TestCase
+{
+    private Connection $db;
+    private Config $config;
+    private InvoiceImportService $importer;
+    private int $supplierId = 0;
+    private int $userId = 0;
+    private string $supplierIc = '';
+    private int $currencyId = 0;
+    private ?int $vendorId = null;
+    private array $createdPurchaseIds = [];
+
+    protected function setUp(): void
+    {
+        if (!is_file(dirname(__DIR__, 4) . '/cfg.php')) {
+            $this->markTestSkipped('cfg.php neexistuje — test vyžaduje DB connection.');
+        }
+        try {
+            $c = Bootstrap::buildApp()->getContainer();
+            $this->db       = $c->get(Connection::class);
+            $this->config   = $c->get(Config::class);
+            $this->importer = $c->get(InvoiceImportService::class);
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('DI nedostupné: ' . $e->getMessage());
+        }
+        $pdo = $this->db->pdo();
+        $row = $pdo->query('SELECT id, ic FROM supplier ORDER BY id LIMIT 1')->fetch(PDO::FETCH_ASSOC) ?: [];
+        $this->supplierId = (int) ($row['id'] ?? 0);
+        $this->supplierIc = preg_replace('/\D/', '', (string) ($row['ic'] ?? '')) ?? '';
+        $this->userId     = (int) ($pdo->query('SELECT id FROM users ORDER BY id LIMIT 1')->fetchColumn() ?: 0);
+        $this->currencyId = (int) ($pdo->query("SELECT id FROM currencies WHERE code='CZK' ORDER BY id LIMIT 1")->fetchColumn() ?: 0);
+        if ($this->supplierId === 0 || $this->supplierIc === '' || $this->userId === 0 || $this->currencyId === 0) {
+            $this->markTestSkipped('Chybí supplier s IČO / user / měna v DB.');
+        }
+        $countryId = (int) ($pdo->query("SELECT id FROM countries WHERE iso2='CZ' LIMIT 1")->fetchColumn() ?: 0);
+        // Pre-create vendor (ať resolveVendor reusne a nevolá ARES).
+        $pdo->prepare(
+            'INSERT INTO clients (supplier_id, company_name, street, city, zip, country_id, ic, main_email,
+                                  language, currency_default_id, is_customer, is_vendor)
+             VALUES (?, "Source Test Vendor", "Test 1", "Praha", "11000", ?, "12345678", "v@example.com",
+                     "cs", ?, 0, 1)'
+        )->execute([$this->supplierId, $countryId, $this->currencyId]);
+        $this->vendorId = (int) $pdo->lastInsertId();
+    }
+
+    protected function tearDown(): void
+    {
+        if (!isset($this->db)) return;
+        $pdo = $this->db->pdo();
+        foreach ($this->createdPurchaseIds as $id) {
+            $pdo->prepare('DELETE FROM purchase_invoice_items WHERE purchase_invoice_id = ?')->execute([$id]);
+            $pdo->prepare('DELETE FROM purchase_invoices WHERE id = ?')->execute([$id]);
+        }
+        if ($this->vendorId !== null) {
+            $pdo->prepare('DELETE FROM clients WHERE id = ?')->execute([$this->vendorId]);
+        }
+        $this->db->close();
+    }
+
+    public function testIsdocImportArchivesOriginalSourceArtifact(): void
+    {
+        $isdoc = $this->minimalIsdoc('SRC-TEST-001');
+        $report = $this->importer->importBundle(
+            [['name' => 'src-test.isdoc', 'content' => $isdoc]],
+            $this->supplierId,
+            $this->userId,
+            'purchase',
+        );
+        self::assertSame(1, $report['summary']['created'] ?? 0, 'import musí vytvořit 1 přijatou fakturu');
+
+        $row = $this->loadCreated('SRC-TEST-001');
+        self::assertNotNull($row, 'faktura se musí vytvořit');
+        self::assertSame('isdoc', $row['source_format'], 'source_format = isdoc');
+        self::assertStringStartsWith('sources/supplier-' . $this->supplierId . '/', (string) $row['source_path'],
+            'source_path je v odděleném sources/ podstromu');
+        self::assertSame(strlen($isdoc), (int) $row['source_size_bytes'], 'velikost = originál');
+        self::assertSame(hash('sha256', $isdoc), $row['source_hash'], 'hash = originál');
+
+        // Soubor na disku = originální bajty AS-IS.
+        $abs = $this->archiveRoot() . '/' . $row['source_path'];
+        self::assertFileExists($abs);
+        self::assertSame($isdoc, file_get_contents($abs), 'uložené bajty = originál (as-is)');
+    }
+
+    public function testSourceMetadataIsWriteOnce(): void
+    {
+        $isdoc = $this->minimalIsdoc('SRC-TEST-002');
+        $this->importer->importBundle([['name' => 'a.isdoc', 'content' => $isdoc]], $this->supplierId, $this->userId, 'purchase');
+        $first = $this->loadCreated('SRC-TEST-002');
+        self::assertNotNull($first);
+        $origUploadedAt = $first['source_uploaded_at'];
+
+        // Re-import téhož dokladu — dedup vrátí existující fakturu; source_* se NESMÍ přepsat.
+        $this->importer->importBundle([['name' => 'a.isdoc', 'content' => $isdoc]], $this->supplierId, $this->userId, 'purchase');
+        $second = $this->loadCreated('SRC-TEST-002');
+        self::assertSame($first['source_path'], $second['source_path'], 'source_path write-once');
+        self::assertSame($origUploadedAt, $second['source_uploaded_at'], 'source_uploaded_at se nepřepisuje');
+    }
+
+    /** @return array<string,mixed>|null */
+    private function loadCreated(string $varsymbol): ?array
+    {
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT id, source_path, source_hash, source_size_bytes, source_format, source_uploaded_at
+               FROM purchase_invoices WHERE supplier_id = ? AND vendor_invoice_number = ? LIMIT 1'
+        );
+        $stmt->execute([$this->supplierId, $varsymbol]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) return null;
+        $this->createdPurchaseIds[(int) $row['id']] = (int) $row['id'];
+        return $row;
+    }
+
+    private function archiveRoot(): string
+    {
+        $dir = (string) $this->config->get('purchase_invoice.archive_storage', '');
+        if ($dir !== '') return $dir;
+        $uploads = (string) $this->config->get('storage.uploads_dir', '');
+        if ($uploads !== '') return dirname($uploads) . '/purchase-invoices';
+        return RuntimePaths::storage('purchase-invoices');
+    }
+
+    private function minimalIsdoc(string $id): string
+    {
+        $ic = $this->supplierIc;
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="http://isdoc.cz/namespace/2013">
+  <DocumentType>1</DocumentType>
+  <ID>{$id}</ID>
+  <IssueDate>2026-05-01</IssueDate>
+  <TaxPointDate>2026-05-01</TaxPointDate>
+  <LocalCurrencyCode>CZK</LocalCurrencyCode>
+  <CurrencyCode>CZK</CurrencyCode>
+  <AccountingSupplierParty><Party>
+    <PartyIdentification><ID>12345678</ID></PartyIdentification>
+    <PartyName><Name>Source Test Vendor</Name></PartyName>
+  </Party></AccountingSupplierParty>
+  <AccountingCustomerParty><Party>
+    <PartyName><Name>Buyer</Name></PartyName>
+    <PartyIdentification><ID>{$ic}</ID></PartyIdentification>
+  </Party></AccountingCustomerParty>
+  <InvoiceLines><InvoiceLine>
+    <Item><Description>Test položka</Description></Item>
+    <InvoicedQuantity unitCode="ks">1</InvoicedQuantity>
+    <UnitPrice>100</UnitPrice>
+    <ClassifiedTaxCategory><Percent>21</Percent></ClassifiedTaxCategory>
+  </InvoiceLine></InvoiceLines>
+</Invoice>
+XML;
+    }
+}

--- a/db/migrations/0123_purchase_invoice_source_artifact.sql
+++ b/db/migrations/0123_purchase_invoice_source_artifact.sql
@@ -1,0 +1,20 @@
+-- Strojově čitelný / autoritativní ZDROJOVÝ artefakt přijaté faktury.
+--
+-- Samostatná osa vedle `pdf_*` (lidsky čitelný render). U importů ze strukturovaného
+-- zdroje (ISDOC/ISDOCX, později Pohoda XML / iDoklad / Fakturoid JSON) se sem uloží
+-- ORIGINÁLNÍ nahrané bajty as-is (u .isdocx NEROZBALENÉ — zachová podpis ZIP obálky;
+-- u embedded ISDOC v PDF/A-3 vytažený XML). Důvod: strojový originál má pro audit/FÚ
+-- (10letá archivační lhůta) vyšší hodnotu než PDF render a umožňuje zpětnou
+-- rekonstrukci/re-extrakci bez datové migrace.
+--
+-- `source_format` je formát-agnostický ENUM, ať budoucí zdroje nepotřebují další migraci.
+-- Zápis je write-once (PurchaseInvoiceRepository::setSourceMetadata nepřepisuje, je-li
+-- source_path už vyplněn) — evidenční stopa se nesmí přepsat re-extrakcí.
+
+ALTER TABLE purchase_invoices
+  ADD COLUMN IF NOT EXISTS source_path VARCHAR(255) NULL DEFAULT NULL AFTER pdf_uploaded_at,
+  ADD COLUMN IF NOT EXISTS source_hash CHAR(64) NULL DEFAULT NULL AFTER source_path,
+  ADD COLUMN IF NOT EXISTS source_size_bytes INT(10) UNSIGNED NULL DEFAULT NULL AFTER source_hash,
+  ADD COLUMN IF NOT EXISTS source_original_name VARCHAR(255) NULL DEFAULT NULL AFTER source_size_bytes,
+  ADD COLUMN IF NOT EXISTS source_format ENUM('isdoc','isdocx','pdf','pohoda_xml','idoklad_json','fakturoid_json') NULL DEFAULT NULL AFTER source_original_name,
+  ADD COLUMN IF NOT EXISTS source_uploaded_at TIMESTAMP NULL DEFAULT NULL AFTER source_format;

--- a/web/src/api/purchaseInvoices.ts
+++ b/web/src/api/purchaseInvoices.ts
@@ -168,6 +168,13 @@ export interface PurchaseInvoice {
   pdf_size_bytes: number | null
   pdf_original_name: string | null
   pdf_uploaded_at: string | null
+  /** Strojově čitelný zdrojový originál (ISDOC/ISDOCX/…) — důkazní stopa. */
+  source_path: string | null
+  source_hash: string | null
+  source_size_bytes: number | null
+  source_original_name: string | null
+  source_format: 'isdoc' | 'isdocx' | 'pdf' | 'pohoda_xml' | 'idoklad_json' | 'fakturoid_json' | null
+  source_uploaded_at: string | null
   vat_classification_code: string | null
   expense_category_id: number | null
   /** Název + kód kategorie nákladu (join z expense_categories, jen v detailu). */
@@ -473,6 +480,14 @@ export const purchaseInvoicesApi = {
     if (inline) params.set('inline', '1')
     const qs = params.toString()
     return `/api/purchase-invoices/${id}/pdf${qs ? '?' + qs : ''}`
+  },
+  /** URL ke stažení strojového zdrojového originálu (ISDOC/ISDOCX/…) — vždy attachment. */
+  sourceUrl: (id: number) => {
+    const sid = localStorage.getItem('myinvoice.current_supplier_id')
+    const params = new URLSearchParams()
+    if (sid && /^\d+$/.test(sid)) params.set('supplier_id', sid)
+    const qs = params.toString()
+    return `/api/purchase-invoices/${id}/source${qs ? '?' + qs : ''}`
   },
 
   /** Naše vygenerované PDF (mPDF z dat). Když nemáme originál nebo chceme vlastní layout. */

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -516,7 +516,8 @@
       "upload_error": "Nahrání selhalo: {error}"
     },
     "source": {
-      "download": "Zdrojový doklad (ISDOC)"
+      "download": "Zdrojový doklad (ISDOC)",
+      "badge_title": "Strojový originál dokladu — klikni pro stažení"
     },
     "extraction": {
       "isdoc_found": "Z PDF jsem rozpoznal ISDOC. Pole jsou předvyplněna z přílohy.",

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -515,6 +515,9 @@
       "duplicate": "Stejný PDF dokument už je archivován u jiné faktury.",
       "upload_error": "Nahrání selhalo: {error}"
     },
+    "source": {
+      "download": "Zdrojový doklad (ISDOC)"
+    },
     "extraction": {
       "isdoc_found": "Z PDF jsem rozpoznal ISDOC. Pole jsou předvyplněna z přílohy.",
       "ai_pending": "Toto PDF neobsahuje ISDOC. Vyplň pole ručně, nebo použij AI extrakci v Externí integrace → AI.",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -516,7 +516,8 @@
       "upload_error": "Upload failed: {error}"
     },
     "source": {
-      "download": "Source document (ISDOC)"
+      "download": "Source document (ISDOC)",
+      "badge_title": "Machine-readable source document — click to download"
     },
     "extraction": {
       "isdoc_found": "ISDOC detected in PDF. Fields prefilled from attachment.",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -515,6 +515,9 @@
       "duplicate": "The same PDF is already archived under another invoice.",
       "upload_error": "Upload failed: {error}"
     },
+    "source": {
+      "download": "Source document (ISDOC)"
+    },
     "extraction": {
       "isdoc_found": "ISDOC detected in PDF. Fields prefilled from attachment.",
       "ai_pending": "This PDF has no ISDOC. Fill manually, or use AI extraction in External integrations → AI.",

--- a/web/src/pages/purchase-invoices/InvoiceDetail.vue
+++ b/web/src/pages/purchase-invoices/InvoiceDetail.vue
@@ -536,6 +536,12 @@ const purchaseActions = computed<ActionItem[]>(() => {
         <span class="text-xs px-2 py-0.5 rounded font-normal bg-neutral-100 text-neutral-600">
           {{ t(`purchase_invoice.document_kind.${invoice.document_kind}`) }}
         </span>
+        <a
+          v-if="invoice.source_format"
+          :href="purchaseInvoicesApi.sourceUrl(invoice.id)"
+          class="text-xs px-2 py-0.5 rounded font-normal bg-emerald-100 text-emerald-700 hover:bg-emerald-200 transition-colors"
+          :title="t('purchase_invoice.source.badge_title')"
+        >{{ invoice.source_format.toUpperCase() }}</a>
       </h1>
       <ActionBar :actions="purchaseActions" />
     </div>

--- a/web/src/pages/purchase-invoices/InvoiceDetail.vue
+++ b/web/src/pages/purchase-invoices/InvoiceDetail.vue
@@ -471,6 +471,8 @@ const purchaseActions = computed<ActionItem[]>(() => {
 
   items.push({ key: 'orig', label: t('purchase_invoice.pdf.download_original'), icon: 'doc', tier: 'overflow', variant: 'neutral',
     show: !!inv.pdf_path, href: purchaseInvoicesApi.pdfUrl(inv.id) })
+  items.push({ key: 'source', label: t('purchase_invoice.source.download'), icon: 'inbox', tier: 'overflow', variant: 'neutral',
+    show: !!inv.source_format, href: purchaseInvoicesApi.sourceUrl(inv.id) })
   items.push({ key: 'exp-pdf', label: t('purchase_invoice.export.our_pdf'), icon: 'doc', tier: 'overflow', variant: 'neutral',
     href: purchaseInvoicesApi.ourPdfUrl(inv.id) })
   items.push({ key: 'exp-isdoc', label: t('purchase_invoice.export.isdoc'), icon: 'inbox', tier: 'overflow', variant: 'primary',


### PR DESCRIPTION
Implementace dle tvého návrhu v #175 (formát-agnostické `source_*`, ne `isdoc_*`).

## Co to dělá

Při importu přijaté faktury ze strukturovaného zdroje (`.isdoc` / `.isdocx` / ISDOC embedded v PDF/A-3) se **trvale archivuje originální strojově čitelný doklad** do nových `source_*` sloupců — jako samostatná osa vedle `pdf_*` (vizuální render). Důkazní stopa s možností re-extrakce.

V detailu přijaté faktury přibyla akce **„Zdrojový doklad (ISDOC)"** (jen když `source_format != null`).

## Design (dle #175)

- **Formát-agnostické** `source_path/hash/size_bytes/original_name/format(ENUM)/uploaded_at`. `source_format` = `isdoc|isdocx|pdf|pohoda_xml|idoklad_json|fakturoid_json` → budoucí zdroje bez další migrace.
- **Bajty AS-IS** — `.isdocx` se **NErozbaluje** (zachová podpis ZIP obálky), embedded ISDOC v PDF se uloží jako vytažené XML.
- **Write-once** — `setSourceMetadata` má `AND source_path IS NULL`, re-import/re-extrakce nepřepíše evidenční stopu.
- **NE přes knihovnu Dokumentů** — sloupec na faktuře drží 1:1 nemazatelný lifecycle se zdrojem.
- **Sdílený sharding helper** — `PurchaseInvoicePdfArchiver::shardedRelPath(sid, hash, ext)` (default `pdf` = zpětně kompat), nový `archiveSourceBytes()` ukládá do odděleného `sources/` podstromu + **magic-byte validace** per formát. Žádný copy-paste.

## Pokrytí

Obě importní brány: **dávkový import** (`InvoiceImportService`) i **dropzone/AI** (`AiPdfExtractor` — přímý `.isdocx` i embedded ISDOC v PDF).

## API + FE

- `GET /api/purchase-invoices/{id}/source` — jeden download action parametrizovaný fakturou (Content-Type dle `source_format`, vždy attachment, path-traversal guard shodně s PDF).
- `source_*` v detailovém response (`pi.*`) + OpenAPI schéma.
- FE: `sourceUrl()` helper + akce v detailu + i18n (cs/en).

## Migrace

`0123` přes `migrate.php` (idempotentní `ADD COLUMN IF NOT EXISTS`). Bez dopadu na stávající doklady (sloupce NULL).

## Testy

`PurchaseInvoiceSourceArchiveTest` — import ISDOC archivuje originál as-is (obsah + hash sedí, oddělený `sources/` podstrom) + write-once. Celá Unit+Integration sada zelená kromě 5/25 pre-existujících `Bank` testů (vkládají hodnotu do generated sloupce `amount_to_pay` → MariaDB strict `1906`; nesouvisí). Ověřeno i e2e importem reálného ISDOC dokladu.

Bonus dle tvé poznámky: vzniká základ pro **re-import/re-extrakci ze zdroje** (přepočet novějším mapperem bez datové migrace).