### PR TITLE
feat(api): ISDOC jedné vystavené faktury + veřejný hromadný export

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -448,6 +448,70 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /api/v1/invoices/export:
+    get:
+      tags: [Invoices]
+      summary: Hromadný export vystavených faktur za měsíc nebo čtvrtletí
+      description: |
+        Jeden soubor se všemi vystavenými doklady za období (status
+        issued/sent/reminded/paid), supplier scope dle `X-Supplier-Id`:
+
+        - `pdf-zip` — ZIP s jedním PDF na doklad (`Faktura-{vs}.pdf`, dobropisy
+          `Dobropis-{vs}.pdf` atd.)
+        - `isdoc` — ISDOC XML; jeden doklad = samostatný `.isdoc`, víc dokladů = ZIP
+        - `pohoda` — Pohoda XML dataPack
+        - `stereo` — Stereo (Ježek) XML
+
+        Období: `month=YYYY-MM`, nebo `period=quarterly&year=YYYY&quarter=1..4`.
+        `date_by=issue|tax` řídí zařazení do období (default issue; `tax` = DUZP,
+        shodné s výkazy DPH).
+      parameters:
+        - $ref: '#/components/parameters/SupplierIdHeader'
+        - { in: query, name: format, required: true, schema: { type: string, enum: [pdf-zip, isdoc, pohoda, stereo] } }
+        - { in: query, name: month, schema: { type: string, pattern: '^\d{4}-\d{2}$' } }
+        - { in: query, name: period, schema: { type: string, enum: [monthly, quarterly] } }
+        - { in: query, name: year, schema: { type: integer } }
+        - { in: query, name: quarter, schema: { type: integer, minimum: 1, maximum: 4 } }
+        - { in: query, name: date_by, schema: { type: string, enum: [issue, tax], default: issue } }
+        - { in: query, name: type, schema: { type: string, enum: [invoice, proforma, credit_note, cancellation], description: "Jen jeden typ dokladu (default všechny)" } }
+      responses:
+        '200':
+          description: ZIP / XML stream (Content-Disposition attachment)
+          content:
+            application/zip:
+              schema: { type: string, format: binary }
+            application/xml:
+              schema: { type: string, format: binary }
+        '400':
+          $ref: '#/components/responses/ValidationFailed'
+        '404':
+          description: Za období nejsou žádné vystavené faktury
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/v1/invoices/{id}/isdoc:
+    get:
+      tags: [Invoices]
+      summary: ISDOC XML jedné vystavené faktury
+      description: |
+        Strojově čitelná faktura (ISDOC) — symetrie
+        s `/api/v1/purchase-invoices/{id}/isdoc`. Koncept (draft) nelze
+        exportovat (400) — nemá přidělené číslo.
+      parameters:
+        - $ref: '#/components/parameters/SupplierIdHeader'
+        - { in: path, name: id, required: true, schema: { type: integer, format: int64 } }
+      responses:
+        '200':
+          description: ISDOC XML (Content-Disposition attachment, Faktura-{vs}.isdoc)
+          content:
+            application/xml:
+              schema: { type: string, format: binary }
+        '400':
+          $ref: '#/components/responses/ValidationFailed'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/invoices/{id}:
     parameters:
       - $ref: '#/components/parameters/SupplierIdHeader'

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -497,7 +497,8 @@ paths:
       description: |
         Strojově čitelná faktura (ISDOC) — symetrie
         s `/api/v1/purchase-invoices/{id}/isdoc`. Koncept (draft) nelze
-        exportovat (400) — nemá přidělené číslo.
+        exportovat (400) — nemá přidělené číslo. Stornovanou fakturu (409)
+        také ne — stejné pravidlo jako u hromadného exportu.
       parameters:
         - $ref: '#/components/parameters/SupplierIdHeader'
         - { in: path, name: id, required: true, schema: { type: integer, format: int64 } }
@@ -511,6 +512,11 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: Stornovanou fakturu nelze exportovat do ISDOC
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
   /api/v1/invoices/{id}:
     parameters:

--- a/api/src/Action/Invoice/InvoiceIsdocAction.php
+++ b/api/src/Action/Invoice/InvoiceIsdocAction.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Action\Invoice;
+
+use MyInvoice\Http\Json;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Middleware\SupplierScopeMiddleware;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\Export\IsdocExporter;
+use MyInvoice\Service\IpMatcher;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * GET /api/invoices/{id}/isdoc — ISDOC XML jedné vystavené faktury.
+ *
+ * Doplňuje symetrii s /api/purchase-invoices/{id}/isdoc (přijaté ho mají,
+ * vystavené dosud jen hromadně přes admin export). Pro integrace: účetní
+ * software zákazníka si stáhne strojově čitelnou fakturu bez ZIP obalu.
+ *
+ * Supplier scope: faktura musí patřit aktuálnímu dodavateli (X-Supplier-Id),
+ * jinak 404 — stejně jako GetInvoiceAction.
+ */
+final class InvoiceIsdocAction
+{
+    public function __construct(
+        private readonly InvoiceRepository $repo,
+        private readonly IsdocExporter $isdoc,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
+    ) {}
+
+    public function __invoke(Request $request, Response $response, array $args): Response
+    {
+        $id  = (int) ($args['id'] ?? 0);
+        $sid = (int) $request->getAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, 0);
+
+        $invoice = $this->repo->find($id);
+        if ($invoice === null || (int) ($invoice['supplier_id'] ?? 0) !== $sid) {
+            return Json::error($response, 'not_found', 'Faktura nenalezena.', 404);
+        }
+        // Draft nemá číslo (varsymbol) — ISDOC dává smysl až pro vystavený doklad.
+        if (($invoice['status'] ?? '') === 'draft') {
+            return Json::error($response, 'validation_failed', 'Koncept nelze exportovat do ISDOC — nejdřív fakturu vystavte.', 400);
+        }
+
+        try {
+            $xml = $this->isdoc->buildXml($invoice);
+        } catch (\Throwable $e) {
+            return Json::error($response, 'export_failed', $e->getMessage(), 500);
+        }
+
+        $user = (array) $request->getAttribute(AuthMiddleware::ATTR_USER, []);
+        $ip = $this->ipMatcher->clientIpFromRequest($request->getServerParams());
+        $this->logger->log('invoice.isdoc_exported', isset($user['id']) ? (int) $user['id'] : null, 'invoice', $id,
+            null, $ip, $request->getHeaderLine('User-Agent'), $sid);
+
+        $vs = preg_replace('/[^A-Za-z0-9_-]/', '_', (string) ($invoice['varsymbol'] ?? $id));
+        $response->getBody()->write($xml);
+        return $response
+            ->withHeader('Content-Type', 'application/xml; charset=utf-8')
+            ->withHeader('Content-Disposition', 'attachment; filename="Faktura-' . $vs . '.isdoc"')
+            ->withHeader('Cache-Control', 'no-store');
+    }
+}

--- a/api/src/Action/Invoice/InvoiceIsdocAction.php
+++ b/api/src/Action/Invoice/InvoiceIsdocAction.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace MyInvoice\Action\Invoice;
 
 use MyInvoice\Http\Json;
+use MyInvoice\Http\SupplierGuard;
 use MyInvoice\Middleware\AuthMiddleware;
-use MyInvoice\Middleware\SupplierScopeMiddleware;
 use MyInvoice\Repository\InvoiceRepository;
 use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\Currency\ExchangeRateApplier;
 use MyInvoice\Service\Export\IsdocExporter;
 use MyInvoice\Service\IpMatcher;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -31,20 +32,39 @@ final class InvoiceIsdocAction
         private readonly IsdocExporter $isdoc,
         private readonly ActivityLogger $logger,
         private readonly IpMatcher $ipMatcher,
+        private readonly ExchangeRateApplier $rateApplier,
     ) {}
 
     public function __invoke(Request $request, Response $response, array $args): Response
     {
         $id  = (int) ($args['id'] ?? 0);
-        $sid = (int) $request->getAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, 0);
+        $sid = SupplierGuard::currentId($request);
 
         $invoice = $this->repo->find($id);
