### PR TITLE
feat(api): upload loga dodavatele přes veřejné API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2013,6 +2013,78 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /api/v1/settings/supplier/logo:
+    parameters:
+      - $ref: '#/components/parameters/SupplierIdHeader'
+    post:
+      tags: [Settings]
+      summary: Nahrání loga dodavatele
+      description: |
+        Multipart upload loga (pole `file`). Formáty PNG / JPG / SVG / WebP,
+        max **1 MiB**. Rastr se zmenší na max 240×800 px; SVG se sanitizuje
+        a rasterizuje (vektorová kopie se zachová pro ostré PDF). Logo se
+        v e-mailech a PDF fakturách zobrazuje jen při
+        `email_branding_enabled = true` (nastavíš přes
+        `PUT /api/v1/settings/supplier`).
+
+        `logo_path` NELZE měnit přes mass-assign na supplier update — vždy jen
+        tímto endpointem (bezpečnost).
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: PNG / JPG / SVG / WebP, max 1 MiB
+      responses:
+        '200':
+          description: Logo uloženo
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  logo_path: { type: string, example: "storage/supplier-logos/sup-1.png" }
+                  width: { type: integer, example: 480 }
+                  height: { type: integer, example: 160 }
+        '400':
+          description: Chybí soubor / nepodporovaný formát / konverze selhala
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '403':
+          description: Uživatel není admin nebo token nemá scope `read_write`
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '413':
+          description: Soubor přes 1 MiB
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+    delete:
+      tags: [Settings]
+      summary: Odebrání loga dodavatele
+      responses:
+        '200':
+          description: Logo odstraněno
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted: { type: boolean, example: true }
+        '403':
+          description: Uživatel není admin nebo token nemá scope `read_write`
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
   /api/v1/suppliers:
     get:
       tags: [Settings]

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1912,6 +1912,106 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/SupplierFull' }
+    put:
+      tags: [Settings]
+      summary: Úprava aktuálního dodavatele
+      description: |
+        Částečný update supplier-a v jehož scope token operuje — pošli jen pole,
+        která chceš změnit. Vyžaduje token se scope `read_write` patřící adminovi.
+
+        Zahrnuje i **číslování dokladů** (`invoice_number_format`,
+        `proforma_number_format`, `credit_note_number_format`,
+        `purchase_invoice_number_format`, `invoice_number_period`) a **branding
+        PDF/e-mailů** (`email_branding_enabled`, `email_accent_color`,
+        `pdf_logo_show_name`, `display_name`, `tagline`). Logo se nahrává zvlášť
+        (není součástí tohoto endpointu).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SupplierUpdate' }
+      responses:
+        '200':
+          description: Aktualizovaný supplier
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SupplierFull' }
+        '400':
+          $ref: '#/components/responses/ValidationFailed'
+        '403':
+          description: Uživatel není admin nebo token nemá scope `read_write`
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/v1/settings/supplier/invoice-counter:
+    put:
+      tags: [Settings]
+      summary: Nastavení counteru číselné řady dokladů
+      description: |
+        Nastaví supplier-wide counter tak, aby **příští vystavený doklad** daného
+        typu dostal číslo `next_number`. `date` určuje, do kterého období (dle
+        `invoice_number_period` supplier-a) se counter zapíše — default dnes.
+
+        Na rozdíl od samoopravné synchronizace umí counter i **snížit**; pokud by
+        nové číslo kolidovalo s už vystaveným dokladem, vystavení se automaticky
+        posune na první volné číslo (číslo se nikdy nezduplikuje).
+
+        Typický use-case: převzetí existující číselné řady při migraci z jiného
+        fakturačního software nebo napojení externího systému.
+      parameters:
+        - $ref: '#/components/parameters/SupplierIdHeader'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [next_number]
+              properties:
+                type:
+                  type: string
+                  enum: [invoice, proforma, credit_note]
+                  default: invoice
+                next_number:
+                  type: integer
+                  minimum: 1
+                  maximum: 999999999
+                  example: 42
+                  description: Číslo, které dostane příští vystavený doklad.
+                date:
+                  type: string
+                  format: date
+                  description: Datum určující období řady (YYYY-MM-DD). Default = dnes.
+      responses:
+        '200':
+          description: Counter nastaven
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type: { type: string, example: invoice }
+                  next_number: { type: integer, example: 42 }
+                  counter:
+                    type: integer
+                    example: 41
+                    description: Uložená hodnota `last_number` (= next_number - 1).
+                  period:
+                    type: string
+                    example: "202607"
+                    description: Klíč období counteru (YYYY / YYYYMM / ALL).
+                  preview:
+                    type: string
+                    example: "2607042"
+                    description: Jak bude vypadat příští vygenerované číslo.
+        '400':
+          $ref: '#/components/responses/ValidationFailed'
+        '403':
+          description: Uživatel není admin nebo token nemá scope `read_write`
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
   /api/v1/suppliers:
     get:
