### PR TITLE
fix(invoice): stažení/náhled zdrojového PDF z importu u vydané faktury

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -778,6 +778,35 @@ paths:
             application/pdf:
               schema: { type: string, format: binary }
 
+  /api/v1/invoices/{id}/imported-pdf:
+    parameters:
+      - $ref: '#/components/parameters/SupplierIdHeader'
+      - in: path
+        name: id
+        required: true
+        schema: { type: integer, format: int64 }
+      - in: query
+        name: inline
+        required: false
+        description: "`1` → Content-Disposition: inline (náhled v prohlížeči); jinak attachment (stažení)."
+        schema: { type: integer, enum: [1] }
+    get:
+      tags: [Invoices]
+      summary: Zdrojové PDF vydané faktury z importu
+      description: |
+        Vrátí archivovaný ZDROJOVÝ PDF vydané faktury tak, jak dorazil z importu
+        (iDoklad/Fakturoid) — nezaměňovat s naším vlastním rendered PDF
+        (`GET /api/v1/invoices/{id}/pdf`). Dostupné jen pro faktury s neprázdným
+        `imported_pdf_path`; jinak `404`.
+      responses:
+        '200':
+          description: PDF stream
+          content:
+            application/pdf:
+              schema: { type: string, format: binary }
+        '404':
+          description: Faktura nenalezena, nemá archivovaný zdrojový PDF, nebo soubor chybí na disku.
+
   /api/v1/projects:
     get:
       tags: [Projects]