-        if ($invoice === null || (int) ($invoice['supplier_id'] ?? 0) !== $sid) {
+        if (!SupplierGuard::owns($request, $invoice)) {
             return Json::error($response, 'not_found', 'Faktura nenalezena.', 404);
         }
         // Draft nemá číslo (varsymbol) — ISDOC dává smysl až pro vystavený doklad.
         if (($invoice['status'] ?? '') === 'draft') {
             return Json::error($response, 'validation_failed', 'Koncept nelze exportovat do ISDOC — nejdřív fakturu vystavte.', 400);
+        }
+        // Stornovanou fakturu (status=cancelled, viz CancelInvoiceAction) hromadný
+        // export za období (ExportAction::findInvoiceIds) záměrně vynechává —
+        // stejné pravidlo platí i tady, ať účetní software nedostane tentýž doklad
+        // jinak podle toho, kterým z obou endpointů ho stáhne.
+        if (($invoice['status'] ?? '') === 'cancelled') {
+            return Json::error($response, 'invalid_state', 'Stornovanou fakturu nelze exportovat do ISDOC.', 409);
+        }
+
+        // Backfill kurzu (cache → ČNB → last known) pro cizí měnu bez zafixovaného
+        // kurzu — stejně jako GetInvoiceAction / PdfAction; jinak IsdocExporter::buildXml
+        // padá na kurz 1.0 u starších dokladů bez uloženého exchange_rate.
+        if (
+            (string) ($invoice['currency'] ?? 'CZK') !== 'CZK'
+            && empty($invoice['exchange_rate'])
+        ) {
+            $this->rateApplier->ensureRate($id);
+            $invoice = $this->repo->find($id);
         }
 
         try {

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -63,6 +63,7 @@ use MyInvoice\Action\Invoice\DeleteInvoiceAction;
 use MyInvoice\Action\Invoice\ExportCsvAction;
 use MyInvoice\Action\Invoice\InvoiceActivityAction;
 use MyInvoice\Action\Invoice\GetInvoiceAction;
+use MyInvoice\Action\Invoice\InvoiceIsdocAction;
 use MyInvoice\Action\Invoice\IssueInvoiceAction;
 use MyInvoice\Action\Invoice\ListInvoicesAction;
 use MyInvoice\Action\Invoice\PreviewVarsymbolAction;
@@ -279,6 +280,9 @@ final class Routes
         // Invoices (M3 — draft + editor + sumace; vystavení/odeslání/PDF přijde v M4)
         $app->get    ('/api/invoices',              ListInvoicesAction::class);
         $app->get    ('/api/invoices/export.csv',   ExportCsvAction::class);
+        // Veřejný alias admin exportu (bearer allowlist pokrývá /api/invoices/*):
+        // ?format=pdf-zip|isdoc|pohoda|stereo & month=YYYY-MM nebo period=quarterly&year&quarter
+        $app->get    ('/api/invoices/export',       ExportAction::class);
         $app->get    ('/api/invoices/preview-varsymbol', PreviewVarsymbolAction::class);
         $app->post   ('/api/invoices',              CreateInvoiceAction::class);
         $app->get    ('/api/invoices/{id:[0-9]+}',  GetInvoiceAction::class);
@@ -294,6 +298,7 @@ final class Routes
         $app->delete ('/api/invoices/{id:[0-9]+}/payments/{paymentId:[0-9]+}', DeletePaymentAction::class);
         $app->post   ('/api/invoices/{id:[0-9]+}/payments/{paymentId:[0-9]+}/tax-document', CreatePaymentTaxDocumentAction::class);
         $app->post   ('/api/invoices/{id:[0-9]+}/cancel',    CancelInvoiceAction::class);
+        $app->get    ('/api/invoices/{id:[0-9]+}/isdoc',     InvoiceIsdocAction::class);
         $app->get    ('/api/invoices/{id:[0-9]+}/pdf',       PdfAction::class);
         $app->get    ('/api/invoices/{id:[0-9]+}/pdfs',      ListPdfsAction::class);
         $app->get    ('/api/invoices/{id:[0-9]+}/pdfs/{archiveId:[0-9]+}', DownloadArchivedPdfAction::class);

--- a/api/tests/Unit/Middleware/ApiScopeMiddlewareTest.php
+++ b/api/tests/Unit/Middleware/ApiScopeMiddlewareTest.php
@@ -125,6 +125,22 @@ final class ApiScopeMiddlewareTest extends TestCase
         self::assertSame('token_endpoint_forbidden', $this->errorCode($r));
     }
 
+    public function testBearerReadCanUseInvoiceExports(): void
+    {
+        // Hromadný export + per-faktura ISDOC jsou verejné GETy pod /api/invoices —
+        // bearer token se scope `read` na ně dosáhne (na rozdíl od /api/admin/export).
+        foreach ([
+            '/api/invoices/export',
+            '/api/invoices/42/isdoc',
+        ] as $path) {
+            $r = $this->middleware()->process(
+                $this->bearer('GET', $path, 'read'),
+                $this->okHandler(),
+            );
+            self::assertSame(204, $r->getStatusCode(), "bearer GET $path");
+        }
+    }
+
     public function testBearerReadCannotWriteAllowedResource(): void
     {
         // Path je povolená, ale read scope nesmí POST → insufficient_scope (NE path).

--- a/manual/41_API.md
+++ b/manual/41_API.md
@@ -180,9 +180,24 @@ curl -X POST https://mojefirma.example/api/v1/settings/supplier/logo \
   -H "Authorization: Bearer $TOKEN" \
   -F "file=@logo.png"
 # → { "logo_path": "storage/supplier-logos/sup-1.png", "width": 480, "height": 160 }
+
+## 41.9 Export faktur přes API
+
+- **`GET /api/v1/invoices/export?format=pdf-zip|isdoc|pohoda|stereo&month=YYYY-MM`**
+  — hromadný export vystavených dokladů za měsíc (nebo
+  `period=quarterly&year=YYYY&quarter=1..4`). PDF ZIP, ISDOC, Pohoda či Stereo
+  XML; `date_by=tax` zařazuje dle DUZP (shodně s výkazy DPH). Stejná logika
+  jako interní `Daně → Hromadný export`, dostupná integračně.
+- **`GET /api/v1/invoices/{id}/isdoc`** — ISDOC XML jedné vystavené faktury
+  (koncept nelze, 400). PDF varianta existovala už dřív
+  (`GET /api/v1/invoices/{id}/pdf`).
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" -OJ \
+  "https://mojefirma.example/api/v1/invoices/export?format=isdoc&month=2026-06"
 ```
 
-## 41.9 Bezpečnost tokenů — best practices
+## 41.10 Bezpečnost tokenů — best practices
 
 - **Ukládej token jako secret** (password manager, Make encrypted variable, GitHub Secrets…).
   Nepushuj do gitu.
@@ -193,7 +208,7 @@ curl -X POST https://mojefirma.example/api/v1/settings/supplier/logo \
 - **Sleduj `last_used_at`** v UI — token, který se 3 měsíce nepoužil, asi nepotřebuješ.
 - **Při ztrátě/podezření** — okamžitě **Zrušit** v UI. Revokace je instantní (žádný cache).
 
-## 41.10 Co API nepokrývá
+## 41.11 Co API nepokrývá
 
 - **Admin a settings endpointy** (`/api/admin/*` a `/api/settings/*` mimo
   veřejný subset — supplier, číselníky) nejsou v `openapi.yaml` - jsou určené


### PR DESCRIPTION
## Motivace

Vystavené faktury jdou přes veřejné API stáhnout jen jako PDF po jedné (`/invoices/{id}/pdf`). ISDOC existuje pro **přijaté** (`/purchase-invoices/{id}/isdoc`), pro vystavené ne; hromadný export (PDF ZIP / ISDOC / Pohoda / Stereo) žije jen na `/api/admin/export`, které je pro bearer tokeny správně blokované. Integrace (můj use-case: SaaS platforma vystavující faktury přes myinvoice, která chce merchantům nabídnout „stáhnout vše za měsíc pro účetní") tak nemá jak.

## Co PR přidává

- **`GET /api/v1/invoices/{id}/isdoc`** — nová malá akce zrcadlící `ExportPurchaseInvoiceAction::isdoc`: supplier scope jako `GetInvoiceAction` (cizí/neexistující → 404), draft → 400, `IsdocExporter::buildXml`, activity log `invoice.isdoc_exported`, sanitizovaný filename.
- **`GET /api/v1/invoices/export`** — čistý route-alias na stávající `ExportAction` (žádná duplikace logiky). Akce už je supplier-scoped a role-guarded (admin/accountant/readonly), takže jediné, co chybělo, byla cesta mimo `/api/admin/*`. Bearer allowlist pokrývá `/api/invoices/*` — **žádná změna middlewaru**. FastRoute kolize s `{id:[0-9]+}` nehrozí (regex constraint).
- OpenAPI dokumentace obou endpointů, test bearer-scope, manuál 41.

## Ověření

- `phpunit tests/Unit/Middleware`: 26 testů OK (PHP 8.5.7)
- DI kontejner akci sestaví; Slim route collector registruje obě cesty; `php -l` čisté; openapi validní YAML

Pozn.: drobný konflikt v `manual/41_API.md` s #185 (obě PR přidávají sekci před „Bezpečnost tokenů") — vyřeším rebase podle toho, co se mergne dřív.

🤖 Generated with [Claude Code](https://claude.com/claude-code)