### PR TITLE
feat(import): iDoklad přebírá přijaté účtenky/paragony (ReceivedReceipts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **iDoklad import — přijaté účtenky/paragony (`ReceivedReceipts`).** Import z iDokladu dosud stahoval jen `ReceivedInvoices` (přijaté faktury) a koncový bod `ReceivedReceipts` přeskakoval — přijaté účtenky/paragony se tak vůbec nepřenesly. Nově se importují do `purchase_invoices` s `document_kind='receipt'` (řídí se přes nový parametr `include_receipts`, default zapnuto). Mapování zohledňuje odlišnosti účtenky od faktury: účtenka nemá splatnost (`DateOfMaturity`) ani DUZP (`DateOfTaxing`) → `issue_date`/`tax_date`/`due_date` se odvodí z `DateOfIssue`, a číslo dokladu dodavatele je `ExternalDocumentNumber` (fallback `DocumentNumber`). Hotovostní účtenka bez kontaktu (`Partner` = null) se **naváže na sběrného systémového dodavatele „Hotovostní nákup (účtenka)"** (aby se náklad neztratil) a importuje se **bez nároku na odpočet DPH** (`vat_deduction='none'`) s upozorněním k doplnění dodavatele — u plátce tak nevzniká chybný odpočet, u neplátce je to bez dopadu. Dedup přes `idoklad_id` i `(vendor, číslo, datum)` zůstává — opakovaný import nepřidává duplicity. Položkové ceny i rekapitulace DPH se skládají z autoritativních per-řádkových `Prices` stejně jako u přijatých faktur (řeší i ceny s DPH na účtenkách). Účtenka je hrazená na místě, takže se importuje rovnou jako **zaplacená** (`paid_at` = datum vystavení), pokud iDoklad nevrátí konkrétnější stav úhrady.
+
 ## [4.43.4] — 2026-07-01
 
 ### Fixed

--- a/api/src/Action/Admin/Import/StartIdokladImportAction.php
+++ b/api/src/Action/Admin/Import/StartIdokladImportAction.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 /**
  * POST /api/admin/imports/idoklad/start
  *
- * Body: { include_clients?: bool, include_issued?: bool, include_received?: bool, dry_run?: bool }
+ * Body: { include_clients?: bool, include_issued?: bool, include_received?: bool, include_receipts?: bool, dry_run?: bool }
  *
  * Vytvoří import_jobs řádek se status='queued' a spustí background worker
  * (detached process — Windows DETACHED_PROCESS, Linux nohup). UI pak polluje
@@ -74,6 +74,7 @@ final class StartIdokladImportAction
             'include_clients'      => $body['include_clients']      ?? true,
             'include_issued'       => $body['include_issued']       ?? true,
             'include_received'     => $body['include_received']     ?? true,
+            'include_receipts'     => $body['include_receipts']     ?? true,
             'incremental'          => !empty($body['incremental']),
             'download_attachments' => !empty($body['download_attachments']),
             'dry_run'              => !empty($body['dry_run']),

--- a/api/src/Repository/ClientRepository.php
+++ b/api/src/Repository/ClientRepository.php
@@ -9,6 +9,9 @@ use PDO;
 
 final class ClientRepository
 {
+    /** Název sběrného systémového dodavatele hotovostních účtenek (viz findOrCreateCashReceiptVendor). */
+    private const CASH_RECEIPT_VENDOR_NAME = 'Hotovostní nákup (účtenka)';
+
     public function __construct(private readonly Connection $db) {}
 
     public function find(int $id): ?array
@@ -294,6 +297,37 @@ final class ClientRepository
         $this->db->pdo()
             ->prepare('UPDATE clients SET is_vendor = 1 WHERE id = ? AND is_vendor = 0')
             ->execute([$id]);
+    }
+
+    /**
+     * Systémový (sběrný) dodavatel „Hotovostní nákup (účtenka)" — pod něj se navazují
+     * hotovostní účtenky bez identifikace protistrany (iDoklad Partner == null). Jeden na
+     * tenanta; poznává se podle názvu (bez potřeby extra sloupce — iDoklad import je okrajový).
+     * Zakládá se jako neplátce DPH (neznámý/neověřený dodavatel) → bezpečný default pro odpočet.
+     * Idempotentní: při opakovaném importu vrací stejný řádek.
+     */
+    public function findOrCreateCashReceiptVendor(int $supplierId): int
+    {
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT id FROM clients WHERE supplier_id = ? AND company_name = ? AND is_vendor = 1 LIMIT 1'
+        );
+        $stmt->execute([$supplierId, self::CASH_RECEIPT_VENDOR_NAME]);
+        $id = $stmt->fetchColumn();
+        if ($id !== false) {
+            return (int) $id;
+        }
+
+        return $this->create([
+            'company_name' => self::CASH_RECEIPT_VENDOR_NAME,
+            'street'       => '',
+            'city'         => '',
+            'zip'          => '',
+            'main_email'   => '',
+            'country_iso2' => 'CZ',
+            'is_customer'  => false,
+            'is_vendor'    => true,
+            'is_vat_payer' => false,
+        ], $supplierId);
     }
 
     /**

--- a/api/src/Service/Import/IdokladClient.php
+++ b/api/src/Service/Import/IdokladClient.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
  *   - GET  https://api.idoklad.cz/v3/Contacts
  *   - GET  https://api.idoklad.cz/v3/IssuedInvoices
  *   - GET  https://api.idoklad.cz/v3/ReceivedInvoices
+ *   - GET  https://api.idoklad.cz/v3/ReceivedReceipts
  *
  * Rate limit per docs: 60 req/min. Vlastní hint counter — pokud >50 req/min,
  * sleep 1s před requestem (smooth rate).

--- a/api/src/Service/Import/IdokladImportService.php
+++ b/api/src/Service/Import/IdokladImportService.php
@@ -59,6 +59,7 @@ final class IdokladImportService
      *   - include_clients: bool (default true)
      *   - include_issued: bool (default true)
      *   - include_received: bool (default true)
+     *   - include_receipts: bool (default true) — přijaté účtenky/paragony
      *   - dry_run: bool (default false)
      */
     public function run(int $jobId): void