--- a/api/src/Action/Invoice/DownloadImportedPdfAction.php
+++ b/api/src/Action/Invoice/DownloadImportedPdfAction.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Action\Invoice;
+
+use MyInvoice\Http\Json;
+use MyInvoice\Http\SupplierGuard;
+use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Infrastructure\Config\RuntimePaths;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\IpMatcher;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * GET /api/invoices/{id}/imported-pdf
+ *
+ * Stáhne archivovaný ZDROJOVÝ PDF vydané faktury tak, jak dorazil z importu
+ * (iDoklad/Fakturoid) — uložený v `imported_pdf_*` columnech, MIMO náš vlastní
+ * rendered PDF (`pdf_path`). Parita s {@see \MyInvoice\Action\PurchaseInvoice\DownloadPurchaseInvoicePdfAction}
+ * pro přijaté faktury: stream přes PHP, soubor je mimo webroot, path traversal je
+ * defenzivně zabaleno přes realpath() check vůči import-archive rootu.
+ *
+ * Autorizace:
+ *   1. SupplierGuard::owns (faktura patří current supplier scope)
+ *   2. path-traversal guard (výsledná cesta nesmí utéct z archive rootu)
+ *
+ * Pokud faktura nemá `imported_pdf_path` → 404.
+ */
+final class DownloadImportedPdfAction
+{
+    public function __construct(
+        private readonly InvoiceRepository $repo,
+        private readonly Config $config,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
+    ) {}
+
+    public function __invoke(Request $request, Response $response, array $args): Response
+    {
+        $id = (int) ($args['id'] ?? 0);
+        if ($id <= 0) {
+            return Json::error($response, 'invalid_id', 'Neplatné ID', 400);
+        }
+
+        $invoice = $this->repo->find($id);
+        if (!SupplierGuard::owns($request, $invoice)) {
+            return Json::error($response, 'not_found', 'Faktura nenalezena.', 404);
+        }
+
+        $relativePath = (string) ($invoice['imported_pdf_path'] ?? '');
+        if ($relativePath === '') {
+            return Json::error($response, 'no_pdf', 'K této faktuře není archivovaný zdrojový PDF dokument.', 404);
+        }
+
+        $archiveRoot = $this->resolveArchiveRoot();
+        $archiveRootReal = realpath($archiveRoot);
+        if ($archiveRootReal === false) {
+            return Json::error($response, 'storage_unavailable', 'Archiv nelze nalézt.', 500);
+        }
+
+        // Sestavit absolutní cestu a ověřit, že NEUTÍKÁ z archiveRoot (path traversal guard).
+        $fullPath = $archiveRootReal . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+        $fullPathReal = realpath($fullPath);
+        if ($fullPathReal === false || !is_file($fullPathReal)) {
+            return Json::error($response, 'file_missing', 'Archivovaný soubor nebyl na disku nalezen.', 404);
+        }
+        // Windows je case-insensitive FS — realpath() může vrátit nekonzistentní casing
+        // mezi archiveRootReal a fullPathReal. Na Linuxu zachováme striktní compare.
+        $isWindows = DIRECTORY_SEPARATOR === '\\';
+        $haystack = ($isWindows ? strtolower($fullPathReal) : $fullPathReal);
+        $needle   = ($isWindows ? strtolower($archiveRootReal) : $archiveRootReal) . DIRECTORY_SEPARATOR;
+        if (!str_starts_with($haystack, $needle)) {
+            return Json::error($response, 'forbidden', 'Cesta mimo archive root.', 403);
+        }
+
+        $size = filesize($fullPathReal);
+        if ($size === false) {
+            return Json::error($response, 'read_failed', 'Nelze přečíst velikost souboru.', 500);
+        }
+
+        $downloadName = (string) ($invoice['imported_pdf_original_name']
+            ?? ('faktura-' . ($invoice['varsymbol'] ?? $id) . '.pdf'));
+        $downloadName = preg_replace('/[\x00-\x1F"<>|*?:\\\\\/]/', '_', $downloadName) ?: 'invoice.pdf';
+        // Obsah je VŽDY PDF (Content-Type níže). Vynuť .pdf příponu, ať prohlížeč
+        // neuloží soubor pod jinou/žádnou příponou.
+        if (!preg_match('/\.pdf$/i', $downloadName)) {
+            $downloadName = preg_replace('/\.[^.]+$/', '', $downloadName) . '.pdf';
+        }
+
+        // Stream — pro velké soubory nestavíme do paměti.
+        $stream = fopen($fullPathReal, 'rb');
+        if ($stream === false) {
+            return Json::error($response, 'read_failed', 'Nepodařilo se otevřít soubor.', 500);
+        }
+
+        $user = (array) $request->getAttribute(AuthMiddleware::ATTR_USER, []);
+        $ip = $this->ipMatcher->clientIpFromRequest($request->getServerParams());
+        $this->logger->log('invoice.imported_pdf_downloaded', $user['id'] ?? null, 'invoice', $id,
+            ['size_bytes' => $size], $ip, $request->getHeaderLine('User-Agent'));
+
+        $body = $response->getBody();
+        while (!feof($stream)) {
+            $chunk = fread($stream, 65536);
+            if ($chunk === false) {
+                break;
+            }
+            $body->write($chunk);
+        }
+        fclose($stream);
+
+        // `?inline=1` → Content-Disposition: inline (povolí browser-native PDF viewer v iframe).
+        // Bez parametru: attachment (download). Detail page má iframe preview přes ?inline=1.
+        $inline = !empty($request->getQueryParams()['inline']);
+        $disposition = ($inline ? 'inline' : 'attachment') . '; filename="' . $downloadName . '"';
+
+        $resp = $response
+            ->withHeader('Content-Type', 'application/pdf')
+            ->withHeader('Content-Length', (string) $size)
+            ->withHeader('Content-Disposition', $disposition)
+            ->withHeader('Cache-Control', 'private, no-store')
+            ->withHeader('X-Content-Type-Options', 'nosniff');
+
+        // CSP override pro inline mode — globální .htaccess/web.config nastavuje
+        // `frame-ancestors 'none'` (anti-clickjacking). To by zakázalo embed PDF do
+        // iframe v naší vlastní SPA. Override per-response na `'self'` umožňuje
+        // embed jen z naší origin. X-Frame-Options jako fallback pro starší browsery.
+        if ($inline) {
+            $resp = $resp
+                ->withHeader('Content-Security-Policy', "frame-ancestors 'self'")
+                ->withHeader('X-Frame-Options', 'SAMEORIGIN');
+        }
+
+        return $resp;
+    }
+
+    /**
+     * Import-archive root pro vydané faktury. MUSÍ být shodný s tím, kam zapisuje
+     * import (IdokladImportService/FakturoidImportService::archiveIssuedPdf), tzn.
+     * config klíč `invoice.import_archive_storage` s fallbackem na `invoices-imported`.
+     */
+    private function resolveArchiveRoot(): string
+    {
+        $dir = (string) $this->config->get('invoice.import_archive_storage', '');
+        if ($dir !== '') {
+            return $dir;
+        }
+        $uploads = (string) $this->config->get('storage.uploads_dir', '');
+        if ($uploads !== '') {
+            return dirname($uploads) . '/invoices-imported';
+        }
+        return RuntimePaths::storage('invoices-imported');
+    }
+}

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -109,6 +109,7 @@ use MyInvoice\Action\Invoice\UnlinkAdvanceAction as UnlinkInvoiceAdvanceAction;
 use MyInvoice\Action\Invoice\PdfAction;
 use MyInvoice\Action\Invoice\ListPdfsAction;
 use MyInvoice\Action\Invoice\DownloadArchivedPdfAction;
