### PR TITLE
fix(pdf): vygenerované PDF přijaté faktury zobrazuje zaokrouhlení

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Vygenerované PDF přijaté faktury („Náš PDF") nově zobrazuje zaokrouhlení.** Rekonstrukční PDF dokladu u faktur se zaokrouhlením ukazovalo v souhrnu jen „Celkem k úhradě" = základ + DPH, takže chybělo haléřové zaokrouhlení a částka k úhradě byla o haléře vedle skutečnosti. Nově se u dokladů se zaokrouhlením vypíše samostatný řádek **Zaokrouhlení** a „Celkem k úhradě" = celkem s DPH + zaokrouhlení (u dokladů bez zaokrouhlení beze změny).
 - **Import ISDOC u dokladů se zaokrouhlením — „k úhradě" nově sedí na doklad.** Přijatá faktura z ISDOC se zaokrouhlením „k úhradě" (typicky e-faktury z e-shopů) se dosud naimportovala s částkou k úhradě = přesný součet položek, takže `K úhradě` bylo o haléře vedle skutečné částky na dokladu (a nepárovalo se přesně s platbou v bance). Import nově čte z ISDOC `<LegalMonetaryTotal>/<PayableAmount>` a haléřový rozdíl uloží jako zaokrouhlení — stejně jako už dělá rozpoznávání z PDF přes AI. Příklad: doklad se základem+DPH 999,99 a zaokrouhlením +0,01 se nově naimportuje tak, že `K úhradě` = 1 000,00. Základ a DPH zůstávají nezměněné (správně pro přiznání DPH a kontrolní hlášení). Sémantika `amount_to_pay` se nemění — zaokrouhlení se i nadále vede mimo něj (pole *Zaokrouhlení*) a do „k úhradě" se promítá stejnou cestou jako u AI importu (QR, platební příkaz, PDF, UI).
 
 ## [4.43.2] — 2026-06-29

--- a/api/templates/purchase-invoice/purchase-invoice.twig
+++ b/api/templates/purchase-invoice/purchase-invoice.twig
@@ -156,9 +156,20 @@
     <td class="label">{% if locale == 'en' %}VAT total{% else %}DPH celkem{% endif %}</td>
     <td class="num">{{ totals.vat|number_format(2, ',', ' ') }} {{ currency }}</td>
   </tr>
-  <tr class="grand">
-    <td class="label">{% if locale == 'en' %}Total inc. VAT{% else %}Celkem k úhradě{% endif %}</td>
+  {% set rnd = invoice.rounding|default(0) %}
+  {% if rnd != 0 %}
+  <tr>
+    <td class="label">{% if locale == 'en' %}Total inc. VAT{% else %}Celkem s DPH{% endif %}</td>
     <td class="num">{{ totals.with_vat|number_format(2, ',', ' ') }} {{ currency }}</td>
+  </tr>
+  <tr>
+    <td class="label">{% if locale == 'en' %}Rounding{% else %}Zaokrouhlení{% endif %}</td>
+    <td class="num">{{ rnd|number_format(2, ',', ' ') }} {{ currency }}</td>
+  </tr>
+  {% endif %}
+  <tr class="grand">
+    <td class="label">{% if locale == 'en' %}Total due{% else %}Celkem k úhradě{% endif %}</td>
+    <td class="num">{{ (totals.with_vat + rnd)|number_format(2, ',', ' ') }} {{ currency }}</td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Problém

Rekonstrukční PDF přijaté faktury („Náš PDF" / `OurPdfPurchaseInvoiceAction`) u dokladů se zaokrouhlením ukazovalo v souhrnu jen:

```
Celkem k úhradě    (= totals.with_vat, tj. základ + DPH)
```

Chybělo haléřové **zaokrouhlení**, takže částka k úhradě v PDF byla o haléře vedle skutečné částky na dokladu (např. 856,04 místo 856,00). Doplňuje #174 (tam se zaokrouhlení opravilo pro KH/přiznání a UI/QR/příkaz, ale rekonstrukční PDF ho nezobrazovalo).

## Oprava

`templates/purchase-invoice/purchase-invoice.twig` — u dokladů s `rounding != 0` se nově vypíše samostatný řádek **Zaokrouhlení** a „Celkem k úhradě" = `totals.with_vat + invoice.rounding`:

```
Celkem s DPH       856,04 CZK
Zaokrouhlení        -0,04 CZK
Celkem k úhradě     856,00 CZK
```

Doklady **bez** zaokrouhlení (`rounding = 0`) zůstávají beze změny (jeden řádek „Celkem k úhradě" = celkem s DPH). Renderer už `invoice.rounding` do template předával — šlo čistě o zobrazení, žádná změna v PHP.

## Ověření

E2E render reálného dokladu se zaokrouhlením — extrakce textu z PDF potvrzuje řádek „Zaokrouhlení -0,04" a „Celkem k úhradě 856,00".