@@ -96,6 +97,10 @@ final class IdokladImportService
             }
             if (!empty($params['include_received']) || ($params['include_received'] ?? null) === null) {
                 $this->importReceived($jobId, $supplierId, $userId, $dryRun, $bookmarkSince, $downloadAttachments);
+                $this->checkCancel($jobId);
+            }
+            if (!empty($params['include_receipts']) || ($params['include_receipts'] ?? null) === null) {
+                $this->importReceipts($jobId, $supplierId, $userId, $dryRun, $bookmarkSince, $downloadAttachments);
             }
 
             // Mark completed + bookmark
@@ -585,6 +590,205 @@ final class IdokladImportService
         );
 
         return $id;
+    }
+
+    /**
+     * Import ReceivedReceipts (přijaté účtenky / paragony) → purchase_invoices (document_kind='receipt').
+     *
+     * iDoklad endpoint GET /v3/ReceivedReceipts používá stejný paginated envelope jako
+     * ReceivedInvoices, takže řídicí smyčka je shodná s importReceived(). Liší se mapování:
+     * účtenky nemají splatnost ani DUZP a Partner může být null (hotovostní nákup) — viz
+     * createReceiptFromIdoklad().
+     */
+    private function importReceipts(int $jobId, int $supplierId, int $userId, bool $dryRun, ?string $bookmarkSince = null, bool $downloadAttachments = false): void
+    {
+        $this->jobs->updateProgress($jobId, ['current_step' => 'Importing received receipts…', 'processed' => 0]);
+        $this->jobs->appendLog($jobId, 'Stahuji přijaté účtenky z iDoklad…');
+
+        $query = $bookmarkSince !== null ? ['filter' => "DateLastChange>={$bookmarkSince}"] : [];
+
+        $created = 0; $skipped = 0; $failed = 0; $processed = 0;
+        foreach ($this->idoklad->getAll($supplierId, 'ReceivedReceipts', $query) as $idoklad) {
+            $processed++;
+            if ($processed % self::PROGRESS_FLUSH_EVERY === 0) {
+                $this->jobs->updateProgress($jobId, ['processed' => $processed, 'created_count' => $created, 'skipped_count' => $skipped, 'failed_count' => $failed]);
+                $this->checkCancel($jobId);
+            }
+
+            $idokladId = (int) ($idoklad['Id'] ?? 0);
+            if ($idokladId === 0) continue;
+
+            $stmt = $this->db->pdo()->prepare(
+                'SELECT id FROM purchase_invoices WHERE supplier_id = ? AND idoklad_id = ? LIMIT 1'
+            );
+            $stmt->execute([$supplierId, $idokladId]);
+            if ($stmt->fetchColumn() !== false) { $skipped++; continue; }
+
+            if ($dryRun) { $created++; continue; }
+
+            try {
+                $purchaseId = $this->createReceiptFromIdoklad($idoklad, $supplierId, $userId);
+                if ($purchaseId === null) { $skipped++; continue; } // hotovostní účtenka bez Partnera
+                $this->db->pdo()->prepare(
+                    'UPDATE purchase_invoices SET idoklad_id = ? WHERE id = ?'
+                )->execute([$idokladId, $purchaseId]);
+                $this->purCalc->recompute($purchaseId);
+                if ($downloadAttachments) {
+                    $this->archiveReceivedPdf($supplierId, $purchaseId, $idokladId);
+                }
+                $created++;
+            } catch (\Throwable $e) {
+                $failed++;
+                $this->jobs->appendLog($jobId, "Účtenka #{$idokladId}: " . $e->getMessage());
+            }
+        }
+        $this->jobs->updateProgress($jobId, ['processed' => $processed, 'created_count' => $created, 'skipped_count' => $skipped, 'failed_count' => $failed]);
+        $this->jobs->appendLog($jobId, "Přijaté účtenky: vytvořeno {$created}, přeskočeno {$skipped}, chyby {$failed} (z {$processed}).");
+    }
+
+    /**
+     * Vytvoří jednu přijatou účtenku z iDoklad payloadu jako purchase_invoice s document_kind='receipt'.
+     *
+     * Rozdíly oproti createReceivedFromIdoklad():
+     *   • Partner je vnořený a MŮŽE být null (hotovostní nákup bez kontaktu) → vrátí null, caller skip.
+     *   • Účtenka nemá splatnost (DateOfMaturity) ani DUZP (DateOfTaxing) → vše z DateOfIssue.
+     *   • Číslo dokladu dodavatele je ExternalDocumentNumber (ne ReceivedDocumentNumber); často chybí.
+     *   • iDoklad u účtenek nevrací hlavičkovou slevu (DiscountType/DiscountPercentage).
+     */
+    private function createReceiptFromIdoklad(array $i, int $supplierId, int $userId): ?int
+    {
+        $hdr = self::idokladReceiptHeader($i, date('Y-m-d'));
+
+        // Hotovostní účtenka bez kontaktu (Partner == null) — nemáme koho navázat jako vendora.
+        if ($hdr['partner_id'] === 0) {
+            return null;
+        }
+        $vendorId = $this->resolveClientByIdoklad($hdr['partner_id'], $supplierId);
+        if ($vendorId === null) {
+            throw new \RuntimeException("Dodavatel s iDoklad ID {$hdr['partner_id']} nenalezen — nejdřív naimportuj kontakty.");
+        }
+        $this->clients->markAsVendor($vendorId);
+
+        $issueDate = $hdr['issue_date'];
+        $taxDate   = $hdr['tax_date'];
+        $dueDate   = $hdr['due_date'];
+
+        $vatRates = $this->loadVatRateMap();
+        $defaultVatRateId = $this->matchVatRateId($vatRates, 21.0) ?? $this->matchVatRateId($vatRates, 0.0) ?? 0;
+
+        // Položky — stejný tvar jako ReceivedInvoices (Amount/Name/Unit/VatRate + per-řádek Prices).
+        // idokladNetUnitPrice() řeší i PriceType=WithVat (účtenky bývají ceny s DPH).
+        $items = [];
+        foreach (($i['Items'] ?? []) as $idx => $line) {
+            $rate = (float) ($line['VatRate'] ?? 0);
+            $vatRateId = $this->matchVatRateId($vatRates, $rate) ?? $defaultVatRateId;
+            $items[] = [
+                'description'            => (string) ($line['Name'] ?? $line['Description'] ?? ''),
+                'quantity'               => (float) ($line['Amount'] ?? 1),
+                'unit'                   => (string) ($line['Unit'] ?? 'ks'),
+                'unit_price_without_vat' => self::idokladNetUnitPrice($line, $rate),
+                'vat_rate_id'            => $vatRateId,
+                'order_index'            => $idx,
+            ];
+        }
+
+        $reverseCharge = $this->inferReverseChargeFromItems($vendorId, $items);
+        $currencyCode  = $this->idokladCurrencyCode($i, $supplierId);
+
+        $payload = [
+            'vendor_id'             => $vendorId,
+            'vendor_invoice_number' => $this->sanitizeVendorNumber($hdr['vendor_invoice_number']),
+            'document_kind'         => 'receipt',
+            'issue_date'            => $issueDate,
+            'tax_date'              => $taxDate,
+            'due_date'              => $dueDate,
+            'received_at'           => date('Y-m-d'),
+            'currency_id'           => $this->resolveCurrencyId($currencyCode, $supplierId, isActive: false),
+            'exchange_rate'         => self::idokladExchangeRate($i),
+            'exchange_rate_source'  => 'manual',
+            'reverse_charge'        => $reverseCharge,
+            'language'              => 'cs',
+            'items'                 => $items,
+        ];
+
+        // Dedup guard — re-import stejné účtenky (typicky při opakovaném pullu) by jinak hodil
+        // SQL 23000 duplicate key. Vrátíme existující ID.
+        $existingId = $this->purchaseRepo->findIdByVendorInvoice(
+            $supplierId, $vendorId,
+            (string) $payload['vendor_invoice_number'],
+            (string) $payload['issue_date'],
+        );
+        if ($existingId !== null) {
+            return $existingId;
+        }
+
+        $id = $this->purchaseRepo->createDraft($payload, $userId, $supplierId);
+        if (!empty($items)) {
+            $this->purchaseRepo->replaceItems($id, $items);
+        }
+        $this->cnbApplier->applyIfMissing(
+            $id,
+            $supplierId,
+            $currencyCode,
+            (string) ($payload['tax_date'] ?? $payload['issue_date'] ?? ''),
+            $payload['exchange_rate'] ?? null,
+        );
+
+        // Seed override rekapitulace DPH z per-řádek Prices (stejně jako createReceivedFromIdoklad).
+        // Účtenka nemá hlavičkovou slevu, takže recap seedujeme bezpodmínečně, je-li kompletní.
+        $docByRate = self::idokladVatRecap($i['Items'] ?? []);
+        if ($docByRate !== []) {
+            $this->purCalc->recompute($id);
+            $warning = (new PurchaseVatRecapSeeder($this->purchaseRepo, $this->purCalc))->seed(
+                $id,
+                $supplierId,
+                $docByRate,
+                $currencyCode,
+                false,
+            );
+            if ($warning !== null) {
+                try {
+                    $this->purchaseRepo->appendExtractionWarning($id, $supplierId, $warning);
+                } catch (\Throwable) {
+                    // Varování je „nice to have".
+                }
+            }
+        }
+
+        // Účtenka/paragon je hrazená na místě → import rovnou jako zaplacená (paid_at = datum
+        // vystavení). ReceivedReceipts payload obvykle PaymentStatus nenese (ověřeno živě: null),
+        // takže fromIdoklad() vrátí null; přesto když by iDoklad stav úhrady vrátil, respektuj ho.
+        $paymentState = ImportedPaymentStateMapper::fromIdoklad($i)
+            ?? ['status' => 'paid', 'paid_at' => $issueDate];
+        $this->applyPurchasePaymentState($id, $supplierId, $paymentState, $issueDate);
+
+        return $id;
+    }
+
+    /**
+     * Receipt-specifické mapování hlavičky (čistá funkce, bez DB — proto unit-testovatelná).
+     *
+     * Účtenky se od přijatých faktur liší: Partner je vnořený a může být null (hotovostní
+     * nákup), chybí splatnost (DateOfMaturity) i DUZP (DateOfTaxing) → issue/tax/due odvodíme
+     * shodně z DateOfIssue; číslo dokladu dodavatele je ExternalDocumentNumber (fallback
+     * DocumentNumber) — účtenka ho nemusí mít vůbec, prázdné je u document_kind='receipt' OK.
+     *
+     * @param array<string,mixed> $i      iDoklad ReceivedReceipt payload
+     * @param string              $today  fallback datum (Y-m-d), když DateOfIssue chybí
+     * @return array{partner_id:int, vendor_invoice_number:string, issue_date:string, tax_date:string, due_date:string}
+     */
+    public static function idokladReceiptHeader(array $i, string $today): array
+    {
+        $partnerId = (int) ($i['Partner']['Id'] ?? $i['PartnerId'] ?? 0);
+        $issueDate = (string) ($i['DateOfIssue'] ?? '') ?: $today;
+
+        return [
+            'partner_id'            => $partnerId,
+            'vendor_invoice_number' => (string) ($i['ExternalDocumentNumber'] ?? $i['DocumentNumber'] ?? ''),
+            'issue_date'            => $issueDate,
+            'tax_date'              => $issueDate,
+            'due_date'              => $issueDate,
+        ];
     }
 
     /**

--- a/api/src/Service/Import/IdokladImportService.php
+++ b/api/src/Service/Import/IdokladImportService.php
@@ -650,7 +650,9 @@ final class IdokladImportService
      * Vytvoří jednu přijatou účtenku z iDoklad payloadu jako purchase_invoice s document_kind='receipt'.
      *
      * Rozdíly oproti createReceivedFromIdoklad():
-     *   • Partner je vnořený a MŮŽE být null (hotovostní nákup bez kontaktu) → vrátí null, caller skip.
+     *   • Partner je vnořený a MŮŽE být null (hotovostní nákup bez kontaktu) → doklad se naváže
+     *     na sběrného systémového dodavatele „Hotovostní nákup (účtenka)" (náklad se neztratí)
+     *     a importuje se bez nároku na odpočet DPH (viz níže).
      *   • Účtenka nemá splatnost (DateOfMaturity) ani DUZP (DateOfTaxing) → vše z DateOfIssue.
      *   • Číslo dokladu dodavatele je ExternalDocumentNumber (ne ReceivedDocumentNumber); často chybí.
      *   • iDoklad u účtenek nevrací hlavičkovou slevu (DiscountType/DiscountPercentage).
@@ -659,15 +661,27 @@ final class IdokladImportService
     {
         $hdr = self::idokladReceiptHeader($i, date('Y-m-d'));
 
-        // Hotovostní účtenka bez kontaktu (Partner == null) — nemáme koho navázat jako vendora.
-        if ($hdr['partner_id'] === 0) {
-            return null;
+        // Hotovostní účtenka bez kontaktu (Partner == null) — dodavatele neznáme. Místo zahození
+        // nákladu ji navážeme na sběrného systémového vendora a odpočet DPH necháme neuplatněný
+        // (nemůžeme ověřit dodavatele ani jeho plátcovství — bezpečný default pro plátce; neplátce
+        // to neřeší). Uživatel může po doplnění dodavatele odpočet povolit.
+        $unknownVendor = ($hdr['partner_id'] === 0);
+        if ($unknownVendor) {
+            $vendorId = $this->clients->findOrCreateCashReceiptVendor($supplierId);
+        } else {
+            $vendorId = $this->resolveClientByIdoklad($hdr['partner_id'], $supplierId);
+            if ($vendorId === null) {
+                throw new \RuntimeException("Dodavatel s iDoklad ID {$hdr['partner_id']} nenalezen — nejdřív naimportuj kontakty.");
+            }
+            $this->clients->markAsVendor($vendorId);
         }
-        $vendorId = $this->resolveClientByIdoklad($hdr['partner_id'], $supplierId);
-        if ($vendorId === null) {
-            throw new \RuntimeException("Dodavatel s iDoklad ID {$hdr['partner_id']} nenalezen — nejdřív naimportuj kontakty.");
+
+        // Číslo dokladu — createDraft ho vyžaduje neprázdné; hotovostní účtenka ho nemusí mít.
+        // Fallback na stabilní iDoklad Id, aby dedup (vendor+číslo+datum) i re-import fungovaly.
+        $vendorNumber = $this->sanitizeVendorNumber($hdr['vendor_invoice_number']);
+        if ($vendorNumber === '') {
+            $vendorNumber = 'UCT-' . (int) ($i['Id'] ?? 0);
         }
-        $this->clients->markAsVendor($vendorId);
 
         $issueDate = $hdr['issue_date'];
         $taxDate   = $hdr['tax_date'];
@@ -697,7 +711,7 @@ final class IdokladImportService
 
         $payload = [
             'vendor_id'             => $vendorId,
-            'vendor_invoice_number' => $this->sanitizeVendorNumber($hdr['vendor_invoice_number']),
+            'vendor_invoice_number' => $vendorNumber,
             'document_kind'         => 'receipt',
             'issue_date'            => $issueDate,
             'tax_date'              => $taxDate,
@@ -707,6 +721,9 @@ final class IdokladImportService
             'exchange_rate'         => self::idokladExchangeRate($i),
             'exchange_rate_source'  => 'manual',
             'reverse_charge'        => $reverseCharge,
+            // Neznámý dodavatel (hotovostní účtenka) → bez nároku na odpočet DPH. Import jde přes
+            // createDraft(), který NEuplatňuje auto-none z CreatePurchaseInvoiceAction, proto explicitně.
+            'vat_deduction'         => $unknownVendor ? 'none' : 'full',
             'language'              => 'cs',
             'items'                 => $items,
         ];
@@ -752,6 +769,20 @@ final class IdokladImportService
                 } catch (\Throwable) {
                     // Varování je „nice to have".
                 }
+            }
+        }
+
+        // Hotovostní účtenka bez identifikace dodavatele — upozorni na revizi (odpočet je záměrně
+        // neuplatněný; uživatel po doplnění dodavatele může nárok povolit).
+        if ($unknownVendor) {
+            try {
+                $this->purchaseRepo->appendExtractionWarning(
+                    $id,
+                    $supplierId,
+                    'Účtenka bez identifikace dodavatele (hotovostní nákup) — pro uplatnění odpočtu DPH doplňte dodavatele a povolte odpočet.',
+                );
+            } catch (\Throwable) {
+                // Varování je „nice to have".
             }
         }
 

--- a/api/tests/Unit/Service/Import/IdokladReceiptHeaderTest.php
+++ b/api/tests/Unit/Service/Import/IdokladReceiptHeaderTest.php
@@ -12,7 +12,8 @@ use PHPUnit\Framework\TestCase;
  *
  * Účtenky se od přijatých faktur (ReceivedInvoices) liší a tahle čistá funkce drží
  * právě ty rozdíly:
- *   • Partner je vnořený objekt a může chybět (hotovostní nákup) → partner_id=0 → caller skip.
+ *   • Partner je vnořený objekt a může chybět (hotovostní nákup) → partner_id=0; caller pak doklad
+ *     naváže na sběrného systémového dodavatele (viz createReceiptFromIdoklad).
  *   • Nemají splatnost (DateOfMaturity) ani DUZP (DateOfTaxing) → issue/tax/due == DateOfIssue.
  *   • Číslo dokladu dodavatele je ExternalDocumentNumber (fallback DocumentNumber), může chybět.
  */