+use MyInvoice\Action\Invoice\DownloadImportedPdfAction;
 use MyInvoice\Action\Invoice\Attachment\ListAttachmentsAction;
 use MyInvoice\Action\Invoice\Attachment\UploadAttachmentAction;
 use MyInvoice\Action\Invoice\Attachment\DeleteAttachmentAction;
@@ -302,6 +303,7 @@ final class Routes
         $app->get    ('/api/invoices/{id:[0-9]+}/pdf',       PdfAction::class);
         $app->get    ('/api/invoices/{id:[0-9]+}/pdfs',      ListPdfsAction::class);
         $app->get    ('/api/invoices/{id:[0-9]+}/pdfs/{archiveId:[0-9]+}', DownloadArchivedPdfAction::class);
+        $app->get    ('/api/invoices/{id:[0-9]+}/imported-pdf', DownloadImportedPdfAction::class);
         $app->get    ('/api/invoices/{id:[0-9]+}/attachments', ListAttachmentsAction::class);
         $app->post   ('/api/invoices/{id:[0-9]+}/attachments', UploadAttachmentAction::class);
         $app->get    ('/api/invoices/{id:[0-9]+}/attachments/{attId:[0-9]+}', DownloadAttachmentAction::class);

--- a/api/tests/Unit/Action/Invoice/DownloadImportedPdfActionTest.php
+++ b/api/tests/Unit/Action/Invoice/DownloadImportedPdfActionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Action\Invoice;
+
+use MyInvoice\Action\Invoice\DownloadImportedPdfAction;
+use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Middleware\SupplierScopeMiddleware;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\IpMatcher;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ResponseFactory;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+/**
+ * Chování GET /api/invoices/{id}/imported-pdf — servírování archivovaného zdrojového
+ * PDF vydané faktury z importu. Final třídy (repo/logger/matcher) jsou mockované přes
+ * dg/bypass-finals (viz tests/bootstrap.php); DB není potřeba — soubor je na tmp disku.
+ */
+final class DownloadImportedPdfActionTest extends TestCase
+{
+    private const SUPPLIER_ID = 1;
+    private const REL_PATH = 'supplier-1/ab/abcdef1234567890.pdf';
+    private const PDF_BYTES = "%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF";
+
+    private string $archiveRoot = '';
+
+    protected function setUp(): void
+    {
+        $this->archiveRoot = sys_get_temp_dir() . '/mi-imported-pdf-test-' . getmypid() . '-' . uniqid();
+        @mkdir($this->archiveRoot . '/supplier-1/ab', 0777, true);
+        file_put_contents($this->archiveRoot . '/' . self::REL_PATH, self::PDF_BYTES);
+    }
+
+    protected function tearDown(): void
+    {
+        // Uklidit celý tmp strom.
+        foreach (array_reverse(glob($this->archiveRoot . '/{,*/,*/*/}*', GLOB_BRACE) ?: []) as $p) {
+            is_dir($p) ? @rmdir($p) : @unlink($p);
+        }
+        @rmdir($this->archiveRoot);
+    }
+
+    /** @param array<string,mixed>|null $invoiceRow */
+    private function action(?array $invoiceRow): DownloadImportedPdfAction
+    {
+        $repo = $this->createStub(InvoiceRepository::class);
+        $repo->method('find')->willReturn($invoiceRow);
+
+        $config = new Config(['invoice' => ['import_archive_storage' => $this->archiveRoot]], null);
+
+        $logger = $this->createStub(ActivityLogger::class);
+
+        $ip = $this->createStub(IpMatcher::class);
+        $ip->method('clientIpFromRequest')->willReturn('127.0.0.1');
+
+        return new DownloadImportedPdfAction($repo, $config, $logger, $ip);
+    }
+
+    private function request(string $query = ''): \Psr\Http\Message\ServerRequestInterface
+    {
+        $req = (new ServerRequestFactory())
+            ->createServerRequest('GET', '/api/invoices/854/imported-pdf' . ($query ? "?$query" : ''))
+            ->withAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, self::SUPPLIER_ID);
+        if ($query !== '') {
+            parse_str($query, $qp);
+            $req = $req->withQueryParams($qp);
+        }
+        return $req;
+    }
+
+    private function ownedInvoice(array $overrides = []): array
+    {
+        return array_merge([
+            'id'                         => 854,
+            'supplier_id'                => self::SUPPLIER_ID,
+            'varsymbol'                  => '20260013',
+            'imported_pdf_path'          => self::REL_PATH,
+            'imported_pdf_original_name' => '20260013.pdf',
+            'imported_pdf_size_bytes'    => strlen(self::PDF_BYTES),
+        ], $overrides);
+    }
+
+    public function testServesArchivedPdfAsAttachment(): void
+    {
+        $resp = ($this->action($this->ownedInvoice()))($this->request(), (new ResponseFactory())->createResponse(), ['id' => 854]);
+
+        self::assertSame(200, $resp->getStatusCode());
+        self::assertSame('application/pdf', $resp->getHeaderLine('Content-Type'));
+        self::assertSame((string) strlen(self::PDF_BYTES), $resp->getHeaderLine('Content-Length'));
+        self::assertSame(self::PDF_BYTES, (string) $resp->getBody());
+        self::assertStringContainsString('attachment', $resp->getHeaderLine('Content-Disposition'));
+        self::assertStringContainsString('20260013.pdf', $resp->getHeaderLine('Content-Disposition'));
+        // Nosniff vždy; sandbox/frame-ancestors jen v inline režimu.
+        self::assertSame('nosniff', $resp->getHeaderLine('X-Content-Type-Options'));
+        self::assertFalse($resp->hasHeader('X-Frame-Options'), 'attachment režim nesmí nastavovat X-Frame-Options');
+    }
+
+    public function testInlineModeSetsFrameAncestorsForIframePreview(): void
+    {
+        $resp = ($this->action($this->ownedInvoice()))($this->request('inline=1'), (new ResponseFactory())->createResponse(), ['id' => 854]);
+
+        self::assertSame(200, $resp->getStatusCode());
+        self::assertStringContainsString('inline', $resp->getHeaderLine('Content-Disposition'));
+        self::assertSame("frame-ancestors 'self'", $resp->getHeaderLine('Content-Security-Policy'));
+        self::assertSame('SAMEORIGIN', $resp->getHeaderLine('X-Frame-Options'));
+    }
+
+    public function testForcesPdfExtensionOnDownloadName(): void
+    {
+        $inv = $this->ownedInvoice(['imported_pdf_original_name' => 'uctenka.jpg']);
+        $resp = ($this->action($inv))($this->request(), (new ResponseFactory())->createResponse(), ['id' => 854]);
+
+        self::assertStringContainsString('uctenka.pdf', $resp->getHeaderLine('Content-Disposition'));
+        self::assertStringNotContainsString('.jpg', $resp->getHeaderLine('Content-Disposition'));
+    }
+
+    public function testReturns404WhenInvoiceNotOwnedBySupplier(): void
+    {
+        $inv = $this->ownedInvoice(['supplier_id' => 999]);
+        $resp = ($this->action($inv))($this->request(), (new ResponseFactory())->createResponse(), ['id' => 854]);
+
+        self::assertSame(404, $resp->getStatusCode());
+    }
+
+    public function testReturns404WhenNoImportedPdf(): void
+    {
+        $inv = $this->ownedInvoice(['imported_pdf_path' => null]);
+        $resp = ($this->action($inv))($this->request(), (new ResponseFactory())->createResponse(), ['id' => 854]);
+
+        self::assertSame(404, $resp->getStatusCode());
+        self::assertStringContainsString('no_pdf', (string) $resp->getBody());
+    }
+
+    public function testReturns404WhenFileMissingOnDisk(): void
+    {
+        $inv = $this->ownedInvoice(['imported_pdf_path' => 'supplier-1/zz/doesnotexist000.pdf']);
+        $resp = ($this->action($inv))($this->request(), (new ResponseFactory())->createResponse(), ['id' => 854]);
+
+        self::assertSame(404, $resp->getStatusCode());
+    }
+
+    public function testRejectsPathTraversalOutsideArchiveRoot(): void
+    {
+        // Soubor mimo archive root — cesta se přes ../ snaží utéct ven.
+        $outside = $this->archiveRoot . '-secret.pdf';
+        file_put_contents($outside, 'SECRET');
+        try {
+            $inv = $this->ownedInvoice(['imported_pdf_path' => '../' . basename($outside)]);
+            $resp = ($this->action($inv))($this->request(), (new ResponseFactory())->createResponse(), ['id' => 854]);
+
+            self::assertNotSame(200, $resp->getStatusCode(), 'traversal nesmí vrátit obsah souboru mimo root');
+            self::assertStringNotContainsString('SECRET', (string) $resp->getBody());
+        } finally {
+            @unlink($outside);
+        }
+    }
+}

