### PR TITLE
fix(import): přílohy účtenek přes documentType=ReceivedReceipt + konverze fotek na PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **iDoklad import — přílohy přijatých účtenek se nikdy nestáhly (a fotky se zahazovaly).** Stahování příloh se dotazovalo jen scope `documentType=ReceivedInvoice`, ale přílohy účtenek žijí v odděleném scope `ReceivedReceipt` (SDK enum 11) — dotaz se špatným scope vrací 404, takže účtenky zůstaly bez zdrojového dokladu (`imported_pdf_path = NULL`) i s `download_attachments=true`, tiše. Navíc se archivovaly jen přílohy `%PDF` — fotka paragonu z telefonu (JPG, u účtenek nejběžnější případ) se zahodila i u přijatých faktur. Nově: přílohy účtenek se stahují přes správný scope a fotky se konvertují na PDF stejnou cestou jako ruční upload (`ImageToPdfConverter`, EXIF rotace, přejmenování `.jpg → .pdf`), takže výsledek je od ručně nahraného dokladu k nerozeznání. Výběr přílohy (preferuj PDF, jinak první obrázek) je vytažený do čisté testované funkce.
+
+
 ## [4.44.0] — 2026-07-02
 
 ### Added

--- a/api/src/Service/Import/IdokladClient.php
+++ b/api/src/Service/Import/IdokladClient.php
@@ -348,16 +348,18 @@ final class IdokladClient
      * List attachments pro přijatou fakturu (PDF originály od dodavatele).
      *
      * iDoklad v3 endpoint: GET /v3/Attachments/{documentId}/{documentType}/{compressed}