@@ -6086,6 +6186,54 @@ components:
         matched_at: { type: string, format: date-time, nullable: true }
         matched_by: { type: integer, nullable: true, description: "User ID (u ručního párování)" }
 
+    SupplierUpdate:
+      type: object
+      description: |
+        Částečný update dodavatele — pošli jen pole ke změně. Zrcadlí
+        mass-assign whitelist `PUT /api/v1/settings/supplier`; níže veřejný
+        subset (fakturační údaje, defaulty, číslování, branding). `logo_path`
+        a `signature_path` přes tento endpoint změnit NELZE (bezpečnost).
+      properties:
+        company_name: { type: string }
+        display_name: { type: string, nullable: true, description: "Obchodní/značkové jméno v hlavičce PDF a e-mailů (fallback = company_name)" }
+        street: { type: string }
+        city: { type: string }
+        zip: { type: string }
+        country_id: { type: integer }
+        ic: { type: string, nullable: true }
+        dic: { type: string, nullable: true }
+        is_vat_payer: { type: boolean }
+        email: { type: string, format: email, nullable: true }
+        phone: { type: string, nullable: true }
+        web: { type: string, nullable: true }
+        tagline: { type: string, nullable: true, description: "Podtitulek v patičce PDF a e-mailů" }
+        default_currency_id: { type: integer }
+        default_payment_due_days: { type: integer }
+        default_payment_due_unit: { type: string, enum: [days, month] }
+        default_prices_include_vat: { type: boolean }
+        invoice_number_format:
+          type: string
+          nullable: true
+          maxLength: 60
+          example: "{YY}{MM}{CCC}"
+          description: |
+            Template čísla faktury: `{YYYY}`/`{YY}` rok, `{MM}` měsíc, `{C..C}`
+            counter s paddingem dle počtu C (např. `{CCC}` → 001). Musí
+            obsahovat counter placeholder. Prázdný string / null = fallback
+            na globální cfg.
+        proforma_number_format: { type: string, nullable: true, maxLength: 60, example: "9{YY}{MM}{CCC}" }
+        credit_note_number_format: { type: string, nullable: true, maxLength: 60, example: "7{YY}{MM}{CCC}" }
+        purchase_invoice_number_format: { type: string, nullable: true, maxLength: 60, description: "Interní číslování přijatých faktur" }
+        invoice_number_period:
+          type: string
+          enum: [year, month, none]
+          description: "Reset counteru: ročně / měsíčně / nikdy (jedna průběžná řada). Společné pro všechny typy dokladů."
+        email_branding_enabled: { type: boolean, description: "Zapne logo + akcentní barvu v e-mailech a PDF" }
+        email_accent_color: { type: string, example: "#3B2D83", description: "Hex #RRGGBB; akcentní barva e-mailů a PDF faktur" }
+        pdf_logo_show_name: { type: boolean, description: "Zobrazit vedle loga v PDF i název dodavatele" }
+        auto_send_reminders: { type: boolean }
+        reminder_days_after_due: { type: integer, minimum: 1, maximum: 365 }
+
     SupplierFull:
       type: object
       description: |
@@ -6120,10 +6268,12 @@ components:
         invoice_number_format:
           type: string
           nullable: true
-          example: "F{YYYY}-{####}"
-          description: "{YYYY}, {MM}, {####} placeholders. Per-supplier."
+          example: "{YY}{MM}{CCC}"
+          description: "{YYYY}/{YY}, {MM}, {C..C} placeholders (viz SupplierUpdate). Per-supplier; null = globální cfg."
         proforma_number_format: { type: string, nullable: true }
         credit_note_number_format: { type: string, nullable: true }
+        purchase_invoice_number_format: { type: string, nullable: true }
+        invoice_number_period: { type: string, enum: [year, month, none], description: "Reset counteru číselných řad" }
         taxpayer_type: { type: string, enum: [fo, po], nullable: true, description: "Fyzická / právnická osoba (EPO výkazy)" }
         vat_period: { type: string, enum: [monthly, quarterly], nullable: true }
         financial_office_code: { type: string, nullable: true, description: "Kód FÚ pro EPO (= CRPDPH cisloFu)" }

--- a/api/src/Action/Settings/EmailBrandingAction.php
+++ b/api/src/Action/Settings/EmailBrandingAction.php
@@ -24,6 +24,10 @@ use Twig\Loader\FilesystemLoader;
  *   DELETE /api/settings/email-branding/logo   — odebrat logo soubor
  *   GET    /api/settings/email-branding/preview?locale=cs  — vyrenderovaný email layout
  *