--- a/manual/11_Faktura_PDF.md
+++ b/manual/11_Faktura_PDF.md
@@ -15,6 +15,9 @@ Detail ukazuje:
 - **Hlavičku** — variabilní symbol, typ, klient, data, částka, stav
 - **Položky** — read-only zobrazení řádků
 - **Náhled PDF** — embed iframe (lze otevřít na celou obrazovku)
+- **Zdrojové PDF z importu** — jen u faktur naimportovaných z iDoklad/Fakturoid:
+  originální PDF dokladu, jak dorazil ze zdrojového systému (náhled + stažení).
+  Je oddělené od našeho vygenerovaného PDF — viz [16. Importy](16_Importy.md).
 - **Activity log** — kdo a kdy fakturu vytvořil / vystavil / odeslal / označil
   zaplacenou
 

--- a/web/src/api/invoices.ts
+++ b/web/src/api/invoices.ts
@@ -148,6 +148,10 @@ export interface Invoice {
   paid_at: string | null
   cancelled_at: string | null
   pdf_path: string | null
+  /** Zdrojové PDF z importu (iDoklad/Fakturoid) — oddělené od našeho rendered `pdf_path`. */
+  imported_pdf_path: string | null
+  imported_pdf_original_name?: string | null
+  imported_pdf_size_bytes?: number | string | null
   created_at: string
   updated_at: string
   /** Výsledek děkovného e-mailu (issue #57) — vrací mark-paid, jen když se odesílalo. */
@@ -475,6 +479,17 @@ export const invoicesApi = {
     if (sid && /^\d+$/.test(sid)) params.set('supplier_id', sid)
     const qs = params.toString()
     return `/api/invoices/${id}/pdf${qs ? '?' + qs : ''}`
+  },
+
+  importedPdfUrl: (id: number, inline: boolean = false) => {
+    // Přímá navigace / iframe / <a href> neposílá X-Supplier-Id header (na rozdíl od
+    // axios) — proto přidáváme supplier_id jako query param (middleware ho čte jako fallback).
+    const sid = localStorage.getItem('myinvoice.current_supplier_id')
+    const params = new URLSearchParams()
+    if (inline) params.set('inline', '1')
+    if (sid && /^\d+$/.test(sid)) params.set('supplier_id', sid)
+    const qs = params.toString()
+    return `/api/invoices/${id}/imported-pdf${qs ? '?' + qs : ''}`
   },
 
   listPdfs: (id: number) =>

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -1395,6 +1395,11 @@
       "no_candidates": "Žádné nespárované zálohové faktury tohoto odběratele.",
       "no_candidates_final": "Žádné nepropojené daňové doklady tohoto odběratele."
     },