-     * documentType = `ReceivedInvoice` (enum 5). Odpověď nese bajty inline jako
+     * documentType = `ReceivedInvoice` (enum 5) pro přijaté faktury, `ReceivedReceipt`
+     * (enum 11) pro přijaté účtenky — přílohy žijí v odděleném scope per typ dokladu.
+     * Odpověď nese bajty inline jako
      * base64 `FileBytes` — žádný separátní download request.
      * (Starý endpoint /ReceivedInvoices/{id}/Attachments vracel 404 → žádné PDF, viz #80.)
      *
      * @return list<array<string,mixed>>  [{Id, FileName, FileBytes(base64)}]
      */
-    public function listReceivedAttachments(int $supplierId, int $idokladInvoiceId): array
+    public function listReceivedAttachments(int $supplierId, int $idokladInvoiceId, string $documentType = 'ReceivedInvoice'): array
     {
         try {
-            $r = $this->get($supplierId, 'Attachments/' . $idokladInvoiceId . '/ReceivedInvoice/false', 1, 100);
+            $r = $this->get($supplierId, 'Attachments/' . $idokladInvoiceId . '/' . $documentType . '/false', 1, 100);
             return $r['Items'];
         } catch (\Throwable $e) {
             $this->logger->info('iDoklad listReceivedAttachments failed', ['invoice_id' => $idokladInvoiceId, 'error' => $e->getMessage()]);

--- a/api/src/Service/Import/IdokladImportService.php
+++ b/api/src/Service/Import/IdokladImportService.php
@@ -50,6 +50,7 @@ final class IdokladImportService
         private readonly LoggerInterface $logger,
         private readonly PurchaseInvoiceCnbApplier $cnbApplier,
         private readonly SnapshotBuilder $snapshots,
+        private readonly ImageToPdfConverter $imageToPdf,
     ) {}
 
     /**
@@ -634,7 +635,7 @@ final class IdokladImportService
                 )->execute([$idokladId, $purchaseId]);
                 $this->purCalc->recompute($purchaseId);
                 if ($downloadAttachments) {
-                    $this->archiveReceivedPdf($supplierId, $purchaseId, $idokladId);
+                    $this->archiveReceivedPdf($supplierId, $purchaseId, $idokladId, 'ReceivedReceipt');
                 }
                 $created++;
             } catch (\Throwable $e) {
@@ -1200,28 +1201,35 @@ final class IdokladImportService
     }
 
     /**
-     * Stáhne první PDF přílohu pro přijatou fakturu (typically jedna od dodavatele).
+     * Stáhne první archivovatelnou přílohu dokladu (typically jedna od dodavatele).
+     *
+     * $documentType = iDoklad Attachments scope: 'ReceivedInvoice' pro přijaté faktury,
+     * 'ReceivedReceipt' pro účtenky (SDK enum 5 / 11) — přílohy žijí v odděleném scope
+     * per typ dokladu, dotaz se špatným scope vrací 404/nic.
+     *
+     * Fotka (JPG/PNG… z telefonu — u účtenek běžný případ) se konvertuje na PDF stejnou
+     * cestou jako ruční upload (ImageToPdfConverter, issue #75), vč. přejmenování na .pdf.
      */
-    private function archiveReceivedPdf(int $supplierId, int $purchaseInvoiceId, int $idokladInvoiceId): void
+    private function archiveReceivedPdf(int $supplierId, int $purchaseInvoiceId, int $idokladInvoiceId, string $documentType = 'ReceivedInvoice'): void
     {
-        $attachments = $this->idoklad->listReceivedAttachments($supplierId, $idokladInvoiceId);
-        // iDoklad v3 vrací bajty přílohy inline v `FileBytes` (base64) — žádný extra download
-        // request. Vyber první PDF (může být víc příloh: obrázky atd.).
-        $pdf = null;
-        $name = 'invoice.pdf';
-        foreach ($attachments as $a) {
-            $bytes = $a['FileBytes'] ?? null;
-            if ($bytes === null || $bytes === '') continue;
-            $raw = base64_decode((string) $bytes, true);
-            if ($raw === false || $raw === '') continue;
-            $fileName = (string) ($a['FileName'] ?? '');
-            if (str_ends_with(strtolower($fileName), '.pdf') || str_starts_with($raw, '%PDF')) {
-                $pdf = $raw;
-                $name = $fileName !== '' ? $fileName : 'invoice.pdf';
-                break;
+        $attachments = $this->idoklad->listReceivedAttachments($supplierId, $idokladInvoiceId, $documentType);
+        $picked = self::pickArchivableAttachment($attachments);
+        if ($picked === null) return;
+        [$pdf, $name] = $picked;
+
+        if (!str_starts_with($pdf, '%PDF')) {
+            $mime = $this->imageToPdf->detectImageMime($pdf);
+            if ($mime === null) {
+                return; // ani PDF, ani podporovaný obrázek — nearchivujeme
             }
+            try {
+                $pdf = $this->imageToPdf->convert($pdf, $mime);
+            } catch (\Throwable $e) {
+                $this->logger->info('iDoklad attachment image→PDF conversion failed', ['purchase_invoice_id' => $purchaseInvoiceId, 'error' => $e->getMessage()]);
+                return;
+            }
+            $name = (string) preg_replace('/\.[^.]+$/', '', $name) . '.pdf';
         }
-        if ($pdf === null) return;
 
         $archiveRoot = (string) $this->config->get('purchase_invoice.archive_storage', '');
         if ($archiveRoot === '') {
@@ -1238,6 +1246,33 @@ final class IdokladImportService
         }
         $relPath = \MyInvoice\Service\Import\PurchaseInvoicePdfArchiver::shardedRelPath($supplierId, $sha);
         $this->purchaseRepo->setPdfMetadata($purchaseInvoiceId, $supplierId, $relPath, $sha, $size, $name);
+    }
+
+    /**
+     * Vybere z iDoklad příloh první archivovatelnou: preferuje PDF (podle přípony
+     * `.pdf` NEBO magic `%PDF` — název může chybět), jinak první přílohu
+     * s dekódovatelnými bajty (typicky fotka; o konverzi/odmítnutí rozhodne caller).
+     *
+     * Čistá funkce (bez IO) — viz IdokladAttachmentPickTest.
+     *
+     * @param list<array<string,mixed>> $attachments  [{FileName, FileBytes(base64)}, …]
+     * @return array{0:string,1:string}|null  [raw bajty, jméno souboru] nebo null
+     */
+    public static function pickArchivableAttachment(array $attachments): ?array
+    {
+        $fallback = null;
+        foreach ($attachments as $a) {
+            $bytes = $a['FileBytes'] ?? null;
+            if ($bytes === null || $bytes === '') continue;
+            $raw = base64_decode((string) $bytes, true);
+            if ($raw === false || $raw === '') continue;
+            $name = (string) ($a['FileName'] ?? '');
+            if (str_ends_with(strtolower($name), '.pdf') || str_starts_with($raw, '%PDF')) {
+                return [$raw, $name !== '' ? $name : 'invoice.pdf'];
+            }
+            $fallback ??= [$raw, $name !== '' ? $name : 'attachment'];
+        }
+        return $fallback;
     }
 
     /**

--- a/api/tests/Unit/Service/Import/IdokladAttachmentPickTest.php
+++ b/api/tests/Unit/Service/Import/IdokladAttachmentPickTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Import;
+
+use MyInvoice\Service\Import\IdokladImportService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Výběr archivovatelné přílohy z iDoklad /v3/Attachments payloadu.
+ *
+ * Pozadí: přílohy účtenek jsou typicky fotky z telefonu (JPG) — dřívější inline logika
+ * je zahazovala (jen `.pdf` / `%PDF`). Nově se vybere PDF přednostně, jinak první příloha
+ * s dekódovatelnými bajty; o konverzi fotky na PDF se stará caller (ImageToPdfConverter,
+ * stejně jako ruční upload / issue #75).
+ */
+final class IdokladAttachmentPickTest extends TestCase
+{
+    /** Minimal JPEG-ish bytes (SOI marker) — reálný tvar: FileBytes base64, FileName foto. */
+    private static function jpegAttachment(string $name = 'IMG_1234.jpg'): array
+    {
+        return ['FileName' => $name, 'FileBytes' => base64_encode("\xFF\xD8\xFF\xE0fakejpegbody")];
+    }
+
+    private static function pdfAttachment(string $name = 'doklad.pdf', string $body = '%PDF-1.4 fake'): array
+    {
+        return ['FileName' => $name, 'FileBytes' => base64_encode($body)];
+    }
+
+    public function testPrefersPdfByExtension(): void
+    {
+        $picked = IdokladImportService::pickArchivableAttachment([
+            self::jpegAttachment(),
+            self::pdfAttachment('faktura.pdf'),
+        ]);
+        self::assertNotNull($picked);
+        self::assertSame('faktura.pdf', $picked[1]);
+        self::assertStringStartsWith('%PDF', $picked[0]);
+    }
+
+    public function testPrefersPdfByMagicWhenNameMissing(): void
+    {
+        // PDF bez přípony/jména — pozná se podle magic bajtů, dostane fallback jméno.
+        $picked = IdokladImportService::pickArchivableAttachment([
+            self::jpegAttachment(),
+            ['FileName' => '', 'FileBytes' => base64_encode('%PDF-1.7 bezejmena')],
+        ]);
+        self::assertNotNull($picked);
+        self::assertSame('invoice.pdf', $picked[1]);
+    }
+
+    public function testFallsBackToImageWhenNoPdf(): void
+    {
+        // Reálný tvar z /v3/Attachments/{id}/ReceivedReceipt/false — fotka účtenky.
+        $picked = IdokladImportService::pickArchivableAttachment([
+            self::jpegAttachment('Jakub Zemek - 2026-05-24 18.18.05.jpg'),
+        ]);
+        self::assertNotNull($picked);
+        self::assertSame('Jakub Zemek - 2026-05-24 18.18.05.jpg', $picked[1]);
+        self::assertStringStartsWith("\xFF\xD8\xFF", $picked[0]);
+    }
+
+    public function testPdfWinsRegardlessOfOrder(): void
+    {
+        $a = IdokladImportService::pickArchivableAttachment([self::pdfAttachment(), self::jpegAttachment()]);
+        $b = IdokladImportService::pickArchivableAttachment([self::jpegAttachment(), self::pdfAttachment()]);
+        self::assertSame('doklad.pdf', $a[1] ?? null);
+        self::assertSame('doklad.pdf', $b[1] ?? null);
+    }
+
+    public function testSkipsInvalidBase64AndEmptyBytes(): void
+    {
+        $picked = IdokladImportService::pickArchivableAttachment([
+            ['FileName' => 'broken.pdf', 'FileBytes' => '!!!not-base64!!!'],
+            ['FileName' => 'empty.pdf', 'FileBytes' => ''],
+            ['FileName' => 'missing.pdf'],
+            self::jpegAttachment(),
+        ]);
+        self::assertNotNull($picked);
+        self::assertStringEndsWith('.jpg', $picked[1]);
+    }
+
+    public function testEmptyListIsNullNotError(): void
+    {
+        self::assertNull(IdokladImportService::pickArchivableAttachment([]));
+    }
+
+    public function testUnnamedImageGetsFallbackName(): void
+    {
+        $picked = IdokladImportService::pickArchivableAttachment([
+            ['FileName' => '', 'FileBytes' => base64_encode("\xFF\xD8\xFF\xE0x")],
+        ]);
+        self::assertSame('attachment', $picked[1] ?? null);
+    }
+}


### PR DESCRIPTION
Closes #189

## Co a proč

Import příloh z iDokladu se dotazuje jen scope `ReceivedInvoice`, takže přílohy **účtenek** (scope `ReceivedReceipt`, enum 11) nikdy nenajde — a i nalezené **fotky** (JPG z telefonu) se zahazují, protože se archivuje jen `%PDF`. Tenhle PR obojí opravuje; fotky jdou stejnou cestou jako ruční upload (`ImageToPdfConverter`, issue #75), takže výsledek je od ručně nahraného dokladu k nerozeznání.

## Změny

- **`IdokladClient::listReceivedAttachments()`** — nový parametr `$documentType` (default `ReceivedInvoice` = beze změny chování pro faktury). Dotaz teď staví scope z parametru.
- **`IdokladImportService`**:
  - `importReceipts()` volá `archiveReceivedPdf(..., 'ReceivedReceipt')`.
  - `archiveReceivedPdf()` — nový parametr `$documentType`; výběr přílohy vytažen do čisté statické `pickArchivableAttachment()`; fotka (ne-`%PDF`) se konvertuje přes `ImageToPdfConverter` (detekce MIME → `convert()` → přejmenování `.jpg → .pdf`), PDF projde beze změny. Nerozpoznaný typ / selhání konverze = tichý no-op jako dosud.
  - DI: konstruktor dostane `ImageToPdfConverter` (autowire; třída nemá vlastní konstruktor, žádná změna wiringu).
- **Testy** — `IdokladAttachmentPickTest` (7 případů): PDF podle přípony i podle magic bez jména, PDF vyhrává bez ohledu na pořadí, fallback na obrázek (reálný tvar `FileBytes`+JPG `FileName`), přeskočení nevalidního base64 / prázdných bajtů, prázdný seznam → `null`, fallback jméno pro nepojmenovaný obrázek.
- **CHANGELOG** — záznam pod `[Unreleased] / Fixed`.

Žádná DB migrace; chování stále gated přes `download_attachments`.

## Odlišnosti účtenky (které oprava řeší)

| | ReceivedInvoice | ReceivedReceipt |
|---|---|---|
| Attachments scope (SDK enum) | 5 | 11 |
| Typická příloha | PDF od dodavatele | fotka paragonu (JPG) |

## Ověřeno

- **Endpoint scope** (živě, reálný tenant): `GET /v3/Attachments/{id}/ReceivedReceipt/false` → 200 s `FileBytes` (fotka účtenky), `…/ReceivedInvoice/false` pro totéž id → 404. Enum potvrzený v oficiálním SDK (`AttachmentDocumentType::ReceivedReceipt = 11`).
- **Výběr přílohy**: 7/7 unit případů prochází proti zpatchované třídě (vč. reálného tvaru payloadu `FileBytes`+JPG `FileName`).
- **Konverze fotky**: skutečná fotka účtenky z tenantu (progressive JPEG, 1536×2048, 118 kB) → `ImageToPdfConverter->convert()` → validní `%PDF-1.4` (151 kB), na runtime PHP 8.5. Oba zpatchované soubory `php -l` čisté.

> Neprověřeno v tomto PR (ponecháno na CI / review): celá PHPUnit suite (regrese jinde) a plně propojená cesta fetch→convert→archive→metadata. Vedlejší efekt níže je odvozený, ne otestovaný (v našem tenantu doklad s čistě foto-přílohou u faktury není).

## Vedlejší efekt (záměrný)

Přijaté **faktury** s čistě foto-přílohou se nově archivují taky (dřív tichý skip) — stejná parita s ruční upload cestou. Kdyby to mělo být za samostatný flag, řekni v review.