+ * Upload/delete mají navíc veřejné API aliasy POST/DELETE /api/settings/supplier/logo
+ * (bearer allowlist, viz ApiScopeMiddleware) — stejné metody, jiná cesta. Preview
+ * zůstává session-only (čte soubory z disku, viz guard níže).
+ *
  * Toggle (`email_branding_enabled`), brand name (`display_name`), tagline
  * a accent barva (`email_accent_color`) se ukládají přes existující PUT /api/settings/supplier.
  */

--- a/api/src/Action/Settings/SupplierInvoiceCounterAction.php
+++ b/api/src/Action/Settings/SupplierInvoiceCounterAction.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Action\Settings;
+
+use MyInvoice\Http\Json;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Middleware\SupplierScopeMiddleware;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\Invoice\VarsymbolGenerator;
+use MyInvoice\Service\IpMatcher;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * PUT /api/settings/supplier/invoice-counter — nastaví counter číselné řady (admin).
+ *
+ * Body: { "type": "invoice"|"proforma"|"credit_note", "next_number": 42, "date": "2026-07-01"? }
+ *
+ * Nastaví supplier-wide counter tak, aby PŘÍŠTÍ vystavený doklad daného typu dostal
+ * číslo `next_number`. `date` určuje, do kterého období (dle `invoice_number_period`)
+ * se counter zapíše — default dnes. Umí counter i snížit; pokud by nové číslo
+ * kolidovalo s už vystaveným dokladem, vystavení se samoopravně posune na první
+ * volné číslo (viz VarsymbolGenerator::next()).
+ *
+ * Typický use-case: napojení externího systému, který přebírá existující číselnou
+ * řadu (import historie, migrace z jiného fakturačního software).
+ *
+ * Response: { "type": "invoice", "next_number": 42, "counter": 41,
+ *             "period": "202607", "preview": "2607042" }
+ */
+final class SupplierInvoiceCounterAction
+{
+    public function __construct(
+        private readonly VarsymbolGenerator $varsymbol,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
+    ) {}
+
+    public function __invoke(Request $request, Response $response): Response
+    {
+        $user = (array) $request->getAttribute(AuthMiddleware::ATTR_USER, []);
+        if (($user['role'] ?? '') !== 'admin') {
+            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        }
+
+        $supplierId = (int) $request->getAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, 0);
+        if ($supplierId <= 0) {
+            return Json::error($response, 'no_supplier', 'Není zvolen dodavatel.', 400);
+        }
+
+        $b    = (array) ($request->getParsedBody() ?? []);
+        $type = (string) ($b['type'] ?? 'invoice');
+        if (!in_array($type, ['invoice', 'proforma', 'credit_note'], true)) {
+            return Json::error($response, 'validation_failed', "Neplatný type (invoice|proforma|credit_note).", 400);
+        }
+
+        $next = (int) ($b['next_number'] ?? 0);
+        if ($next < 1 || $next > 999999999) {
+            return Json::error($response, 'validation_failed', 'next_number musí být celé číslo 1–999999999.', 400);
+        }
+
+        $for = null;
+        if (trim((string) ($b['date'] ?? '')) !== '') {
+            try {
+                $for = new \DateTimeImmutable((string) $b['date']);
+            } catch (\Throwable) {
+                return Json::error($response, 'validation_failed', 'date musí být platné datum (YYYY-MM-DD).', 400);
+            }
+        }
+
+        try {
+            $result = $this->varsymbol->setCounter($supplierId, $type, $next, $for);
+        } catch (\InvalidArgumentException $e) {
+            return Json::error($response, 'validation_failed', $e->getMessage(), 400);
+        }
+
+        $ip = $this->ipMatcher->clientIpFromRequest($request->getServerParams());
+        $this->logger->log(
+            'supplier.invoice_counter_set',
+            (int) ($user['id'] ?? 0),
+            'supplier',
+            $supplierId,
+            ['type' => $type, 'next_number' => $next, 'period' => $result['period']],
+            $ip,
+            $request->getHeaderLine('User-Agent'),
+            $supplierId,
+        );
+
+        return Json::ok($response, [
+            'type'        => $type,
+            'next_number' => $next,
+            'counter'     => $result['counter'],
+            'period'      => $result['period'],
+            'preview'     => $result['preview'],
+        ]);
+    }
+}