@@ -40,9 +41,10 @@ final class IdokladReceiptHeaderTest extends TestCase
         self::assertSame('2026-05-12', $hdr['due_date']);
     }
 
-    public function testNullPartnerYieldsZeroSoCallerSkips(): void
+    public function testNullPartnerYieldsZeroForCollectiveVendorRouting(): void
     {
-        // Hotovostní účtenka bez kontaktu — Partner == null.
+        // Hotovostní účtenka bez kontaktu — Partner == null → partner_id=0 (caller ho navěsí
+        // na sběrného systémového dodavatele „Hotovostní nákup").
         $i = [
             'Id'          => 1,
             'DateOfIssue' => '2026-05-12',

--- a/api/tests/Unit/Service/Import/IdokladReceiptHeaderTest.php
+++ b/api/tests/Unit/Service/Import/IdokladReceiptHeaderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Import;
+
+use MyInvoice\Service\Import\IdokladImportService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Mapování hlavičky iDoklad ReceivedReceipt (přijatá účtenka) → purchase_invoices.
+ *
+ * Účtenky se od přijatých faktur (ReceivedInvoices) liší a tahle čistá funkce drží
+ * právě ty rozdíly:
+ *   • Partner je vnořený objekt a může chybět (hotovostní nákup) → partner_id=0 → caller skip.
+ *   • Nemají splatnost (DateOfMaturity) ani DUZP (DateOfTaxing) → issue/tax/due == DateOfIssue.
+ *   • Číslo dokladu dodavatele je ExternalDocumentNumber (fallback DocumentNumber), může chybět.
+ */
+final class IdokladReceiptHeaderTest extends TestCase
+{
+    private const TODAY = '2026-06-30';
+
+    public function testRealReceiptShapeMapsAllDatesFromIssue(): void
+    {
+        $i = [
+            'Id'                     => 4242,
+            'DateOfIssue'            => '2026-05-12',
+            'ExternalDocumentNumber' => 'UCT-2026-0007',
+            'DocumentNumber'         => 'PR250042',
+            'Partner'                => ['Id' => 99, 'CompanyName' => 'Benzina'],
+        ];
+
+        $hdr = IdokladImportService::idokladReceiptHeader($i, self::TODAY);
+
+        self::assertSame(99, $hdr['partner_id']);
+        self::assertSame('UCT-2026-0007', $hdr['vendor_invoice_number']);
+        // Splatnost ani DUZP účtenka nemá → vše z DateOfIssue.
+        self::assertSame('2026-05-12', $hdr['issue_date']);
+        self::assertSame('2026-05-12', $hdr['tax_date']);
+        self::assertSame('2026-05-12', $hdr['due_date']);
+    }
+
+    public function testNullPartnerYieldsZeroSoCallerSkips(): void
+    {
+        // Hotovostní účtenka bez kontaktu — Partner == null.
+        $i = [
+            'Id'          => 1,
+            'DateOfIssue' => '2026-05-12',
+            'Partner'     => null,
+        ];
+
+        self::assertSame(0, IdokladImportService::idokladReceiptHeader($i, self::TODAY)['partner_id']);
+    }
+
+    public function testFlatPartnerIdFallbackIsAccepted(): void
+    {
+        // Defenzivně: kdyby list endpoint vrátil plochý PartnerId místo vnořeného Partner.
+        $i = ['Id' => 1, 'DateOfIssue' => '2026-05-12', 'PartnerId' => 77];
+
+        self::assertSame(77, IdokladImportService::idokladReceiptHeader($i, self::TODAY)['partner_id']);
+    }
+
+    public function testFallsBackToDocumentNumberWhenExternalMissing(): void
+    {
+        $i = [
+            'Id'             => 1,
+            'DateOfIssue'    => '2026-05-12',
+            'DocumentNumber' => 'PR250042',
+            'Partner'        => ['Id' => 5],
+        ];
+
+        self::assertSame('PR250042', IdokladImportService::idokladReceiptHeader($i, self::TODAY)['vendor_invoice_number']);
+    }
+
+    public function testMissingNumberIsEmptyNotError(): void
+    {
+        // Účtenka/paragon nemusí mít žádné číslo dokladu — prázdné je u receipt OK.
+        $i = ['Id' => 1, 'DateOfIssue' => '2026-05-12', 'Partner' => ['Id' => 5]];
+
+        self::assertSame('', IdokladImportService::idokladReceiptHeader($i, self::TODAY)['vendor_invoice_number']);
+    }
+
+    public function testMissingIssueDateFallsBackToToday(): void
+    {
+        $i = ['Id' => 1, 'Partner' => ['Id' => 5]];
+
+        $hdr = IdokladImportService::idokladReceiptHeader($i, self::TODAY);
+        self::assertSame(self::TODAY, $hdr['issue_date']);
+        self::assertSame(self::TODAY, $hdr['tax_date']);
+        self::assertSame(self::TODAY, $hdr['due_date']);
+    }
+
+    public function testEmptyPayloadIsZeroPartnerAndTodayDates(): void
+    {
+        $hdr = IdokladImportService::idokladReceiptHeader([], self::TODAY);
+
+        self::assertSame(0, $hdr['partner_id']);
+        self::assertSame('', $hdr['vendor_invoice_number']);
+        self::assertSame(self::TODAY, $hdr['issue_date']);
+    }
+}

--- a/manual/16_Importy.md
+++ b/manual/16_Importy.md
@@ -149,7 +149,8 @@ ISDOC přílohu". V tom případě:
 
 Alternativa k file uploadu: přímé volání iDoklad API v3 (OAuth2 Client Credentials).
 Vhodné pro většinu dat — táhne **kontakty + vystavené faktury + dobropisy + přijaté
-faktury** najednou, po sekcích a rocích, s dry-run preview a background jobem.
+faktury + přijaté účtenky/paragony** najednou, po sekcích a rocích, s dry-run
+preview a background jobem.
 
 ### 16.8.1 Získání API credentials
 
@@ -180,7 +181,7 @@ Na téže stránce, sekce **Spustit import**:
 | Pole | Popis |
 |---|---|
 | **Roky** | Range (např. `2020-2025`); můžeš zvolit i jen aktuální + minulý rok |
-| **Sekce** | Zaškrtnout: `contacts` / `invoices` / `credit-notes` / `purchases` |
+| **Sekce** | Zaškrtnout: `contacts` / `invoices` / `credit-notes` / `purchases` / `receipts` (přijaté účtenky/paragony) |
 | **Dry-run (jen náhled)** | Default ON pro první běh — nepíše nic do DB, jen vypíše co BY udělal |
 
 Klikni **Spustit import**.
@@ -193,6 +194,7 @@ Klikni **Spustit import**.
 | **invoices** | `invoices` + `invoice_items` + VAT classification. Status: viz § 16.8.5. |
 | **credit-notes** | `invoices` se `invoice_type='credit_note'` + parent link na původní fakturu (přes `parent_invoice_id`). |
 | **purchases** | `purchase_invoices` + `purchase_invoice_items`. Klient → `clients` s `is_vendor=true`. |
+| **receipts** | Přijaté **účtenky/paragony** (iDoklad `ReceivedReceipts`) → `purchase_invoices` s `document_kind='receipt'`. Účtenka nemá splatnost ani DUZP → `datum vystavení` = DUZP = splatnost. Hrazená na místě → importuje se rovnou jako **Zaplacená**. Hotovostní účtenka **bez dodavatele** viz poznámka níže. |
 
 ### 16.8.5 Platební stav
 
@@ -205,6 +207,17 @@ od file uploadu (§ 16.3), kde se stáří jen odhaduje pravidlem 30 dní:
   zkontroluješ a vystavíš sám — záměrně se automaticky nevystavují, aby na
   reálně nezaplacené historické faktury nezačaly klientům odcházet upomínky.
 - Totéž platí pro **přijaté faktury** (uhrazeno → Zaplacená, jinak Koncept).
+- **Přijaté účtenky/paragony** jsou hrazené na místě → importují se rovnou jako
+  **Zaplacená** (datum úhrady = datum vystavení), pokud iDoklad nevrátí jiný stav.
+
+**Hotovostní účtenka bez dodavatele.** Účtenka bez navázaného kontaktu (typicky
+hotovostní nákup) se **nezahazuje** — náklad se navěsí na sběrného systémového
+dodavatele **„Hotovostní nákup (účtenka)"** (jeden na firmu, založí se automaticky
+jako neplátce). Protože dodavatele ani jeho plátcovství DPH nelze u anonymní
+účtenky ověřit, importuje se **bez nároku na odpočet DPH** a doklad dostane
+upozornění *„Účtenka bez identifikace dodavatele…"*. Pokud si chceš odpočet
+uplatnit, otevři doklad, **doplň skutečného dodavatele a přepni odpočet** na plný.
+Pro neplátce DPH je tohle bez dopadu — účtenka je jen daňový náklad.
 
 **Sleva** — sleva z iDokladu se přenáší: sleva na úrovni dokladu
 (`DiscountType=OnDocument`) se u vydaných faktur uloží jako procentuální sleva


### PR DESCRIPTION
Closes #179

## Co a proč

iDoklad import dosud volal jen `ReceivedInvoices` a samostatný koncový bod **`GET /v3/ReceivedReceipts`** přeskakoval, takže přijaté **účtenky/paragony** se z iDokladu vůbec nepřenesly. Tenhle PR ten import doplňuje — účtenky se ukládají do `purchase_invoices` s `document_kind='receipt'` (model je už podporuje), gateované novým parametrem `include_receipts` (default zapnuto).

## Změny

- **`IdokladImportService`**
  - `importReceipts()` — řídicí smyčka shodná s `importReceived()` (pagination, dedup přes `idoklad_id`, progress/cancel, dry-run).
  - `createReceiptFromIdoklad()` — mapování payloadu na `purchase_invoice` s `document_kind='receipt'`. Stejný tvar `$payload` jako `createReceivedFromIdoklad`, takže `createDraft` staví `vendor_snapshot`/totals beze změny.
  - `idokladReceiptHeader()` — **čistá statická funkce** s receipt-specifickým mapováním hlavičky (proto unit-testovatelná bez DB).
  - Zapojení do `run()` pod `include_receipts`.
- **`StartIdokladImportAction`** — nový `include_receipts` param (default `true`).
- **`IdokladClient`** — endpoint doplněn do docblocku (kód `get()/getAll()` je endpoint-agnostický, beze změny).
- **CHANGELOG** — záznam pod `[Unreleased] / Added`.

## Odlišnosti účtenky od přijaté faktury (které mapování řeší)

- `Partner` je vnořený a **může být null** (hotovostní nákup bez kontaktu) → doklad se **přeskočí** (nenavazovat naslepo). Viz otevřená otázka níže.
- Účtenka nemá `DateOfMaturity` ani `DateOfTaxing` → `issue_date`/`tax_date`/`due_date` se odvodí z `DateOfIssue`.
- Číslo dodavatele je `ExternalDocumentNumber` (fallback `DocumentNumber`); účtenka ho nemusí mít — u `document_kind='receipt'` je prázdné OK.
- Účtenka je hrazená na místě → import rovnou jako **zaplacená** (`paid_at` = datum vystavení). `ReceivedReceipts` payload `PaymentStatus` obvykle nenese (ověřeno živě: `null`), takže `ImportedPaymentStateMapper::fromIdoklad()` je no-op a default je „paid"; pokud by iDoklad stav úhrady vrátil, respektuje se.

## Testy

- `IdokladReceiptHeaderTest` — 7 případů: reálný tvar účtenky, null `Partner` → skip, plochý `PartnerId` fallback, `ExternalDocumentNumber` vs `DocumentNumber`, chybějící číslo, chybějící `DateOfIssue` → fallback, prázdný payload.
- Mapování položkové ceny (`idokladNetUnitPrice`) a kurzu (`idokladExchangeRate`) účtenky sdílí s přijatými fakturami a je už pokryté `IdokladNetUnitPriceTest`.

Ověřeno proti **živému** iDoklad API (GET `/v3/ReceivedReceipts`, reálné účtenky): tvar odpovídá mapování — `Partner` je vnořený objekt (`Partner.Id`, ne plochý `PartnerId`), `DateOfIssue` přítomné, `ExternalDocumentNumber` = číslo dodavatele vs. `DocumentNumber` = interní iDoklad číslo, a položky nesou autoritativní `Prices.TotalWithoutVat` (ověřeno i na účtence s cenami včetně DPH, `PriceType=0`). `PaymentStatus` byl na vzorku `null` → potvrzuje default „paid" z data vystavení. Plný import do běžící DB jsem nespouštěl — krytí na úrovni dat zajišťují unit testy + tato kontrola tvaru; doporučuju doběhnout v review/CI.

## Otevřené otázky pro maintainera

1. **Účtenka bez `Partner` (hotovostní nákup).** Tenhle PR ji **přeskakuje** (bezpečné). Alternativa: navázat na syntetického dodavatele „Hotovostní nákup / pokladní doklad". Preference?
2. **Přílohy.** `download_attachments` u účtenek volá stejný `/v3/Attachments/{id}/{documentType}/...` — `documentType` pro účtenky je nejspíš jiný než u `ReceivedInvoices`. Pokud chceš PDF účtenek archivovat, doplním po potvrzení správné hodnoty.
