### PR TITLE
docs(přijaté faktury): archivace strojového zdroje + zaokrouhlení k úhradě

### DIFF
--- a/manual/17_Prijate_faktury.md
+++ b/manual/17_Prijate_faktury.md
@@ -42,6 +42,7 @@ Nad formulářem je **drag & drop zóna**. Pokud máš PDF od dodavatele:
   - **Pokud ano** (fakturační software jako Money S3, Pohoda, Stormware, sám MyInvoice) → pole formuláře se předvyplní strukturovanými daty.
   - **Pokud ne** (běžné PDF bez přílohy) → můžeš použít **AI extrakci přes Anthropic Claude** (viz [AI extrakce](19_AI_extrakce.md)), nebo pole vyplnit ručně.
 - Originál PDF se po prvním uložení faktury automaticky **archivuje** mimo webroot a v detailu si ho můžeš kdykoli stáhnout zpět.
+- **Strojově čitelný originál (ISDOC/ISDOCX) se uchová jako důkazní stopa.** U faktur importovaných ze strukturovaného zdroje (`.isdoc`, `.isdocx`, nebo ISDOC vložený v PDF/A-3) se vedle vizuálního PDF trvale archivuje i **původní strojový doklad**. Pro audit a kontrolu z finančního úřadu má při 10leté archivační lhůtě vyšší hodnotu než PDF render a umožňuje zpětnou rekonstrukci dat (i kdyby se zpracování v budoucnu změnilo). V detailu faktury ho stáhneš přes badge **„ISDOC"** v hlavičce nebo akci **Zdrojový doklad** v menu. Bajty se ukládají tak, jak přišly — `.isdocx` se nerozbaluje (zachová podpis obálky), embedded ISDOC se uloží jako vytažené XML; originál se nikdy nepřepíše. Formát je univerzální (`source_format`), do budoucna pokryje i další strukturované zdroje.
 
 > 💡 Doklad jde nahrát **už při zakládání nové faktury** (po přetažení se ukáže kartička „soubor připraven, nahraje se po uložení") i **z detailu** faktury, která zatím doklad nemá. Kromě PDF lze přetáhnout i **fotku** (JPG/PNG/WEBP/HEIC) — systém ji převede na PDF — nebo přímo **ISDOC / ISDOCX** balíček: ten se rozbalí a naparsuje deterministicky (bez AI), z `.isdocx` se navíc archivuje zabalené PDF pro náhled.
 
@@ -49,6 +50,8 @@ Limity:
 - Max 20 MiB per soubor
 - Akceptujeme PDF, fotku (JPG/PNG/WEBP/HEIC) a ISDOC/ISDOCX (magic bytes se ověřují server-side)
 - SHA-256 deduplikace — stejný doklad už archivovaný u jiné faktury nebude akceptován
+
+> 💰 **Zaokrouhlení „k úhradě".** U dokladů se zaokrouhlením na celé koruny (typicky e‑faktury z e‑shopů) systém převezme zaokrouhlení přímo z dokladu — částka **K úhradě** pak sedí na haléř se skutečnou částkou na faktuře (a přesně se spáruje s platbou v bance). Základ a DPH zůstávají nezměněné (správně pro přiznání DPH a kontrolní hlášení); zaokrouhlení se vede jako samostatná položka a promítne se do „k úhradě", QR platby, platebního příkazu i vygenerovaného PDF (rekonstrukce „Náš PDF" zobrazí řádek *Zaokrouhlení*).
 
 ### 17.2.2 Povinná pole
 
@@ -211,6 +214,7 @@ Po uložení / přechodu na detail:
 
 - Vidíš dodavatele (s IČO/DIČ), datumy, položky, DPH rozpis, totály, K úhradě.
 - Sekce **Originální PDF od dodavatele** — pokud jsi nahrál, můžeš stáhnout zpět.
+- Badge **„ISDOC"** v hlavičce (a akce **Zdrojový doklad** v menu) — u faktur importovaných ze strukturovaného zdroje stáhne původní strojově čitelný originál (důkazní stopa, viz [§ 17.2.1](#1721-drag--drop-pdf)).
 - Tlačítka pro **přechod stavu** podle state-machine:
   - Z draft: Označit jako přijaté / Stornovat
   - Z received: Označit jako zaúčtované / uhrazené / Stornovat


### PR DESCRIPTION
Aktualizace manuálu § 17 (Přijaté faktury) k featurám vydaným ve v4.43.3:

- **§ 17.2.1** — nový odstavec o uchování **strojově čitelného originálu (ISDOC/ISDOCX)** jako důkazní stopy (PR #176): badge „ISDOC" / akce „Zdrojový doklad", bajty as-is, write-once, formát-agnostické.
- **§ 17.2.1** — poznámka o **zaokrouhlení „k úhradě"** převzatém z dokladu (PR #174/#177): K úhradě sedí na haléř, základ+DPH beze změny, promítne se do QR/příkazu/PDF (rekonstrukce zobrazí řádek *Zaokrouhlení*).
- **§ 17.3** — zmínka o stažení zdrojového dokladu z detailu.

Jen dokumentace, bez dopadu na běh.