--- a/api/src/Middleware/ApiScopeMiddleware.php
+++ b/api/src/Middleware/ApiScopeMiddleware.php
@@ -77,6 +77,7 @@ final class ApiScopeMiddleware implements MiddlewareInterface
         // Nastavení — JEN veřejný subset (supplier + číselníky), NE signing/
         // pdf-signing/email-branding/bank-email-notices.
         '#^/api/settings/supplier$#',
+        '#^/api/settings/supplier/invoice-counter$#',
         '#^/api/settings/currencies(/|$)#',
         '#^/api/settings/vat-rates(/|$)#',
         '#^/api/settings/units(/|$)#',

--- a/api/src/Middleware/ApiScopeMiddleware.php
+++ b/api/src/Middleware/ApiScopeMiddleware.php
@@ -78,6 +78,7 @@ final class ApiScopeMiddleware implements MiddlewareInterface
         // pdf-signing/email-branding/bank-email-notices.
         '#^/api/settings/supplier$#',
         '#^/api/settings/supplier/invoice-counter$#',
+        '#^/api/settings/supplier/logo$#',
         '#^/api/settings/currencies(/|$)#',
         '#^/api/settings/vat-rates(/|$)#',
         '#^/api/settings/units(/|$)#',

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -52,6 +52,7 @@ use MyInvoice\Action\Settings\PdfSigningDiagnosticsAction;
 use MyInvoice\Action\Settings\SettingsAction;
 use MyInvoice\Action\Settings\SignatureDocumentSelectionAction;
 use MyInvoice\Action\Settings\SigningProfilesAction;
+use MyInvoice\Action\Settings\SupplierInvoiceCounterAction;
 use MyInvoice\Action\Bank\BankEmailNoticeAction;
 use MyInvoice\Action\Bank\BankStatementAction;
 use MyInvoice\Action\Dashboard\SummaryAction;
@@ -514,6 +515,7 @@ final class Routes
         // Settings (M6) — aktuální supplier (z X-Supplier-Id)
         $app->get ('/api/settings/supplier',                [SettingsAction::class, 'getSupplier']);
         $app->put ('/api/settings/supplier',                [SettingsAction::class, 'updateSupplier']);
+        $app->put ('/api/settings/supplier/invoice-counter', SupplierInvoiceCounterAction::class);
         $app->get    ('/api/settings/email-profiles',       [EmailProfilesAction::class, 'list']);
         $app->post   ('/api/settings/email-profiles',       [EmailProfilesAction::class, 'create']);
         $app->post   ('/api/settings/email-profiles/test',  [EmailProfilesAction::class, 'testDraft']);

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -579,6 +579,10 @@ final class Routes
         $app->post   ('/api/settings/email-branding/logo',            [EmailBrandingAction::class, 'uploadLogo']);
         $app->delete ('/api/settings/email-branding/logo',            [EmailBrandingAction::class, 'deleteLogo']);
         $app->get    ('/api/settings/email-branding/preview',         [EmailBrandingAction::class, 'preview']);
+        // Veřejné API aliasy pro logo (bearer allowlist) — stejná logika, jiná cesta.
+        // Preview zůstává interní (čte soubory z disku → jen session admin).
+        $app->post   ('/api/settings/supplier/logo',                  [EmailBrandingAction::class, 'uploadLogo']);
+        $app->delete ('/api/settings/supplier/logo',                  [EmailBrandingAction::class, 'deleteLogo']);
 
         $app->get    ('/api/settings/units',                          [SettingsAction::class, 'listUnits']);
         $app->post   ('/api/settings/units',                          [SettingsAction::class, 'createUnit']);

--- a/api/src/Service/Invoice/VarsymbolGenerator.php
+++ b/api/src/Service/Invoice/VarsymbolGenerator.php
@@ -168,6 +168,64 @@ final class VarsymbolGenerator
         return $this->liftCounterTo($supplierId, $counterClientId, $invoiceType, $periodKey, $highest);
     }
 