+    "imported_pdf": {
+      "title": "Zdrojové PDF z importu",
+      "show": "Zobrazit PDF",
+      "hide": "Skrýt PDF"
+    },
     "pdf_history": {
       "title": "Historie PDF",
       "sent": "Odesláno klientovi",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -1395,6 +1395,11 @@
       "no_candidates": "No unlinked advance invoices for this customer.",
       "no_candidates_final": "No unlinked tax documents for this customer."
     },
+    "imported_pdf": {
+      "title": "Imported source PDF",
+      "show": "Show PDF",
+      "hide": "Hide PDF"
+    },
     "pdf_history": {
       "title": "PDF history",
       "sent": "Sent to client",

--- a/web/src/pages/invoices/InvoiceDetail.vue
+++ b/web/src/pages/invoices/InvoiceDetail.vue
@@ -81,6 +81,7 @@ const activity = ref<Array<{ id: number; user_email: string | null; user_name: s
 const activityOpen = ref(false)
 const pdfHistory = ref<Array<{ id: number; filename: string; size_bytes: number; sha256: string; was_sent: boolean; sent_to: string[] | null; reason: string; archived_at: string }>>([])
 const pdfHistoryOpen = ref(false)
+const importedPdfPreviewOpen = ref(false)
 
 // SMTP analýza (box jen pro admina, když je log analýza zapnutá; lazy-load na rozbalení)
 const smtpEnabled = ref(false)
@@ -2228,6 +2229,43 @@ const invoiceActions = computed<ActionItem[]>(() => {
           </span>
           <span class="text-xs text-neutral-500">{{ t('invoice.attachments.drop_here') }}</span>
         </label>
+      </div>
+    </div>
+
+    <!-- Zdrojové PDF z importu (iDoklad/Fakturoid) — originál dokladu, oddělený od našeho rendered PDF -->
+    <div v-if="invoice?.imported_pdf_path" class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="px-4 sm:px-5 py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-center gap-2 min-w-0">
+          <svg class="w-5 h-5 text-neutral-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7 21h10a2 2 0 0 0 2-2V9.414a1 1 0 0 0-.293-.707l-5.414-5.414A1 1 0 0 0 12.586 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2z"/></svg>
+          <div class="min-w-0">
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.imported_pdf.title') }}</h3>
+            <div class="text-xs text-neutral-500 truncate" :title="invoice.imported_pdf_original_name || 'invoice.pdf'">
+              {{ invoice.imported_pdf_original_name || 'invoice.pdf' }}
+              <template v-if="Number(invoice.imported_pdf_size_bytes)"> · {{ formatBytes(Number(invoice.imported_pdf_size_bytes)) }}</template>
+            </div>
+          </div>
+        </div>
+        <div class="flex items-center gap-2 shrink-0">
+          <button type="button" @click="importedPdfPreviewOpen = !importedPdfPreviewOpen"
+            class="cursor-pointer px-3 h-9 text-sm border border-neutral-300 text-neutral-700 hover:bg-neutral-50 rounded-md inline-flex items-center gap-1.5">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
+            {{ importedPdfPreviewOpen ? t('invoice.imported_pdf.hide') : t('invoice.imported_pdf.show') }}
+          </button>
+          <a :href="invoicesApi.importedPdfUrl(invoice.id, false)" target="_blank"
+             class="cursor-pointer px-3 h-9 text-sm border border-primary-500/40 text-primary-700 hover:bg-primary-50 rounded-md inline-flex items-center gap-1.5">
+            <svg class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+            {{ t('common.download') }}
+          </a>
+        </div>
+      </div>
+      <!-- Inline PDF preview přes browser PDF viewer. Musí být ?inline=1 (jinak
+           Content-Disposition: attachment a některé prohlížeče blokují embed). -->
+      <div v-if="importedPdfPreviewOpen" class="bg-neutral-100 border-t border-neutral-200">
+        <iframe
+          :src="invoicesApi.importedPdfUrl(invoice.id, true) + '#view=FitH'"
+          class="w-full h-[80vh] border-0"
+          :title="invoice.imported_pdf_original_name || 'PDF'"
+        ></iframe>
       </div>
     </div>
 


### PR DESCRIPTION
Closes #193.

## Problém
Import vydaných faktur z iDokladu/Fakturoidu archivuje originální PDF dokladu do sloupců `invoices.imported_pdf_{path,hash,size_bytes,original_name}` (`IdokladImportService::archiveIssuedPdf`, `FakturoidImportService::archiveIssuedPdf`). Tato data ale **nejde z aplikace nijak dostat** — neexistuje žádný endpoint ani UI, které by je četly (`imported_pdf` je v `api/src` jen v import-službách; ve frontendu nic). V detailu vydané faktury tak příloha působí jako „chybějící", přestože originál je bezpečně na disku.

Navazuje na #171 (oprava *archivace* zdrojového PDF) — archivace se opravila, ale čtecí strana nebyla nikdy doplněna. Přijaté faktury přitom svůj originál běžně vystavují přes `DownloadPurchaseInvoicePdfAction` (`GET /api/purchase-invoices/{id}/pdf`).

## Řešení
**Backend**
- Nová akce `DownloadImportedPdfAction` → `GET /api/invoices/{id}/imported-pdf`. Stream ze stejného rootu, kam zapisuje import (`invoice.import_archive_storage`), `SupplierGuard::owns`, case-insensitive path-traversal guard, `nosniff`. `?inline=1` → `Content-Disposition: inline` + `frame-ancestors 'self'` pro iframe náhled (parita s přijatými fakturami).
- Route + OpenAPI (`/api/v1/invoices/{id}/imported-pdf`).

**Frontend**
- Karta „Zdrojové PDF z importu" v detailu vydané faktury (náhled v iframe + stažení), zobrazí se jen když `imported_pdf_path` není prázdné.
- `invoicesApi.importedPdfUrl(id, inline)` + pole na `Invoice` interface. i18n cs + en.

**Manuál:** kapitola 11 (detail faktury).

## Testy
- `DownloadImportedPdfActionTest` — 7 případů (servírování PDF, inline vs attachment, vynucení `.pdf`, 404 cizí supplier / bez PDF / chybějící soubor, odmítnutí path traversal).
- Celá PHPUnit sada: **1462 testů, 0 chyb** (Integration bez DB se skipují). `pnpm build` + `vue-tsc` OK. OpenAPI se parsuje bez duplicit.