+    /**
+     * Explicitně nastaví counter supplier-wide řady tak, aby PŘÍŠTÍ vystavený doklad
+     * dostal číslo $nextNumber (uloží last_number = $nextNumber - 1). Na rozdíl od
+     * syncCounter()/liftCounterTo() umí counter i snížit — kolize s už vystavenými
+     * čísly řeší samoopravná logika v next() (přeskočí na první volné číslo).
+     *
+     * Scope je vždy supplier-wide (client_id = 0); per-client řady se nastavují
+     * přes template na klientovi a jejich counter se dorovnává automaticky.
+     *
+     * @return array{counter:int, period:string, preview:string}
+     * @throws \InvalidArgumentException neplatný vstup, chybějící template
+     *                                   nebo template bez counter placeholderu
+     */
+    public function setCounter(int $supplierId, string $invoiceType, int $nextNumber, ?\DateTimeInterface $for = null): array
+    {
+        if ($supplierId <= 0) {
+            throw new \InvalidArgumentException("Neplatný supplier_id: {$supplierId}");
+        }
+        if ($invoiceType === 'tax_document') {
+            $invoiceType = 'invoice'; // sdílená řada s fakturami (viz next())
+        }
+        if (!in_array($invoiceType, self::SUPPORTED_TYPES, true)) {
+            throw new \InvalidArgumentException("Nepodporovaný typ pro varsymbol: {$invoiceType}");
+        }
+        if ($nextNumber < 1) {
+            throw new \InvalidArgumentException('next_number musí být >= 1.');
+        }
+
+        [$template, $period] = $this->resolveTemplateAndPeriod($supplierId, $invoiceType, 0);
+        if ($template === '') {
+            throw new \InvalidArgumentException(
+                "Chybí template pro {$invoiceType}: nastav v Systém → Dodavatelé → Číslování faktur,"
+                . " nebo doplň cfg.varsymbol.templates.{$invoiceType}."
+            );
+        }
+        if (!$this->hasCounterPlaceholder($template)) {
+            throw new \InvalidArgumentException(
+                "Template '{$template}' neobsahuje counter placeholder ({C+}) — číslo je fixní, counter nemá smysl."
+            );
+        }
+
+        $for       = $for ?? new \DateTimeImmutable('today');
+        $periodKey = $this->makePeriodKey($period, $for);
+
+        $stmt = $this->db->pdo()->prepare(
+            'INSERT INTO invoice_counters (supplier_id, client_id, invoice_type, period, last_number)
+             VALUES (?, 0, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE last_number = VALUES(last_number)'
+        );
+        $stmt->execute([$supplierId, $invoiceType, $periodKey, $nextNumber - 1]);
+
+        return [
+            'counter' => $nextNumber - 1,
+            'period'  => $periodKey,
+            'preview' => $this->render($template, $for, $nextNumber),
+        ];
+    }
+
     private function hasCounterPlaceholder(string $template): bool
     {
         return (bool) preg_match('/\{C+\}/', $template);

--- a/api/tests/Integration/Invoice/VarsymbolSetCounterTest.php
+++ b/api/tests/Integration/Invoice/VarsymbolSetCounterTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Integration\Invoice;
+
+use MyInvoice\Bootstrap;
+use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Service\Invoice\VarsymbolGenerator;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Explicitní nastavení counteru číselné řady (API endpoint
+ * PUT /api/settings/supplier/invoice-counter → VarsymbolGenerator::setCounter()):
+ * příští vystavený doklad má dostat přesně zadané číslo, včetně SNÍŽENÍ counteru
+ * (na rozdíl od syncCounter). Kolize s existujícími čísly řeší self-heal v next().
+ *
+ * Izolace: rok 2099 (viz VarsymbolCounterSyncTest). Soft-skip bez cfg.php / DB / template.
+ */
+#[Group('integration')]
+final class VarsymbolSetCounterTest extends TestCase
+{
+    private Connection $db;
+    private VarsymbolGenerator $gen;
+    private int $supplierId = 0;
+    private int $clientId = 0;
+    private int $currencyId = 0;
+    private int $userId = 0;
+    private string $template = '';
+    private \DateTimeImmutable $date;
+    /** @var int[] */
+    private array $created = [];
+
+    protected function setUp(): void
+    {
+        $rootDir = dirname(__DIR__, 4);
+        if (!is_file($rootDir . '/cfg.php')) {
+            $this->markTestSkipped('cfg.php neexistuje — test vyžaduje DB.');
+        }
+        try {
+            $c = Bootstrap::buildApp()->getContainer();
+            $this->db = $c->get(Connection::class);
+            $this->gen = $c->get(VarsymbolGenerator::class);
+            $config = $c->get(Config::class);
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('DI/DB nedostupné: ' . $e->getMessage());
+        }
+        $pdo = $this->db->pdo();
+        $this->supplierId = (int) ($pdo->query('SELECT id FROM supplier ORDER BY id LIMIT 1')->fetchColumn() ?: 0);
+        if ($this->supplierId === 0) {
+            $this->markTestSkipped('Chybí supplier.');
+        }
+        $this->template = trim((string) ($pdo->query(
+            "SELECT invoice_number_format FROM supplier WHERE id = {$this->supplierId}"
+        )->fetchColumn() ?: ''));
+        if ($this->template === '') {
+            $this->template = trim((string) $config->get('varsymbol.templates.invoice', ''));
+        }
+        if ($this->template === '' || !str_contains($this->template, '{C')) {
+            $this->markTestSkipped('Není template s counterem ({C+}) pro vydanou fakturu.');
+        }
+
+        $this->clientId = (int) ($pdo->query("SELECT id FROM clients WHERE supplier_id = {$this->supplierId} ORDER BY id LIMIT 1")->fetchColumn() ?: 0);
+        $this->currencyId = (int) ($pdo->query("SELECT id FROM currencies WHERE supplier_id = {$this->supplierId} AND code = 'CZK' ORDER BY id LIMIT 1")->fetchColumn() ?: 0);
+        $this->userId = (int) ($pdo->query('SELECT id FROM users ORDER BY id LIMIT 1')->fetchColumn() ?: 0);
+        if ($this->clientId === 0 || $this->currencyId === 0 || $this->userId === 0) {
+            $this->markTestSkipped('Chybí client/CZK currency/user.');
+        }
+
+        $this->date = new \DateTimeImmutable('2099-06-15');
+        $this->cleanup();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->db)) {
+            $this->cleanup();
+        }
+    }
+
+    private function cleanup(): void
+    {
+        $pdo = $this->db->pdo();
+        foreach ($this->created as $id) {
+            $pdo->prepare('DELETE FROM invoices WHERE id = ?')->execute([$id]);
+        }
+        $this->created = [];
+        $pdo->prepare("DELETE FROM invoice_counters WHERE supplier_id = ? AND period LIKE '2099%'")
+            ->execute([$this->supplierId]);
+    }
+
+    private function insertIssued(int $counter): string
+    {
+        $varsymbol = $this->gen->render($this->template, $this->date, $counter);
+        $pdo = $this->db->pdo();
+        $pdo->prepare(
+            "INSERT INTO invoices
+                (invoice_type, varsymbol, client_id, supplier_id, issue_date, tax_date, due_date,
+                 currency_id, status, total_without_vat, total_with_vat, created_by)
+             VALUES ('invoice', ?, ?, ?, ?, ?, ?, ?, 'issued', 0, 0, ?)"
+        )->execute([
+            $varsymbol, $this->clientId, $this->supplierId,
+            $this->date->format('Y-m-d'), $this->date->format('Y-m-d'), $this->date->format('Y-m-d'),
+            $this->currencyId, $this->userId,
+        ]);
+        $this->created[] = (int) $pdo->lastInsertId();
+        return $varsymbol;
+    }
+
+    public function testSetCounterMakesNextIssueUseExactNumber(): void
+    {
+        $result = $this->gen->setCounter($this->supplierId, 'invoice', 42, $this->date);
+
+        self::assertSame(41, $result['counter'], 'last_number = next_number - 1');
+        self::assertSame($this->gen->render($this->template, $this->date, 42), $result['preview']);
+
+        $next = $this->gen->next($this->supplierId, 'invoice', $this->date);
+        self::assertSame($result['preview'], $next, 'Příští vystavení dostane přesně nastavené číslo.');
+    }
+
+    public function testSetCounterCanLowerCounter(): void
+    {
+        // Counter vepředu na 50 (např. po testovacích fakturách, které byly smazané).
+        $this->gen->setCounter($this->supplierId, 'invoice', 51, $this->date);
+        // Na rozdíl od syncCounter jde explicitně snížit.
+        $result = $this->gen->setCounter($this->supplierId, 'invoice', 5, $this->date);
+        self::assertSame(4, $result['counter']);
+
+        $next = $this->gen->next($this->supplierId, 'invoice', $this->date);
+        self::assertSame($this->gen->render($this->template, $this->date, 5), $next);
+    }
+
+    public function testNextSelfHealsWhenSetCounterCollides(): void
+    {
+        // Číslo 7 už je obsazené vystavenou fakturou.
+        $occupied = $this->insertIssued(7);
+
+        // Admin přesto nastaví řadu na 7 → vystavení nesmí číslo zduplikovat.
+        $this->gen->setCounter($this->supplierId, 'invoice', 7, $this->date);
+        $next = $this->gen->next($this->supplierId, 'invoice', $this->date);
+
+        self::assertNotSame($occupied, $next, 'Kolize se musí self-healnout, ne zduplikovat.');
+        self::assertSame($this->gen->render($this->template, $this->date, 8), $next);
+    }
+
+    public function testSetCounterRejectsInvalidInput(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gen->setCounter($this->supplierId, 'invoice', 0, $this->date);
+    }
+
+    public function testSetCounterRejectsUnsupportedType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->gen->setCounter($this->supplierId, 'nonsense', 1, $this->date);
+    }
+}

--- a/api/tests/Unit/Middleware/ApiScopeMiddlewareTest.php
+++ b/api/tests/Unit/Middleware/ApiScopeMiddlewareTest.php
@@ -84,6 +84,26 @@ final class ApiScopeMiddlewareTest extends TestCase
         }
     }
 
+    public function testBearerReadWriteCanSetInvoiceCounter(): void
+    {
+        $r = $this->middleware()->process(
+            $this->bearer('PUT', '/api/settings/supplier/invoice-counter', 'read_write'),
+            $this->okHandler(),
+        );
+        self::assertSame(204, $r->getStatusCode());
+    }
+
+    public function testBearerReadCannotSetInvoiceCounter(): void
+    {
+        // Path je povolená, ale read scope nesmí PUT → insufficient_scope.
+        $r = $this->middleware()->process(
+            $this->bearer('PUT', '/api/settings/supplier/invoice-counter', 'read'),
+            $this->okHandler(),
+        );
+        self::assertSame(403, $r->getStatusCode());
+        self::assertSame('insufficient_scope', $this->errorCode($r));
+    }
+
     public function testBearerReadCannotWriteAllowedResource(): void
     {
         // Path je povolená, ale read scope nesmí POST → insufficient_scope (NE path).

--- a/api/tests/Unit/Middleware/ApiScopeMiddlewareTest.php
+++ b/api/tests/Unit/Middleware/ApiScopeMiddlewareTest.php
@@ -104,6 +104,27 @@ final class ApiScopeMiddlewareTest extends TestCase
         self::assertSame('insufficient_scope', $this->errorCode($r));
     }
 
+    public function testBearerReadWriteCanUploadSupplierLogo(): void
+    {
+        $r = $this->middleware()->process(
+            $this->bearer('POST', '/api/settings/supplier/logo', 'read_write'),
+            $this->okHandler(),
+        );
+        self::assertSame(204, $r->getStatusCode());
+    }
+
+    public function testBearerBlockedFromEmailBrandingLogoDespiteLogoAlias(): void
+    {
+        // Alias /api/settings/supplier/logo je povolený, ale původní interní
+        // cesta email-branding zůstává pro tokeny zavřená (preview = čtení disku).
+        $r = $this->middleware()->process(
+            $this->bearer('POST', '/api/settings/email-branding/logo', 'read_write'),
+            $this->okHandler(),
+        );
+        self::assertSame(403, $r->getStatusCode());
+        self::assertSame('token_endpoint_forbidden', $this->errorCode($r));
+    }
+
     public function testBearerReadCannotWriteAllowedResource(): void
     {
         // Path je povolená, ale read scope nesmí POST → insufficient_scope (NE path).

--- a/manual/41_API.md
+++ b/manual/41_API.md
@@ -170,6 +170,18 @@ dokladem, vystavení se samoopravně posune na první volné číslo — duplici
 číslo nikdy nevznikne. Volitelné `date` (YYYY-MM-DD) určuje období řady
 (při `invoice_number_period` = `year`/`month`), default je dnešek.
 
+- **`POST /api/v1/settings/supplier/logo`** — multipart upload loga (pole
+  `file`; PNG / JPG / SVG / WebP, max 1 MiB). Logo se v e-mailech a PDF
+  zobrazuje při `email_branding_enabled = true`. `DELETE` na stejné cestě
+  logo odebere:
+
+```bash
+curl -X POST https://mojefirma.example/api/v1/settings/supplier/logo \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@logo.png"
+# → { "logo_path": "storage/supplier-logos/sup-1.png", "width": 480, "height": 160 }
+```
+
 ## 41.9 Bezpečnost tokenů — best practices
 
 - **Ukládej token jako secret** (password manager, Make encrypted variable, GitHub Secrets…).

--- a/manual/41_API.md
+++ b/manual/41_API.md
@@ -141,7 +141,36 @@ Všechny chyby v unifikovaném formátu:
 | `not_found` | Zdroj neexistuje (nebo nepatří aktuálnímu supplier-ovi) |
 | `rate_limited` | Překročen limit (viz `Retry-After`) |
 
-## 41.8 Bezpečnost tokenů — best practices
+## 41.8 Nastavení dodavatele a číslování dokladů přes API
+
+Veřejný subset nastavení dodavatele jde měnit tokenem se scope `read_write`
+(uživatel tokenu musí být admin):
+
+- **`PUT /api/v1/settings/supplier`** — částečný update: fakturační údaje,
+  defaulty, **číslování dokladů** (`invoice_number_format`,
+  `proforma_number_format`, `credit_note_number_format`,
+  `purchase_invoice_number_format`, `invoice_number_period`) a **branding**
+  (`email_branding_enabled`, `email_accent_color`, `pdf_logo_show_name`,
+  `display_name`, `tagline`). Logo se přes tento endpoint nastavit nedá.
+
+- **`PUT /api/v1/settings/supplier/invoice-counter`** — nastaví counter číselné
+  řady tak, aby příští vystavený doklad dostal zadané číslo. Hodí se při
+  migraci z jiného fakturačního software (navázání na existující řadu):
+
+```bash
+curl -X PUT https://mojefirma.example/api/v1/settings/supplier/invoice-counter \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{ "type": "invoice", "next_number": 42 }'
+# → { "type": "invoice", "next_number": 42, "counter": 41,
+#     "period": "202607", "preview": "2607042" }
+```
+
+Counter jde i **snížit**; pokud by nové číslo kolidovalo s už vystaveným
+dokladem, vystavení se samoopravně posune na první volné číslo — duplicitní
+číslo nikdy nevznikne. Volitelné `date` (YYYY-MM-DD) určuje období řady
+(při `invoice_number_period` = `year`/`month`), default je dnešek.
+
+## 41.9 Bezpečnost tokenů — best practices
 
 - **Ukládej token jako secret** (password manager, Make encrypted variable, GitHub Secrets…).
   Nepushuj do gitu.
@@ -152,12 +181,13 @@ Všechny chyby v unifikovaném formátu:
 - **Sleduj `last_used_at`** v UI — token, který se 3 měsíce nepoužil, asi nepotřebuješ.
 - **Při ztrátě/podezření** — okamžitě **Zrušit** v UI. Revokace je instantní (žádný cache).
 
-## 41.9 Co API nepokrývá
+## 41.10 Co API nepokrývá
 
-- **Admin a settings endpointy** (`/api/admin/*`, `/api/settings/*`) nejsou v
-  `openapi.yaml` - jsou určené pro interní administraci, integrace na nich
-  stavět nemá smysl. Platí to i pro interní podpisové endpointy, například
-  per-dokladový výběr podpisu (`/api/documents/.../signature-selection`).
+- **Admin a settings endpointy** (`/api/admin/*` a `/api/settings/*` mimo
+  veřejný subset — supplier, číselníky) nejsou v `openapi.yaml` - jsou určené
+  pro interní administraci, integrace na nich stavět nemá smysl. Platí to
+  i pro interní podpisové endpointy, například per-dokladový výběr podpisu
+  (`/api/documents/.../signature-selection`).
 - **Webhooks** zatím nejsou — pokud potřebuješ notifikaci o platbě, použij polling
   `/api/v1/invoices?status=paid&from=<last_check>`.
 - **OAuth2** nepodporujeme — PAT je vědomé zjednodušení pro tenhle typ produktu.


### PR DESCRIPTION
> **Závisí na #185** (větev je postavená nad `feat/api-supplier-numbering`, sdílí bearer-allowlist a sekci manuálu; po merge #185 se diff zúží jen na logo změny).

## Motivace

Branding faktur jde přes API nastavit skoro celý — `email_accent_color`, `email_branding_enabled`, `pdf_logo_show_name`, `display_name`, `tagline` přijímá `PUT /api/v1/settings/supplier`. Chybí jen **logo**: `logo_path` je (správně) vyloučený z mass-assignu a upload endpoint `/api/settings/email-branding/logo` je mimo bearer allowlist. Externí systém (provisioning, SaaS integrace) tak dnes logo nastavit nemůže.

## Co PR přidává

- **`POST /api/v1/settings/supplier/logo`** + **`DELETE`** — route aliasy na existující `EmailBrandingAction::uploadLogo/deleteLogo`. **Žádná nová upload logika** — stejný sanitizovaný pipeline (`SupplierLogoConverter`: detekce magic bytes, pixel-bomb guard, SVG sanitizace + rasterizace s vektorovým sidecar pro PDF, limit 1 MiB), stejný admin guard, stejný activity log.
- **Allowlist jen přesné cesty** `#^/api/settings/supplier/logo$#` — původní `/api/settings/email-branding/*` zůstává pro tokeny zavřené, zejména `preview`, které čte soubory z disku (viz security report #2). Test to explicitně hlídá (`testBearerBlockedFromEmailBrandingLogoDespiteLogoAlias`).
- **OpenAPI**: dokumentace multipart POST + DELETE. **Manuál 41.8**: curl příklad.

## Ověření

- `phpunit tests/Unit/Middleware`: 29 testů OK (PHP 8.5.7)
- Slim route collector registruje POST/DELETE `/api/settings/supplier/logo`, YAML validní, `php -l` čisté
- Bez DB migrace, bez zásahu do web/, CHANGELOG/VERSION nedotčeny

🤖 Generated with [Claude Code](https://claude.com/claude-code)