### PR TITLE
feat(invoice): web faktura — trvalý veřejný odkaz na vystavenou fakturu

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1164,6 +1164,74 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Invoice' }
 
+  /api/v1/invoices/{id}/public-link:
+    parameters:
+      - $ref: '#/components/parameters/SupplierIdHeader'
+      - in: path
+        name: id
+        required: true
+        schema: { type: integer, format: int64 }
+    post:
+      tags: [InvoiceComms]
+      summary: Web faktura — vrátí (a případně vytvoří) trvalý veřejný odkaz
+      description: |
+        Trvalý veřejný odkaz `/invoice/{token}` — klient si na něm fakturu
+        bez přihlášení prohlédne v HTML a stáhne PDF (obdoba „web faktury"
+        ve Fakturoidu). Token se generuje lazy při prvním volání; opakované
+        volání vrací tentýž odkaz (idempotentní). Odkaz se také automaticky
+        přikládá do e-mailu při odeslání faktury klientovi.
+
+        `public_viewed_at` = poslední zobrazení klientem (anonymní přístup);
+        null dokud klient fakturu neotevřel.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url: { type: string, example: "https://faktury.example.cz/invoice/a1b2…" }
+                  token: { type: string, description: "48 hex znaků" }
+                  public_viewed_at: { type: string, format: date-time, nullable: true }
+        '409':
+          description: Faktura je draft — web faktura je dostupná až po vystavení
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404': { description: "Faktura nenalezena" }
+
+  /api/v1/invoices/{id}/public-link/regenerate:
+    parameters:
+      - $ref: '#/components/parameters/SupplierIdHeader'
+      - in: path
+        name: id
+        required: true
+        schema: { type: integer, format: int64 }
+    post:
+      tags: [InvoiceComms]
+      summary: Web faktura — zneplatní stávající odkaz vygenerováním nového
+      description: |
+        Revokace veřejného odkazu (např. při úniku URL) — starý token přestane
+        okamžitě platit, vrací se nová URL. `public_viewed_at` se resetuje.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url: { type: string }
+                  token: { type: string }
+                  public_viewed_at: { type: string, nullable: true, example: null }
+        '409':
+          description: Faktura je draft
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404': { description: "Faktura nenalezena" }
+
   /api/v1/invoices/{id}/pdfs:
     parameters:
       - $ref: '#/components/parameters/SupplierIdHeader'
@@ -5579,6 +5647,8 @@ components:
           type: string
           nullable: true
           enum: [none, requested, approved, rejected]
+        public_token: { type: string, nullable: true, description: "Token trvalého veřejného odkazu „web faktura\" (/invoice/{token}); null dokud odkaz nevznikl. Viz POST /invoices/{id}/public-link." }
+        public_viewed_at: { type: string, format: date-time, nullable: true, description: "Poslední zobrazení web faktury klientem (anonymní přístup); null = klient ji zatím neotevřel." }
         items:
           type: array
           items: { $ref: '#/components/schemas/InvoiceItem' }

--- a/api/src/Action/Invoice/PublicInvoiceAttachmentAction.php
+++ b/api/src/Action/Invoice/PublicInvoiceAttachmentAction.php
@@ -6,35 +6,34 @@ namespace MyInvoice\Action\Invoice;
 
 use MyInvoice\Http\Json;
 use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Repository\InvoiceAttachmentRepository;
 use MyInvoice\Repository\InvoiceRepository;
 use MyInvoice\Service\ActivityLogger;
 use MyInvoice\Service\Approval\ApprovalTokenValidator;
 use MyInvoice\Service\IpMatcher;
-use MyInvoice\Service\Pdf\InvoicePdfRenderer;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Psr7\Stream;
 
 /**
- * GET /api/public/invoice/{token}/pdf
+ * GET /api/public/invoice/{token}/attachment/{attId}
  *
- * Stažení PDF z veřejné web faktury (bez auth, jen token) — vzor PdfAction,
- * ale bez SupplierGuard (identitu nahrazuje tajný token) a bez regenerate
- * (public návštěvník nesmí vynutit přegenerování). Draft 404 jako u GET.
+ * Stažení přílohy e-mailu z veřejné web faktury — vzor DownloadAttachmentAction,
+ * ale gated tokenem faktury místo SupplierGuard. Vazba attId → invoice_id
+ * v `find($attId, $id)` brání stažení přílohy cizí faktury (IDOR).
+ * Vždy attachment disposition — public návštěvníkovi nic nevykreslujeme inline.
  */
-final class PublicInvoicePdfAction
+final class PublicInvoiceAttachmentAction
 {
     public function __construct(
-        private readonly InvoicePdfRenderer $renderer,
         private readonly InvoiceRepository $repo,
+        private readonly InvoiceAttachmentRepository $attachments,
         private readonly ActivityLogger $logger,
         private readonly IpMatcher $ipMatcher,
     ) {}
 
     public function __invoke(Request $request, Response $response, array $args): Response
     {
-        // Vypni HTML error output (deprecation warnings z 3rd party libs by jinak
-        // skončily v PDF binary streamu).
         ini_set('display_errors', '0');
         ini_set('html_errors', '0');
 
@@ -43,44 +42,44 @@ final class PublicInvoicePdfAction
             return Json::error($response, 'invalid_token', 'Neplatný odkaz.', 404);
         }
 
-        // Lehký lookup — plnou fakturu si render() načte sám.
         $ref = $this->repo->publicInvoiceRefByToken($token);
         if ($ref === null) {
             return Json::error($response, 'token_invalid_or_expired',
                 'Tento odkaz není platný nebo byl zneplatněn.', 404);
         }
-        $id = $ref['id'];
 
-        // Zachyť případné echo/warning z 3rd party libs během renderu.
-        ob_start();
-        try {
-            $path = $this->renderer->render($id);
-        } catch (\Throwable) {
-            ob_end_clean();
-            // Public endpoint — žádné interní detaily chyby ven
-            return Json::error($response, 'pdf_failed', 'PDF se nepodařilo vygenerovat.', 500);
+        $att = $this->attachments->find((int) ($args['attId'] ?? 0), $ref['id']);
+        if ($att === null) {
+            return Json::error($response, 'not_found', 'Příloha nenalezena.', 404);
         }
-        ob_end_clean();
+
+        $path = $this->attachments->pathFor($ref['supplier_id'], $ref['id'], (string) $att['filename']);
+        if (!is_file($path)) {
+            return Json::error($response, 'not_found', 'Soubor nenalezen na disku.', 404);
+        }
 
         $user = $request->getAttribute(AuthMiddleware::ATTR_USER);
         if (!is_array($user) || empty($user['id'])) {
-            $this->repo->markPublicViewed($id);
-            $this->logger->log('invoice.public_pdf_downloaded', null, 'invoice', $id, [],
+            $this->repo->markPublicViewed($ref['id']);
+            $this->logger->log('invoice.public_attachment_downloaded', null, 'invoice', $ref['id'],
+                ['original_name' => (string) $att['original_name']],
                 $this->ipMatcher->clientIpFromRequest($request->getServerParams()),
                 $request->getHeaderLine('User-Agent'), $ref['supplier_id']);
         }
 
-        $download = !empty($request->getQueryParams()['download']);
-        $filename = basename($path);
-        $disposition = $download ? "attachment; filename=\"{$filename}\"" : "inline; filename=\"{$filename}\"";
+        $safe = preg_replace('/[\r\n"\\\\]/', '_', (string) $att['original_name']);
 
         $stream = new Stream(fopen($path, 'rb'));
         return $response
             ->withStatus(200)
-            ->withHeader('Content-Type', 'application/pdf')
-            ->withHeader('Content-Disposition', $disposition)
+            ->withHeader('Content-Type', (string) $att['mime_type'])
+            ->withHeader('Content-Disposition', "attachment; filename=\"{$safe}\"")
             ->withHeader('Content-Length', (string) filesize($path))
             ->withHeader('Cache-Control', 'no-store')
+            // Defense-in-depth proti MIME sniffingu / aktivnímu obsahu
+            // (parita s DownloadAttachmentAction).
+            ->withHeader('X-Content-Type-Options', 'nosniff')
+            ->withHeader('Content-Security-Policy', "default-src 'none'; sandbox")
             ->withBody($stream);
     }
 }

--- a/api/src/Action/Invoice/PublicInvoiceGetAction.php
+++ b/api/src/Action/Invoice/PublicInvoiceGetAction.php
@@ -6,6 +6,7 @@ namespace MyInvoice\Action\Invoice;
 
 use MyInvoice\Http\Json;
 use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Repository\InvoiceAttachmentRepository;
 use MyInvoice\Repository\InvoiceRepository;
 use MyInvoice\Service\ActivityLogger;
 use MyInvoice\Service\Approval\ApprovalTokenValidator;
@@ -35,6 +36,7 @@ final class PublicInvoiceGetAction
 {
     public function __construct(
         private readonly InvoiceRepository $repo,
+        private readonly InvoiceAttachmentRepository $attachments,
         private readonly InvoicePdfRenderer $renderer,
         private readonly InvoiceEmailVarsBuilder $emailVars,
         private readonly ActivityLogger $logger,
@@ -61,7 +63,7 @@ final class PublicInvoiceGetAction
             if ($firstView) {
                 $this->logger->log('invoice.public_viewed', null, 'invoice', (int) $invoice['id'], [],
                     $this->ipMatcher->clientIpFromRequest($request->getServerParams()),
-                    $request->getHeaderLine('User-Agent'));
+                    $request->getHeaderLine('User-Agent'), (int) $invoice['supplier_id']);
             }
         }
 
@@ -71,6 +73,7 @@ final class PublicInvoiceGetAction
             $this->renderer->resolveClient($invoice),
             $this->renderer->resolveBank($invoice),
             $this->emailVars->paymentQrDataUri($invoice),
+            $this->attachments->listForInvoice((int) $invoice['id']),
         ));
     }
 
@@ -80,10 +83,11 @@ final class PublicInvoiceGetAction
      * vzor ApprovalEmailVarsBuilder::buildSubject). Nikdy sem nepřidávat tokeny,
      * snapshoty, interní ID vazeb ani e-maily klienta.
      *
-     * @param array<string,mixed>      $invoice  Řádek z InvoiceRepository::find()
-     * @param array<string,mixed>      $supplier Z InvoicePdfRenderer::resolveSupplier()
-     * @param array<string,mixed>      $client   Z InvoicePdfRenderer::resolveClient()
-     * @param array<string,mixed>|null $bank     Z InvoicePdfRenderer::resolveBank()
+     * @param array<string,mixed>      $invoice     Řádek z InvoiceRepository::find()
+     * @param array<string,mixed>      $supplier    Z InvoicePdfRenderer::resolveSupplier()
+     * @param array<string,mixed>      $client      Z InvoicePdfRenderer::resolveClient()
+     * @param array<string,mixed>|null $bank        Z InvoicePdfRenderer::resolveBank()
+     * @param list<array<string,mixed>> $attachments Z InvoiceAttachmentRepository::listForInvoice()
      * @return array<string,mixed>
      */
     public static function buildPayload(
@@ -92,6 +96,7 @@ final class PublicInvoiceGetAction
         array $client,
         ?array $bank,
         ?string $qrDataUri,
+        array $attachments = [],
     ): array {
         $pick = static fn (array $src, array $keys): array =>
             array_intersect_key($src, array_flip($keys));
@@ -130,6 +135,15 @@ final class PublicInvoiceGetAction
                 'account_number', 'bank_code', 'bank_name', 'iban', 'bic',
             ]),
             'qr_data_uri' => $qrDataUri,
+            // Přílohy e-mailu ke stažení — id slouží jen jako klíč pro download
+            // URL (gated tokenem faktury); NIKDY filename (název na disku),
+            // sha256 ani uploaded_by.
+            'attachments' => array_map(
+                static fn (array $a): array => $pick($a, [
+                    'id', 'original_name', 'size_bytes',
+                ]),
+                $attachments,
+            ),
         ];
     }
 }

--- a/api/src/Action/Invoice/PublicInvoiceGetAction.php
+++ b/api/src/Action/Invoice/PublicInvoiceGetAction.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Action\Invoice;
+
+use MyInvoice\Http\Json;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\Approval\ApprovalTokenValidator;
+use MyInvoice\Service\IpMatcher;
+use MyInvoice\Service\Mail\InvoiceEmailVarsBuilder;
+use MyInvoice\Service\Pdf\InvoicePdfRenderer;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * GET /api/public/invoice/{token}
+ *
+ * Veřejná „web faktura" (bez auth) — data pro HTML náhled vystavené faktury.
+ * Token je v invoices.public_token (trvalý, revokace = regenerace). Draft se
+ * nezobrazuje (404 stejně jako neexistující token — neprozrazovat existenci).
+ *
+ * Vrací STRIKTNĚ whitelistovaný set polí (viz buildPayload) — dodavatel,
+ * odběratel, položky, součty, DPH rekapitulace, platební údaje + QR. Data se
+ * resolvují snapshot-first stejně jako PDF (InvoicePdfRenderer::resolve*),
+ * takže náhled ukazuje totéž co PDF.
+ *
+ * Zobrazení anonymním návštěvníkem nastaví public_viewed_at (indikace
+ * „zobrazeno klientem"); přihlášený interní uživatel indikaci neovlivní
+ * (vzor PublicWorkReportGetAction).
+ */
+final class PublicInvoiceGetAction
+{
+    public function __construct(
+        private readonly InvoiceRepository $repo,
+        private readonly InvoicePdfRenderer $renderer,
+        private readonly InvoiceEmailVarsBuilder $emailVars,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
+    ) {}
+
+    public function __invoke(Request $request, Response $response, array $args): Response
+    {
+        $token = (string) ($args['token'] ?? '');
+        if (!ApprovalTokenValidator::isValidFormat($token)) {
+            return Json::error($response, 'invalid_token', 'Neplatný odkaz.', 404);
+        }
+
+        $invoice = $this->repo->findByPublicToken($token); // drafty filtruje SQL
+        if ($invoice === null) {
+            return Json::error($response, 'token_invalid_or_expired',
+                'Tento odkaz není platný nebo byl zneplatněn.', 404);
+        }
+
+        $user = $request->getAttribute(AuthMiddleware::ATTR_USER);
+        if (!is_array($user) || empty($user['id'])) {
+            $firstView = empty($invoice['public_viewed_at']);
+            $this->repo->markPublicViewed((int) $invoice['id']);
+            if ($firstView) {
+                $this->logger->log('invoice.public_viewed', null, 'invoice', (int) $invoice['id'], [],
+                    $this->ipMatcher->clientIpFromRequest($request->getServerParams()),
+                    $request->getHeaderLine('User-Agent'));
+            }
+        }
+
+        return Json::ok($response, self::buildPayload(
+            $invoice,
+            $this->renderer->resolveSupplier($invoice),
+            $this->renderer->resolveClient($invoice),
+            $this->renderer->resolveBank($invoice),
+            $this->emailVars->paymentQrDataUri($invoice),
+        ));
+    }
+
+    /**
+     * Whitelist public polí — jediné místo, které rozhoduje, co veřejný endpoint
+     * prozradí. Pure function (public static kvůli testovatelnosti bez DB,
+     * vzor ApprovalEmailVarsBuilder::buildSubject). Nikdy sem nepřidávat tokeny,
+     * snapshoty, interní ID vazeb ani e-maily klienta.
+     *
+     * @param array<string,mixed>      $invoice  Řádek z InvoiceRepository::find()
+     * @param array<string,mixed>      $supplier Z InvoicePdfRenderer::resolveSupplier()
+     * @param array<string,mixed>      $client   Z InvoicePdfRenderer::resolveClient()
+     * @param array<string,mixed>|null $bank     Z InvoicePdfRenderer::resolveBank()
+     * @return array<string,mixed>
+     */
+    public static function buildPayload(
+        array $invoice,
+        array $supplier,
+        array $client,
+        ?array $bank,
+        ?string $qrDataUri,
+    ): array {
+        $pick = static fn (array $src, array $keys): array =>
+            array_intersect_key($src, array_flip($keys));
+
+        $publicInvoice = $pick($invoice, [
+            'varsymbol', 'invoice_type', 'status', 'payment_status', 'language',
+            'currency', 'currency_decimals',
+            'issue_date', 'tax_date', 'due_date', 'paid_at',
+            'payment_method', 'reverse_charge', 'prices_include_vat',
+            'note_above_items', 'note_below_items',
+            'amount_to_pay', 'paid_total',
+            'totals', 'vat_breakdown', 'czk_recap',
+        ]);
+        $publicInvoice['items'] = array_map(
+            static fn (array $it): array => $pick($it, [
+                'description', 'quantity', 'unit', 'unit_price_without_vat',
+                'vat_rate_snapshot', 'total_without_vat', 'total_with_vat', 'item_kind',
+            ]),
+            (array) ($invoice['items'] ?? []),
+        );
+
+        return [
+            'invoice'  => $publicInvoice,
+            // Podmnožina polí, která tiskne PDF šablona (api/templates/invoice/invoice.twig)
+            'supplier' => $pick($supplier, [
+                'company_name', 'street', 'city', 'zip',
+                'country_name_cs', 'country_name_en', 'ic', 'dic',
+                'is_vat_payer', 'commercial_register', 'email', 'web',
+            ]),
+            'client'   => $pick($client, [
+                'company_name', 'first_name', 'last_name', 'street', 'city', 'zip',
+                'country_name_cs', 'country_name_en', 'country_iso2',
+                'ic', 'dic', 'tax_number',
+            ]),
+            'bank'     => $bank === null ? null : $pick($bank, [
+                'account_number', 'bank_code', 'bank_name', 'iban', 'bic',
+            ]),
+            'qr_data_uri' => $qrDataUri,
+        ];
+    }
+}

--- a/api/src/Action/Invoice/PublicInvoicePdfAction.php
+++ b/api/src/Action/Invoice/PublicInvoicePdfAction.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Action\Invoice;
+
+use MyInvoice\Http\Json;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\Approval\ApprovalTokenValidator;
+use MyInvoice\Service\IpMatcher;
+use MyInvoice\Service\Pdf\InvoicePdfRenderer;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Psr7\Stream;
+
+/**
+ * GET /api/public/invoice/{token}/pdf
+ *
+ * Stažení PDF z veřejné web faktury (bez auth, jen token) — vzor PdfAction,
+ * ale bez SupplierGuard (identitu nahrazuje tajný token) a bez regenerate
+ * (public návštěvník nesmí vynutit přegenerování). Draft 404 jako u GET.
+ */
+final class PublicInvoicePdfAction
+{
+    public function __construct(
+        private readonly InvoicePdfRenderer $renderer,
+        private readonly InvoiceRepository $repo,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
+    ) {}
+
+    public function __invoke(Request $request, Response $response, array $args): Response
+    {
+        // Vypni HTML error output (deprecation warnings z 3rd party libs by jinak
+        // skončily v PDF binary streamu).
+        ini_set('display_errors', '0');
+        ini_set('html_errors', '0');
+
+        $token = (string) ($args['token'] ?? '');
+        if (!ApprovalTokenValidator::isValidFormat($token)) {
+            return Json::error($response, 'invalid_token', 'Neplatný odkaz.', 404);
+        }
+
+        // Lehký lookup (jen id) — plnou fakturu si render() načte sám.
+        $id = $this->repo->publicInvoiceIdByToken($token);
+        if ($id === null) {
+            return Json::error($response, 'token_invalid_or_expired',
+                'Tento odkaz není platný nebo byl zneplatněn.', 404);
+        }
+
+        // Zachyť případné echo/warning z 3rd party libs během renderu.
+        ob_start();
+        try {
+            $path = $this->renderer->render($id);
+        } catch (\Throwable) {
+            ob_end_clean();
+            // Public endpoint — žádné interní detaily chyby ven
+            return Json::error($response, 'pdf_failed', 'PDF se nepodařilo vygenerovat.', 500);
+        }
+        ob_end_clean();
+
+        $user = $request->getAttribute(AuthMiddleware::ATTR_USER);
+        if (!is_array($user) || empty($user['id'])) {
+            $this->repo->markPublicViewed($id);
+            $this->logger->log('invoice.public_pdf_downloaded', null, 'invoice', $id, [],
+                $this->ipMatcher->clientIpFromRequest($request->getServerParams()),
+                $request->getHeaderLine('User-Agent'));
+        }
+
+        $download = !empty($request->getQueryParams()['download']);
+        $filename = basename($path);
+        $disposition = $download ? "attachment; filename=\"{$filename}\"" : "inline; filename=\"{$filename}\"";
+
+        $stream = new Stream(fopen($path, 'rb'));
+        return $response
+            ->withStatus(200)
+            ->withHeader('Content-Type', 'application/pdf')
+            ->withHeader('Content-Disposition', $disposition)
+            ->withHeader('Content-Length', (string) filesize($path))
+            ->withHeader('Cache-Control', 'no-store')
+            ->withBody($stream);
+    }
+}

--- a/api/src/Action/Invoice/PublicLinkAction.php
+++ b/api/src/Action/Invoice/PublicLinkAction.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Action\Invoice;
+
+use MyInvoice\Http\Json;
+use MyInvoice\Http\SupplierGuard;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\Invoice\InvoicePublicLinkService;
+use MyInvoice\Service\IpMatcher;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Správa veřejného odkazu „web faktura" (authenticated).
+ *
+ * POST /api/invoices/{id}/public-link            → ensure (lazy vytvoření) + URL
+ * POST /api/invoices/{id}/public-link/regenerate → revokace = nový token
+ *
+ * Jen pro vystavené doklady (draft 409) — veřejná stránka drafty nezobrazuje,
+ * odkaz na ně by byl mrtvý.
+ */
+final class PublicLinkAction
+{
+    public function __construct(
+        private readonly InvoiceRepository $repo,
+        private readonly InvoicePublicLinkService $links,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
+    ) {}
+
+    public function ensure(Request $request, Response $response, array $args): Response
+    {
+        $invoice = $this->loadIssuedInvoice($request, $response, $args);
+        if ($invoice instanceof Response) {
+            return $invoice;
+        }
+
+        $token = (string) ($invoice['public_token'] ?? '');
+        if ($token === '') {
+            $token = $this->repo->ensurePublicToken((int) $invoice['id']);
+            $this->log($request, 'invoice.public_link_created', (int) $invoice['id']);
+        }
+
+        return Json::ok($response, [
+            'url'              => $this->links->url($token),
+            'token'            => $token,
+            'public_viewed_at' => $invoice['public_viewed_at'] ?? null,
+        ]);
+    }
+
+    public function regenerate(Request $request, Response $response, array $args): Response
+    {
+        $invoice = $this->loadIssuedInvoice($request, $response, $args);
+        if ($invoice instanceof Response) {
+            return $invoice;
+        }
+
+        $token = $this->repo->regeneratePublicToken((int) $invoice['id']);
+        $this->log($request, 'invoice.public_link_regenerated', (int) $invoice['id']);
+
+        return Json::ok($response, [
+            'url'              => $this->links->url($token),
+            'token'            => $token,
+            'public_viewed_at' => null,
+        ]);
+    }
+
+    /**
+     * Načte fakturu a ověří vlastnictví (SupplierGuard) + ne-draft stav.
+     * Při neúspěchu vrací rovnou chybovou Response.
+     */
+    private function loadIssuedInvoice(Request $request, Response $response, array $args): array|Response
+    {
+        $invoice = $this->repo->find((int) ($args['id'] ?? 0));
+        if (!SupplierGuard::owns($request, $invoice)) {
+            return Json::error($response, 'not_found', 'Faktura nenalezena.', 404);
+        }
+        if (($invoice['status'] ?? '') === 'draft') {
+            return Json::error($response, 'invalid_state', 'Web faktura je dostupná až po vystavení dokladu.', 409);
+        }
+        return $invoice;
+    }
+
+    private function log(Request $request, string $action, int $invoiceId): void
+    {
+        $user = (array) $request->getAttribute(AuthMiddleware::ATTR_USER, []);
+        $this->logger->log($action, $user['id'] ?? null, 'invoice', $invoiceId, [],
+            $this->ipMatcher->clientIpFromRequest($request->getServerParams()),
+            $request->getHeaderLine('User-Agent'));
+    }
+}

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -1346,25 +1346,27 @@ final class InvoiceRepository
     }
 
     /**
-     * ID veřejně viditelné faktury podle public_token, nebo null. Pravidlo
-     * viditelnosti (draft se nezobrazuje) je přímo v SQL, aby ho konzument
-     * nemohl zapomenout (vzor findByApprovalToken s expirací).
+     * Lehká reference veřejně viditelné faktury podle public_token, nebo null.
+     * Pravidlo viditelnosti (draft se nezobrazuje) je přímo v SQL, aby ho
+     * konzument nemohl zapomenout (vzor findByApprovalToken s expirací).
+     *
+     * @return array{id:int, supplier_id:int}|null
      */
-    public function publicInvoiceIdByToken(string $token): ?int
+    public function publicInvoiceRefByToken(string $token): ?array
     {
         $stmt = $this->db->pdo()->prepare(
-            "SELECT id FROM invoices WHERE public_token = ? AND status <> 'draft'"
+            "SELECT id, supplier_id FROM invoices WHERE public_token = ? AND status <> 'draft'"
         );
         $stmt->execute([$token]);
-        $id = $stmt->fetchColumn();
-        return $id === false ? null : (int) $id;
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : ['id' => (int) $row['id'], 'supplier_id' => (int) $row['supplier_id']];
     }
 
     /** Najde veřejně viditelnou fakturu podle public_token (web faktura), nebo null. */
     public function findByPublicToken(string $token): ?array
     {
-        $id = $this->publicInvoiceIdByToken($token);
-        return $id === null ? null : $this->find($id);
+        $ref = $this->publicInvoiceRefByToken($token);
+        return $ref === null ? null : $this->find($ref['id']);
     }
 
     /** Zaznamená zobrazení web faktury klientem (poslední anonymní přístup). */

--- a/api/src/Repository/InvoiceRepository.php
+++ b/api/src/Repository/InvoiceRepository.php
@@ -1307,6 +1307,74 @@ final class InvoiceRepository
     }
 
     /**
+     * Vrátí public_token faktury (web faktura); pokud ještě neexistuje, vygeneruje
+     * ho — bin2hex(random_bytes(24)) → 48 hex znaků (vzor approval_token).
+     * UPDATE podmíněný `public_token IS NULL` serializuje souběžné ensure — vyhraje
+     * první zápis, druhý si token přečte znovu.
+     */
+    public function ensurePublicToken(int $invoiceId): string
+    {
+        $pdo = $this->db->pdo();
+        $sel = $pdo->prepare('SELECT public_token FROM invoices WHERE id = ?');
+        $sel->execute([$invoiceId]);
+        $existing = $sel->fetchColumn();
+        if (is_string($existing) && $existing !== '') {
+            return $existing;
+        }
+
+        $token = bin2hex(random_bytes(24));
+        $upd = $pdo->prepare('UPDATE invoices SET public_token = ? WHERE id = ? AND public_token IS NULL');
+        $upd->execute([$token, $invoiceId]);
+        if ($upd->rowCount() === 1) {
+            return $token;
+        }
+        $sel->execute([$invoiceId]);
+        return (string) $sel->fetchColumn();
+    }
+
+    /**
+     * Zneplatní stávající veřejný odkaz vygenerováním nového tokenu (stará URL
+     * přestane platit). public_viewed_at se resetuje — vztahuje se k aktuálnímu odkazu.
+     */
+    public function regeneratePublicToken(int $invoiceId): string
+    {
+        $token = bin2hex(random_bytes(24));
+        $this->db->pdo()->prepare(
+            'UPDATE invoices SET public_token = ?, public_viewed_at = NULL WHERE id = ?'
+        )->execute([$token, $invoiceId]);
+        return $token;
+    }
+
+    /**
+     * ID veřejně viditelné faktury podle public_token, nebo null. Pravidlo
+     * viditelnosti (draft se nezobrazuje) je přímo v SQL, aby ho konzument
+     * nemohl zapomenout (vzor findByApprovalToken s expirací).
+     */
+    public function publicInvoiceIdByToken(string $token): ?int
+    {
+        $stmt = $this->db->pdo()->prepare(
+            "SELECT id FROM invoices WHERE public_token = ? AND status <> 'draft'"
+        );
+        $stmt->execute([$token]);
+        $id = $stmt->fetchColumn();
+        return $id === false ? null : (int) $id;
+    }
+
+    /** Najde veřejně viditelnou fakturu podle public_token (web faktura), nebo null. */
+    public function findByPublicToken(string $token): ?array
+    {
+        $id = $this->publicInvoiceIdByToken($token);
+        return $id === null ? null : $this->find($id);
+    }
+
+    /** Zaznamená zobrazení web faktury klientem (poslední anonymní přístup). */
+    public function markPublicViewed(int $invoiceId): void
+    {
+        $this->db->pdo()->prepare('UPDATE invoices SET public_viewed_at = NOW() WHERE id = ?')
+            ->execute([$invoiceId]);
+    }
+
+    /**
      * Pro admin „Approval inbox" + reminder cron. Vrací requested faktury filtrované
      * podle dní od poslední upomínky/žádosti.
      *

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -107,6 +107,7 @@ use MyInvoice\Action\Invoice\FinalCandidatesAction;
 use MyInvoice\Action\Invoice\LinkAdvanceAction as LinkInvoiceAdvanceAction;
 use MyInvoice\Action\Invoice\UnlinkAdvanceAction as UnlinkInvoiceAdvanceAction;
 use MyInvoice\Action\Invoice\PdfAction;
+use MyInvoice\Action\Invoice\PublicInvoiceAttachmentAction;
 use MyInvoice\Action\Invoice\PublicInvoiceGetAction;
 use MyInvoice\Action\Invoice\PublicInvoicePdfAction;
 use MyInvoice\Action\Invoice\PublicLinkAction;
@@ -404,9 +405,10 @@ final class Routes
         $app->get    ('/api/public/approval/{token:[a-f0-9]{32,128}}',          PublicApprovalGetAction::class);
         $app->post   ('/api/public/approval/{token:[a-f0-9]{32,128}}/decide',   PublicApprovalDecideAction::class);
 
-        // Web faktura — veřejný náhled + PDF (bez auth, jen token)
+        // Web faktura — veřejný náhled + PDF + přílohy (bez auth, jen token)
         $app->get    ('/api/public/invoice/{token:[a-f0-9]{32,128}}',     PublicInvoiceGetAction::class);
         $app->get    ('/api/public/invoice/{token:[a-f0-9]{32,128}}/pdf', PublicInvoicePdfAction::class);
+        $app->get    ('/api/public/invoice/{token:[a-f0-9]{32,128}}/attachment/{attId:[0-9]+}', PublicInvoiceAttachmentAction::class);
 
         // Public náhled na výkaz práce (bez auth; token + e-mailová autorizace kódem)
         $app->get    ('/api/public/work-report/{token:[a-f0-9]{32,128}}',              PublicWorkReportGetAction::class);

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -107,6 +107,9 @@ use MyInvoice\Action\Invoice\FinalCandidatesAction;
 use MyInvoice\Action\Invoice\LinkAdvanceAction as LinkInvoiceAdvanceAction;
 use MyInvoice\Action\Invoice\UnlinkAdvanceAction as UnlinkInvoiceAdvanceAction;
 use MyInvoice\Action\Invoice\PdfAction;
+use MyInvoice\Action\Invoice\PublicInvoiceGetAction;
+use MyInvoice\Action\Invoice\PublicInvoicePdfAction;
+use MyInvoice\Action\Invoice\PublicLinkAction;
 use MyInvoice\Action\Invoice\ListPdfsAction;
 use MyInvoice\Action\Invoice\DownloadArchivedPdfAction;
 use MyInvoice\Action\Invoice\DownloadImportedPdfAction;
@@ -393,9 +396,17 @@ final class Routes
         $app->post   ('/api/invoices/{id:[0-9]+}/request-approval-test', RequestApprovalTestAction::class);
         $app->put    ('/api/invoices/{id:[0-9]+}/approval-status',       UpdateApprovalStatusAction::class);
 
+        // Web faktura — správa trvalého veřejného odkazu (authenticated)
+        $app->post   ('/api/invoices/{id:[0-9]+}/public-link',            [PublicLinkAction::class, 'ensure']);
+        $app->post   ('/api/invoices/{id:[0-9]+}/public-link/regenerate', [PublicLinkAction::class, 'regenerate']);
+
         // Public schvalovací endpointy (bez auth, jen token)
         $app->get    ('/api/public/approval/{token:[a-f0-9]{32,128}}',          PublicApprovalGetAction::class);
         $app->post   ('/api/public/approval/{token:[a-f0-9]{32,128}}/decide',   PublicApprovalDecideAction::class);
+
+        // Web faktura — veřejný náhled + PDF (bez auth, jen token)
+        $app->get    ('/api/public/invoice/{token:[a-f0-9]{32,128}}',     PublicInvoiceGetAction::class);
+        $app->get    ('/api/public/invoice/{token:[a-f0-9]{32,128}}/pdf', PublicInvoicePdfAction::class);
 
         // Public náhled na výkaz práce (bez auth; token + e-mailová autorizace kódem)
         $app->get    ('/api/public/work-report/{token:[a-f0-9]{32,128}}',              PublicWorkReportGetAction::class);

--- a/api/src/Service/Invoice/InvoicePublicLinkService.php
+++ b/api/src/Service/Invoice/InvoicePublicLinkService.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Invoice;
+
+use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Repository\InvoiceRepository;
+
+/**
+ * Jediný vlastník URL formátu web faktury `/invoice/{token}` (vzor
+ * WorkReportLinkService::publicUrl) — používá ho management endpoint
+ * (PublicLinkAction) i e-mail (InvoiceEmailVarsBuilder). Cesta musí ladit
+ * s Vue routou ve web/src/router/index.ts.
+ */
+final class InvoicePublicLinkService
+{
+    public function __construct(
+        private readonly Config $config,
+        private readonly InvoiceRepository $invoices,
+    ) {}
+
+    /**
+     * URL pro daný token. Bez nakonfigurovaného app.url vrací relativní cestu —
+     * UI („kopírovat odkaz") tak vždy něco dostane; e-mailová cesta absolutnost
+     * hlídá v ensureUrl().
+     */
+    public function url(string $token): string
+    {
+        return rtrim((string) $this->config->get('app.url', ''), '/') . '/invoice/' . $token;
+    }
+
+    /**
+     * Absolutní URL web faktury pro e-mail; token vytvoří lazy při prvním
+     * použití. Null pro draft (veřejná stránka koncepty nezobrazuje) a bez
+     * app.url (relativní odkaz je v e-mailu k ničemu).
+     */
+    public function ensureUrl(array $invoice): ?string
+    {
+        if (($invoice['status'] ?? '') === 'draft') {
+            return null;
+        }
+        if (rtrim((string) $this->config->get('app.url', ''), '/') === '') {
+            return null;
+        }
+        $token = (string) ($invoice['public_token'] ?? '');
+        if ($token === '') {
+            $token = $this->invoices->ensurePublicToken((int) $invoice['id']);
+        }
+        return $this->url($token);
+    }
+}

--- a/api/src/Service/Mail/InvoiceEmailVarsBuilder.php
+++ b/api/src/Service/Mail/InvoiceEmailVarsBuilder.php
@@ -6,6 +6,7 @@ namespace MyInvoice\Service\Mail;
 
 use MyInvoice\Infrastructure\Database\Connection;
 use MyInvoice\Service\Branding\AccentColor;
+use MyInvoice\Service\Invoice\InvoicePublicLinkService;
 use MyInvoice\Service\Qr\QrPaymentGenerator;
 
 /**
@@ -17,6 +18,7 @@ final class InvoiceEmailVarsBuilder
     public function __construct(
         private readonly Connection $db,
         private readonly QrPaymentGenerator $qr,
+        private readonly InvoicePublicLinkService $publicLinks,
     ) {}
 
     /**
@@ -54,7 +56,7 @@ final class InvoiceEmailVarsBuilder
             ),
             'days_overdue'   => $daysOverdue,
             'subject'        => $subject,
-            'qr_data_uri'    => $this->generateQr($invoice),
+            'qr_data_uri'    => $this->paymentQrDataUri($invoice),
             'supplier'       => $this->loadSupplierFooter($invoice),
             'is_test'        => false,
             'is_paid'        => ($invoice['status'] ?? '') === 'paid',
@@ -111,14 +113,22 @@ final class InvoiceEmailVarsBuilder
             'amount_to_pay'  => $amount,
             'is_test'        => $isTest,
             'subject'        => $this->buildSubject($invoice, $isTest, $locale),
-            'qr_data_uri'    => $this->generateQr($invoice),
+            'qr_data_uri'    => $this->paymentQrDataUri($invoice),
             'supplier'       => $this->loadSupplierFooter($invoice),
             'is_paid'        => ($invoice['status'] ?? '') === 'paid',
             'payment_method' => (string) ($invoice['payment_method'] ?? 'bank_transfer'),
+            // Trvalý odkaz na web fakturu do e-mailu; token vzniká lazy při
+            // prvním odeslání. Null pro draft (test e-mail) a bez app.url.
+            'public_url'     => $this->publicLinks->ensureUrl($invoice),
         ];
     }
 
-    private function generateQr(array $invoice): ?string
+    /**
+     * QR platba pro zbývající částku — public: kromě e-mailů ho používá i veřejná
+     * web faktura (PublicInvoiceGetAction). Bank z snapshot (issued+) nebo live
+     * z currencies; null když není co platit / jiná platební metoda.
+     */
+    public function paymentQrDataUri(array $invoice): ?string
     {
         // QR na zbývající částku — po částečné úhradě (#89) se platí jen zbytek.
         $remaining = round((float) ($invoice['amount_to_pay'] ?? 0) - (float) ($invoice['paid_total'] ?? 0), 2);

--- a/api/src/Service/Pdf/InvoicePdfRenderer.php
+++ b/api/src/Service/Pdf/InvoicePdfRenderer.php
@@ -350,7 +350,12 @@ final class InvoicePdfRenderer
         ]);
     }
 
-    private function resolveSupplier(array $invoice): array
+    /**
+     * resolveSupplier/resolveClient/resolveBank jsou public — kromě PDF renderu
+     * je používá i veřejná web faktura (PublicInvoiceGetAction), aby HTML náhled
+     * ukazoval STEJNÁ data jako PDF (snapshot-first s defensive merge).
+     */
+    public function resolveSupplier(array $invoice): array
     {
         $live = $this->getSupplierData((int) ($invoice['supplier_id'] ?? 0));
         if (!empty($invoice['supplier_snapshot'])) {
@@ -365,7 +370,7 @@ final class InvoicePdfRenderer
         return $live;
     }
 
-    private function resolveClient(array $invoice): array
+    public function resolveClient(array $invoice): array
     {
         // Defensive merge: snapshot je primární (historický stav), live data
         // doplní chybějící klíče. Bez merge by legacy/cizí snapshoty (import
@@ -389,7 +394,7 @@ final class InvoicePdfRenderer
         return $live;
     }
 
-    private function resolveBank(array $invoice): ?array
+    public function resolveBank(array $invoice): ?array
     {
         // Live data z currencies (account/bank/IBAN/BIC podle currency_id).
         // Stejný defensive-merge pattern jako u supplier/client — snapshot vyhrává,

--- a/api/templates/email/invoice_send.cs.html.twig
+++ b/api/templates/email/invoice_send.cs.html.twig
@@ -87,8 +87,20 @@
 </table>
 {% endif %}
 
+{% if public_url %}
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center" style="margin:24px auto 8px;">
+  <tr>
+    <td align="center" bgcolor="#3B2D83" style="background:{{ accent }};border-radius:8px;mso-padding-alt:12px 28px;">
+      <a href="{{ public_url }}"
+         style="display:inline-block;padding:12px 28px;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:600;line-height:1;color:#ffffff;text-decoration:none;border-radius:8px;">Zobrazit fakturu online</a>
+    </td>
+  </tr>
+</table>
+{% endif %}
+
 <p style="margin:16px 0 8px;font-size:14px;color:#5A5470;">
-  Faktura v PDF je v příloze tohoto emailu{% if qr_data_uri %}, platbu lze provést naskenováním QR kódu výše{% endif %}.
+  Faktura v PDF je v příloze tohoto emailu{% if qr_data_uri %}, platbu lze provést naskenováním QR kódu výše{% endif %}.{% if public_url %} Online verzi faktury najdete kdykoli na
+  <a href="{{ public_url }}" style="color:{{ accent }};word-break:break-all;">tomto odkazu</a>.{% endif %}
 </p>
 
 {% if not is_test %}

--- a/api/templates/email/invoice_send.cs.txt.twig
+++ b/api/templates/email/invoice_send.cs.txt.twig
@@ -22,6 +22,9 @@ Splatnost:         {{ invoice.due_date|date('j.n.Y') }}
 {% elseif payment_method == 'cash' %}>>> Úhrada v hotovosti.
 
 {% endif %}Faktura v PDF je v příloze tohoto emailu.
+{% if public_url %}
+Fakturu si můžete kdykoli zobrazit online: {{ public_url }}
+{% endif %}
 
 {% if not is_test %}Děkujeme za spolupráci.
 {% else %}=== TEST EMAIL — klient ho nedostal. ==={% endif %}

--- a/api/templates/email/invoice_send.en.html.twig
+++ b/api/templates/email/invoice_send.en.html.twig
@@ -87,8 +87,20 @@
 </table>
 {% endif %}
 
+{% if public_url %}
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" align="center" style="margin:24px auto 8px;">
+  <tr>
+    <td align="center" bgcolor="#3B2D83" style="background:{{ accent }};border-radius:8px;mso-padding-alt:12px 28px;">
+      <a href="{{ public_url }}"
+         style="display:inline-block;padding:12px 28px;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:600;line-height:1;color:#ffffff;text-decoration:none;border-radius:8px;">View invoice online</a>
+    </td>
+  </tr>
+</table>
+{% endif %}
+
 <p style="margin:16px 0 8px;font-size:14px;color:#5A5470;">
-  The invoice PDF is attached{% if qr_data_uri %}; you can pay by scanning the QR code above{% endif %}.
+  The invoice PDF is attached{% if qr_data_uri %}; you can pay by scanning the QR code above{% endif %}.{% if public_url %} The online version of the invoice is always available at
+  <a href="{{ public_url }}" style="color:{{ accent }};word-break:break-all;">this link</a>.{% endif %}
 </p>
 
 {% if not is_test %}

--- a/api/templates/email/invoice_send.en.txt.twig
+++ b/api/templates/email/invoice_send.en.txt.twig
@@ -22,6 +22,9 @@ Due date:        {{ invoice.due_date|date('M j, Y') }}
 {% elseif payment_method == 'cash' %}>>> Cash payment.
 
 {% endif %}The invoice PDF is attached.
+{% if public_url %}
+You can view the invoice online anytime: {{ public_url }}
+{% endif %}
 
 {% if not is_test %}Thank you for your business.
 {% else %}=== TEST EMAIL — client did not receive it. ==={% endif %}

--- a/api/tests/Unit/Action/Invoice/PublicInvoicePayloadTest.php
+++ b/api/tests/Unit/Action/Invoice/PublicInvoicePayloadTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Action\Invoice;
+
+use MyInvoice\Action\Invoice\PublicInvoiceGetAction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Web faktura (migrace 0133) — whitelist veřejného payloadu.
+ *
+ * buildPayload() je jediné místo, které rozhoduje, co veřejný endpoint
+ * GET /api/public/invoice/{token} prozradí. Test hlídá, že se do payloadu
+ * NEdostanou tokeny, snapshoty, interní vazby ani kontaktní údaje klienta —
+ * a naopak že pole potřebná pro vykreslení faktury projdou.
+ *
+ * Čistě unit — buildPayload je pure static function (bez DB).
+ */
+final class PublicInvoicePayloadTest extends TestCase
+{
+    /** Řádek faktury tak, jak ho vrací InvoiceRepository::find() — vč. interních polí. */
+    private function invoiceRow(): array
+    {
+        return [
+            'id'                 => 42,
+            'supplier_id'        => 1,
+            'client_id'          => 7,
+            'project_id'         => 3,
+            'created_by'         => 1,
+            'varsymbol'          => '20260042',
+            'invoice_type'       => 'invoice',
+            'status'             => 'sent',
+            'payment_status'     => 'unpaid',
+            'language'           => 'cs',
+            'currency'           => 'CZK',
+            'currency_symbol'    => 'Kč',
+            'currency_decimals'  => 2,
+            'issue_date'         => '2026-07-01',
+            'tax_date'           => '2026-07-01',
+            'due_date'           => '2026-07-15',
+            'paid_at'            => null,
+            'payment_method'     => 'bank_transfer',
+            'reverse_charge'     => false,
+            'prices_include_vat' => false,
+            'note_above_items'   => 'Fakturujeme Vám za služby.',
+            'note_below_items'   => null,
+            'amount_to_pay'      => 12100.0,
+            'paid_total'         => 0.0,
+            'advance_paid_amount'=> 0.0,
+            'total_without_vat'  => 10000.0,
+            'total_vat'          => 2100.0,
+            'total_with_vat'     => 12100.0,
+            'rounding'           => 0.0,
+            'totals'             => ['without_vat' => 10000.0, 'vat' => 2100.0, 'with_vat' => 12100.0],
+            'vat_breakdown'      => [['rate' => 21.0, 'base' => 10000.0, 'vat' => 2100.0, 'total' => 12100.0]],
+            'czk_recap'          => null,
+            // interní pole, která NESMÍ projít ven
+            'approval_token'     => str_repeat('a', 48),
+            'public_token'       => str_repeat('b', 48),
+            'public_viewed_at'   => null,
+            'client_main_email'  => 'klient@example.com',
+            'client_snapshot'    => '{"company_name":"Klient s.r.o."}',
+            'supplier_snapshot'  => '{"company_name":"Dodavatel s.r.o."}',
+            'bank_snapshot'      => '{"account_number":"1000000005"}',
+            'pdf_path'           => 'storage/pdf/faktura.pdf',
+            'items'              => [[
+                'id'                     => 1001,
+                'invoice_id'             => 42,
+                'description'            => 'Vývoj software',
+                'quantity'               => 10.0,
+                'unit'                   => 'hod',
+                'unit_price_without_vat' => 1000.0,
+                'vat_rate_id'            => 1,
+                'vat_rate_snapshot'      => 21.0,
+                'total_without_vat'      => 10000.0,
+                'total_vat'              => 2100.0,
+                'total_with_vat'         => 12100.0,
+                'order_index'            => 0,
+                'item_kind'              => 'standard',
+                'linked_work_report_id'  => 55,
+            ]],
+        ];
+    }
+
+    private function payload(): array
+    {
+        return PublicInvoiceGetAction::buildPayload(
+            $this->invoiceRow(),
+            [
+                'company_name' => 'Dodavatel s.r.o.',
+                'ic'           => '12345678',
+                'dic'          => 'CZ12345678',
+                'is_vat_payer' => 1,
+                'street'       => 'Ulice 1',
+                'city'         => 'Praha',
+                'zip'          => '11000',
+                'email'        => 'info@dodavatel.cz',
+                // interní / citlivá pole z supplier řádku
+                'id'                     => 1,
+                'logo_path'              => 'storage/logo/1.png',
+                'email_branding_enabled' => 1,
+                'smtp_password'          => 'tajne',
+            ],
+            [
+                'company_name' => 'Klient s.r.o.',
+                'ic'           => '87654321',
+                'street'       => 'Náměstí 2',
+                'city'         => 'Brno',
+                'zip'          => '60200',
+                // interní pole z clients řádku (resolveClient dělá SELECT c.*)
+                'id'           => 7,
+                'main_email'   => 'klient@example.com',
+                'phone'        => '+420777888999',
+                'note'         => 'interní poznámka ke klientovi',
+            ],
+            ['account_number' => '1000000005', 'bank_code' => '0100', 'bank_name' => 'KB', 'iban' => null, 'bic' => null],
+            'data:image/png;base64,QR',
+        );
+    }
+
+    public function testContainsFieldsNeededForRendering(): void
+    {
+        $p = $this->payload();
+
+        self::assertSame('20260042', $p['invoice']['varsymbol']);
+        self::assertSame('sent', $p['invoice']['status']);
+        self::assertSame(12100.0, $p['invoice']['amount_to_pay']);
+        self::assertSame('Vývoj software', $p['invoice']['items'][0]['description']);
+        self::assertSame(21.0, $p['invoice']['items'][0]['vat_rate_snapshot']);
+        self::assertNotEmpty($p['invoice']['vat_breakdown']);
+        self::assertSame('Dodavatel s.r.o.', $p['supplier']['company_name']);
+        self::assertSame('CZ12345678', $p['supplier']['dic']);
+        self::assertSame('Klient s.r.o.', $p['client']['company_name']);
+        self::assertSame('1000000005', $p['bank']['account_number']);
+        self::assertSame('data:image/png;base64,QR', $p['qr_data_uri']);
+    }
+
+    public function testDoesNotLeakInternalInvoiceFields(): void
+    {
+        $inv = $this->payload()['invoice'];
+
+        foreach ([
+            'id', 'supplier_id', 'client_id', 'project_id', 'created_by',
+            'approval_token', 'public_token', 'public_viewed_at',
+            'client_main_email', 'client_snapshot', 'supplier_snapshot',
+            'bank_snapshot', 'pdf_path',
+        ] as $forbidden) {
+            self::assertArrayNotHasKey($forbidden, $inv, "Interní pole '$forbidden' nesmí být ve veřejném payloadu");
+        }
+
+        foreach (['id', 'invoice_id', 'vat_rate_id', 'linked_work_report_id'] as $forbidden) {
+            self::assertArrayNotHasKey($forbidden, $inv['items'][0], "Interní pole položky '$forbidden' nesmí být ve veřejném payloadu");
+        }
+    }
+
+    public function testDoesNotLeakInternalPartyFields(): void
+    {
+        $p = $this->payload();
+
+        foreach (['id', 'logo_path', 'email_branding_enabled', 'smtp_password'] as $forbidden) {
+            self::assertArrayNotHasKey($forbidden, $p['supplier'], "Pole dodavatele '$forbidden' nesmí být ve veřejném payloadu");
+        }
+        foreach (['id', 'main_email', 'phone', 'note'] as $forbidden) {
+            self::assertArrayNotHasKey($forbidden, $p['client'], "Pole klienta '$forbidden' nesmí být ve veřejném payloadu");
+        }
+    }
+
+    public function testBankNullPassesThrough(): void
+    {
+        $p = PublicInvoiceGetAction::buildPayload($this->invoiceRow(), [], [], null, null);
+        self::assertNull($p['bank']);
+        self::assertNull($p['qr_data_uri']);
+    }
+}

--- a/api/tests/Unit/Action/Invoice/PublicInvoicePayloadTest.php
+++ b/api/tests/Unit/Action/Invoice/PublicInvoicePayloadTest.php
@@ -116,6 +116,17 @@ final class PublicInvoicePayloadTest extends TestCase
             ],
             ['account_number' => '1000000005', 'bank_code' => '0100', 'bank_name' => 'KB', 'iban' => null, 'bic' => null],
             'data:image/png;base64,QR',
+            [[
+                'id'            => 9,
+                'invoice_id'    => 42,
+                'filename'      => 'att_9_abcdef.pdf',
+                'original_name' => 'Smlouva.pdf',
+                'size_bytes'    => 12345,
+                'sha256'        => str_repeat('c', 64),
+                'mime_type'     => 'application/pdf',
+                'uploaded_by'   => 1,
+                'uploaded_at'   => '2026-07-01 10:00:00',
+            ]],
         );
     }
 
@@ -166,10 +177,24 @@ final class PublicInvoicePayloadTest extends TestCase
         }
     }
 
+    public function testAttachmentsWhitelisted(): void
+    {
+        $atts = $this->payload()['attachments'];
+
+        self::assertCount(1, $atts);
+        self::assertSame('Smlouva.pdf', $atts[0]['original_name']);
+        self::assertSame(9, $atts[0]['id']);
+        self::assertSame(12345, $atts[0]['size_bytes']);
+        foreach (['filename', 'sha256', 'uploaded_by', 'uploaded_at', 'invoice_id', 'mime_type'] as $forbidden) {
+            self::assertArrayNotHasKey($forbidden, $atts[0], "Pole přílohy '$forbidden' nesmí být ve veřejném payloadu");
+        }
+    }
+
     public function testBankNullPassesThrough(): void
     {
         $p = PublicInvoiceGetAction::buildPayload($this->invoiceRow(), [], [], null, null);
         self::assertNull($p['bank']);
         self::assertNull($p['qr_data_uri']);
+        self::assertSame([], $p['attachments']);
     }
 }

--- a/db/migrations/0133_invoice_public_links.sql
+++ b/db/migrations/0133_invoice_public_links.sql
@@ -1,0 +1,20 @@
+-- 0133: Web faktura — trvalý veřejný odkaz na vystavenou fakturu.
+--
+-- Klient dostane odkaz /invoice/{token}, kde si fakturu bez přihlášení prohlédne
+-- v HTML a stáhne PDF (vzor Fakturoid „web faktura"). Token se generuje lazy
+-- (první použití v UI / při odeslání e-mailu) jako bin2hex(random_bytes(24))
+-- → 48 hex znaků (vzor invoices.approval_token, migrace 0002).
+--
+--   public_token      — tajný token veřejného odkazu; NULL = odkaz zatím nevznikl.
+--                       Regenerace (revokace) = přepsání novým tokenem.
+--   public_viewed_at  — poslední zobrazení klientem (anonymní přístup); indikace
+--                       „zobrazeno klientem" v detailu faktury.
+--
+-- Idempotent přes MariaDB native `IF NOT EXISTS` guards (projekt vyžaduje 10.6+).
+
+SET NAMES utf8mb4;
+
+ALTER TABLE invoices
+  ADD COLUMN IF NOT EXISTS public_token CHAR(48) NULL DEFAULT NULL AFTER pdf_generated_at,
+  ADD COLUMN IF NOT EXISTS public_viewed_at DATETIME NULL DEFAULT NULL AFTER public_token,
+  ADD UNIQUE KEY IF NOT EXISTS uq_inv_public_token (public_token);

--- a/manual/11_Faktura_PDF.md
+++ b/manual/11_Faktura_PDF.md
@@ -255,6 +255,7 @@ z Fakturoidu.
 
 Veřejná stránka zobrazuje jen to, co je na PDF faktury: dodavatele, odběratele,
 položky, součty s rozpadem DPH, platební údaje s QR kódem a poznámky z dokladu.
+Klient si stáhne i **přílohy e-mailu** nahrané k faktuře (smlouva, výkaz…).
 Stav úhrady se ukazuje živě (Uhrazeno / Částečně uhrazeno / Po splatnosti).
 Koncepty veřejný odkaz nemají — stránka je dostupná až po vystavení dokladu.
 

--- a/manual/11_Faktura_PDF.md
+++ b/manual/11_Faktura_PDF.md
@@ -27,10 +27,10 @@ Závisí na stavu faktury:
 
 | Stav | Dostupné akce |
 |---|---|
-| `issued` | Stáhnout PDF, Odeslat e-mailem, Označit zaplacené, Částečná úhrada, Storno, Dobropis, Test odeslání, Test upomínky, **Editovat (force)** |
-| `sent` | Stáhnout PDF, Odeslat znovu, Označit zaplacené, Částečná úhrada, Upomínka, Dobropis |
-| `reminded` | Stáhnout PDF, Další upomínka (cooldown 14 dní), Označit zaplacené, Částečná úhrada |
-| `paid` | Stáhnout PDF, Dobropis (vrátit peníze) |
+| `issued` | Stáhnout PDF, Odeslat e-mailem, Web faktura, Označit zaplacené, Částečná úhrada, Storno, Dobropis, Test odeslání, Test upomínky, **Editovat (force)** |
+| `sent` | Stáhnout PDF, Odeslat znovu, Web faktura, Označit zaplacené, Částečná úhrada, Upomínka, Dobropis |
+| `reminded` | Stáhnout PDF, Další upomínka (cooldown 14 dní), Web faktura, Označit zaplacené, Částečná úhrada |
+| `paid` | Stáhnout PDF, Web faktura, Dobropis (vrátit peníze) |
 
 > 💡 **Test odeslání / Test upomínky** — pošle e-mail jen na **tvůj** e-mail
 > (ne klientovi). Užitečné pro vyzkoušení šablony nebo SMTP konfigurace.
@@ -232,7 +232,37 @@ běžném e-mailovém klientovi.
 
 Detail nastavení je v [kapitole 28. Elektronické podpisy](38_Elektronicke_podpisy.md).
 
-## 11.5 Historie PDF
+## 11.5 Web faktura (trvalý veřejný odkaz)
+
+Každá **vystavená** faktura (i proforma či dobropis) může mít trvalý veřejný
+odkaz ve tvaru `https://vase-domena/invoice/{token}` — klient si na něm fakturu
+**bez přihlášení** prohlédne v prohlížeči a stáhne PDF. Obdoba „web faktury"
+z Fakturoidu.
+
+- **Otevření** — v detailu faktury tlačítko **Web faktura**. První použití
+  odkaz vytvoří (token se generuje lazy), další otevření vrací tentýž odkaz.
+- **Kopírovat / Otevřít** — v modalu lze odkaz zkopírovat do schránky nebo
+  rovnou otevřít v novém panelu.
+- **E-mail klientovi** — odkaz se automaticky vkládá do e-mailu při akci
+  **Odeslat e-mailem** (tlačítko „Zobrazit fakturu online" + textový odkaz).
+- **Zobrazeno klientem** — první anonymní návštěva stránky se zapíše; v detailu
+  faktury se pak ukazuje badge **👁 Zobrazeno klientem** (datum posledního
+  zobrazení je v modalu Web faktury a v historii akcí, včetně stažení PDF).
+  Náhled přihlášeného uživatele indikaci neovlivní.
+- **Vygenerovat nový odkaz** — revokace: stávající URL okamžitě přestane
+  platit (hodí se při úniku odkazu nesprávnému příjemci). Nový odkaz se pak
+  posílá i v dalších e-mailech.
+
+Veřejná stránka zobrazuje jen to, co je na PDF faktury: dodavatele, odběratele,
+položky, součty s rozpadem DPH, platební údaje s QR kódem a poznámky z dokladu.
+Stav úhrady se ukazuje živě (Uhrazeno / Částečně uhrazeno / Po splatnosti).
+Koncepty veřejný odkaz nemají — stránka je dostupná až po vystavení dokladu.
+
+> 🔒 Odkaz obsahuje 48znakový náhodný token — nelze ho uhodnout ani odvodit.
+> Kdo odkaz má, fakturu vidí; pokud se dostal do nesprávných rukou, vygenerujte
+> nový odkaz (starý tím zneplatníte).
+
+## 11.6 Historie PDF
 
 V detailu faktury je sekce **Historie PDF** — seznam všech archivovaných
 verzí PDF, které tato faktura kdy měla:
@@ -259,12 +289,12 @@ U odeslaných verzí navíc vidíš **kam to šlo** (seznam příjemců).
 > Pokud potřebuješ ušetřit místo, použij ruční smazání jen u
 > neodeslaných invalidačních verzí (zatím není UI; přes SQL).
 
-## 11.6 Admin akce nad vystavenou fakturou
+## 11.7 Admin akce nad vystavenou fakturou
 
 Sekce **Další akce** v detailu faktury skrývá několik nástrojů, které jsou
 přístupné jen adminovi a používají se v krajních případech.
 
-### 11.6.1 Editace vystavené faktury (force=1)
+### 11.7.1 Editace vystavené faktury (force=1)
 
 V krajní nouzi (admin udělal v vystavené faktuře překlep, klient ji ještě
 nedostal):
@@ -281,7 +311,7 @@ nedostal):
 > 🛈 **Var. symbol je immutable** — force-edit ho NEzmění. Pokud chceš číslo
 > změnit, vystav storno/dobropis a fakturu znovu pod novým číslem.
 
-### 11.6.2 Nezaplacené (vrátit ze stavu paid)
+### 11.7.2 Nezaplacené (vrátit ze stavu paid)
 
 Tlačítko **Nezaplacené** je viditelné jen u faktur ve stavu `paid` (admin only).
 Vrátí fakturu ze stavu zaplacené zpět do `sent` (pokud byla odeslaná) nebo
@@ -301,7 +331,7 @@ Použití:
 
 Activity log: `invoice.unmark_paid` s `previous_paid_at` pro forenzní stopu.
 
-### 11.6.3 Smazání vystavené faktury (force-delete, admin)
+### 11.7.3 Smazání vystavené faktury (force-delete, admin)
 
 Force-delete je 3. možnost ve **Storno / Dobropis** modalu (otevřeš tlačítkem
 „Storno / Dobropis" v detailu vystavené faktury). Volby v modalu:
@@ -338,7 +368,7 @@ alternativou (storno / dobropis / Nezaplacené).
 > 💡 **Typický legální use case:** vystavil jsi fakturu omylem (jiný klient,
 > špatná částka) a klient ji ještě nedostal. Pokud už dostal, vystav dobropis.
 
-## 11.7 Změna bankovního účtu po vystavení
+## 11.8 Změna bankovního účtu po vystavení
 
 Pokud změníš bankovní účet v **Systém → Číselníky → Měny**, automaticky se
 **invalidují PDF všech faktur**, které renderují bank info live (drafty +
@@ -348,7 +378,7 @@ už dostal).
 
 V activity logu uvidíš `currency.updated` s počtem invalidovaných PDF.
 
-## 11.8 Tipy
+## 11.9 Tipy
 
 - **PDF náhled v iframe na detailu** se neobnoví automaticky po editaci —
   refreshni stránku (F5).

--- a/web/src/api/invoices.ts
+++ b/web/src/api/invoices.ts
@@ -142,6 +142,10 @@ export interface Invoice {
   approval_reminder_at: string | null
   approval_reminder_count: number
   project_requires_approval?: boolean
+  /** Token trvalého veřejného odkazu „web faktura" (/invoice/{token}); null dokud odkaz nevznikl. */
+  public_token: string | null
+  /** Poslední zobrazení web faktury klientem (anonymní přístup); null = zatím nezobrazeno. */
+  public_viewed_at: string | null
   sent_at: string | null
   last_reminder_at: string | null
   reminder_count: number
@@ -568,6 +572,19 @@ export const invoicesApi = {
   requestApprovalTest: (id: number) =>
     api.post<{ sent_to: string[]; sent_at: string; is_test: true }>(
       `/invoices/${id}/request-approval-test`,
+      {},
+    ).then(r => r.data),
+
+  // Web faktura — trvalý veřejný odkaz (ensure = idempotentní vytvoření + URL)
+  publicLink: (id: number) =>
+    api.post<{ url: string; token: string; public_viewed_at: string | null }>(
+      `/invoices/${id}/public-link`,
+      {},
+    ).then(r => r.data),
+
+  regeneratePublicLink: (id: number) =>
+    api.post<{ url: string; token: string; public_viewed_at: null }>(
+      `/invoices/${id}/public-link/regenerate`,
       {},
     ).then(r => r.data),
 

--- a/web/src/api/publicInvoice.ts
+++ b/web/src/api/publicInvoice.ts
@@ -1,0 +1,117 @@
+import axios from 'axios'
+
+// Samostatný axios klient — web faktura je veřejná (bez přihlášení), proto
+// neimplementujeme 401 redirect na /login (to dělá @/api/client). Vzor approval.ts,
+// ale bez Accept-Language interceptoru: anonymní návštěvník nemá v localStorage
+// smysluplnou volbu jazyka — prohlížeč pošle vlastní Accept-Language sám a jazyk
+// obsahu se řídí invoice.language z dat.
+const publicApi = axios.create({
+  baseURL: '/api/public',
+  withCredentials: false,
+  headers: {
+    'Accept': 'application/json',
+  },
+})
+
+export interface PublicInvoiceItem {
+  description: string
+  quantity: number
+  unit: string | null
+  unit_price_without_vat: number
+  vat_rate_snapshot: number
+  total_without_vat: number
+  total_with_vat: number
+  item_kind: 'standard' | 'discount' | string
+}
+
+export interface PublicInvoiceVatRow {
+  vat_rate_id: number
+  rate: number
+  base: number
+  vat: number
+  total: number
+}
+
+export interface PublicInvoiceHeader {
+  varsymbol: string | null
+  invoice_type: 'invoice' | 'proforma' | 'credit_note' | 'cancellation' | 'tax_document'
+  status: 'issued' | 'sent' | 'reminded' | 'paid' | 'cancelled'
+  payment_status: 'unpaid' | 'partially_paid' | 'paid' | 'overpaid' | null
+  language: 'cs' | 'en'
+  currency: string
+  currency_decimals?: number | null
+  issue_date: string
+  tax_date: string | null
+  due_date: string
+  paid_at: string | null
+  payment_method: 'bank_transfer' | 'card' | 'cash' | 'other'
+  reverse_charge: boolean
+  prices_include_vat: boolean
+  note_above_items: string | null
+  note_below_items: string | null
+  amount_to_pay: number
+  paid_total: number
+  totals: {
+    without_vat: number
+    vat: number
+    with_vat: number
+    rounding: number
+    advance_paid_amount: number
+    amount_to_pay: number
+    discount_percent: number
+    discount_amount: number
+  }
+  vat_breakdown: PublicInvoiceVatRow[]
+  czk_recap: {
+    rate: number
+    rate_date: string
+    fallback_used: boolean
+    total_without_vat_czk: number
+    total_vat_czk: number
+    total_with_vat_czk: number
+  } | null
+  items: PublicInvoiceItem[]
+}
+
+export interface PublicInvoiceParty {
+  company_name?: string | null
+  first_name?: string | null
+  last_name?: string | null
+  street?: string | null
+  city?: string | null
+  zip?: string | null
+  country_name_cs?: string | null
+  country_name_en?: string | null
+  country_iso2?: string | null
+  ic?: string | null
+  dic?: string | null
+  tax_number?: string | null
+  is_vat_payer?: boolean | number | null
+  commercial_register?: string | null
+  email?: string | null
+  web?: string | null
+}
+
+export interface PublicInvoiceBank {
+  account_number: string | null
+  bank_code: string | null
+  bank_name: string | null
+  iban: string | null
+  bic: string | null
+}
+
+export interface PublicInvoiceData {
+  invoice: PublicInvoiceHeader
+  supplier: PublicInvoiceParty
+  client: PublicInvoiceParty
+  bank: PublicInvoiceBank | null
+  qr_data_uri: string | null
+}
+
+export const publicInvoiceApi = {
+  get: (token: string) =>
+    publicApi.get<PublicInvoiceData>(`/invoice/${token}`).then(r => r.data),
+
+  pdfUrl: (token: string, download: boolean = false) =>
+    `/api/public/invoice/${token}/pdf${download ? '?download=1' : ''}`,
+}

--- a/web/src/api/publicInvoice.ts
+++ b/web/src/api/publicInvoice.ts
@@ -100,12 +100,19 @@ export interface PublicInvoiceBank {
   bic: string | null
 }
 
+export interface PublicInvoiceAttachment {
+  id: number
+  original_name: string
+  size_bytes: number
+}
+
 export interface PublicInvoiceData {
   invoice: PublicInvoiceHeader
   supplier: PublicInvoiceParty
   client: PublicInvoiceParty
   bank: PublicInvoiceBank | null
   qr_data_uri: string | null
+  attachments: PublicInvoiceAttachment[]
 }
 
 export const publicInvoiceApi = {
@@ -114,4 +121,7 @@ export const publicInvoiceApi = {
 
   pdfUrl: (token: string, download: boolean = false) =>
     `/api/public/invoice/${token}/pdf${download ? '?download=1' : ''}`,
+
+  attachmentUrl: (token: string, attId: number) =>
+    `/api/public/invoice/${token}/attachment/${attId}`,
 }

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -1205,6 +1205,7 @@
       "public_link_regenerated": "Web faktura — vygenerován nový odkaz",
       "public_viewed": "Klient zobrazil web fakturu",
       "public_pdf_downloaded": "Klient stáhl PDF z web faktury",
+      "public_attachment_downloaded": "Klient stáhl přílohu z web faktury",
       "proforma_final_issued": "Vystaven daňový doklad k záloze"
     },
     "approval": {

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -1201,6 +1201,10 @@
       "approval_approved": "Schváleno zákazníkem",
       "approval_rejected": "Zamítnuto zákazníkem",
       "approval_reset": "Stav schválení resetován",
+      "public_link_created": "Web faktura — odkaz vytvořen",
+      "public_link_regenerated": "Web faktura — vygenerován nový odkaz",
+      "public_viewed": "Klient zobrazil web fakturu",
+      "public_pdf_downloaded": "Klient stáhl PDF z web faktury",
       "proforma_final_issued": "Vystaven daňový doklad k záloze"
     },
     "approval": {
@@ -1240,6 +1244,26 @@
       "approved_and_sent": "Schváleno. Faktura odeslána na: {recipients}",
       "auto_send_failed": "Schválení proběhlo, ale auto-odeslání faktury selhalo: {error}",
       "status_update_failed": "Změna stavu selhala"
+    },
+    "public_link": {
+      "btn": "Web faktura",
+      "btn_title": "Trvalý veřejný odkaz na fakturu pro klienta",
+      "modal_title": "Web faktura",
+      "modal_hint": "Trvalý veřejný odkaz — klient si na něm fakturu bez přihlášení prohlédne v prohlížeči a stáhne PDF.",
+      "copy": "Kopírovat",
+      "copied": "Odkaz zkopírován do schránky",
+      "copy_failed": "Kopírování se nepodařilo — zkopírujte odkaz ručně",
+      "open": "Otevřít",
+      "regenerate": "Vygenerovat nový odkaz",
+      "regenerate_title": "Stávající odkaz přestane platit",
+      "regenerate_confirm": "Vygenerovat nový odkaz? Stávající odkaz okamžitě přestane platit (hodí se např. při úniku URL nesprávnému příjemci).",
+      "regenerated": "Nový odkaz vygenerován — původní přestal platit",
+      "regenerate_failed": "Nový odkaz se nepodařilo vygenerovat",
+      "viewed_at": "Klient fakturu zobrazil: {date}",
+      "not_viewed": "Klient fakturu zatím nezobrazil",
+      "viewed_badge": "Zobrazeno klientem",
+      "load_failed": "Web fakturu se nepodařilo načíst",
+      "email_note": "Odkaz se automaticky vkládá do e-mailu při odeslání faktury klientovi."
     },
     "bulk_reissue_failed": "Hromadné klonování selhalo",
     "bulk_send_partial": "Odesláno: {ok}, chyby: {err}",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -1201,6 +1201,10 @@
       "approval_approved": "Approved by customer",
       "approval_rejected": "Rejected by customer",
       "approval_reset": "Approval status reset",
+      "public_link_created": "Web invoice — link created",
+      "public_link_regenerated": "Web invoice — new link generated",
+      "public_viewed": "Client viewed the web invoice",
+      "public_pdf_downloaded": "Client downloaded the PDF from the web invoice",
       "proforma_final_issued": "Final tax document issued from proforma"
     },
     "approval": {
@@ -1240,6 +1244,26 @@
       "approved_and_sent": "Approved. Invoice sent to: {recipients}",
       "auto_send_failed": "Approval succeeded but auto-sending the invoice failed: {error}",
       "status_update_failed": "Status change failed"
+    },
+    "public_link": {
+      "btn": "Web invoice",
+      "btn_title": "Permanent public link to the invoice for the client",
+      "modal_title": "Web invoice",
+      "modal_hint": "Permanent public link — the client can view the invoice in a browser and download the PDF without signing in.",
+      "copy": "Copy",
+      "copied": "Link copied to clipboard",
+      "copy_failed": "Copy failed — please copy the link manually",
+      "open": "Open",
+      "regenerate": "Generate new link",
+      "regenerate_title": "The current link will stop working",
+      "regenerate_confirm": "Generate a new link? The current link will stop working immediately (useful e.g. when the URL leaked to a wrong recipient).",
+      "regenerated": "New link generated — the previous one no longer works",
+      "regenerate_failed": "Failed to generate a new link",
+      "viewed_at": "Client viewed the invoice: {date}",
+      "not_viewed": "Client has not viewed the invoice yet",
+      "viewed_badge": "Viewed by client",
+      "load_failed": "Failed to load the web invoice",
+      "email_note": "The link is automatically included in the email when the invoice is sent to the client."
     },
     "bulk_reissue_failed": "Bulk clone failed",
     "bulk_send_partial": "Sent: {ok}, errors: {err}",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -1205,6 +1205,7 @@
       "public_link_regenerated": "Web invoice — new link generated",
       "public_viewed": "Client viewed the web invoice",
       "public_pdf_downloaded": "Client downloaded the PDF from the web invoice",
+      "public_attachment_downloaded": "Client downloaded an attachment from the web invoice",
       "proforma_final_issued": "Final tax document issued from proforma"
     },
     "approval": {

--- a/web/src/pages/InvoicePublic.vue
+++ b/web/src/pages/InvoicePublic.vue
@@ -99,6 +99,15 @@ const showPayPanel = computed(() =>
 
 const pdfUrl = computed(() => publicInvoiceApi.pdfUrl(token.value, true))
 
+function attachmentUrl(attId: number): string {
+  return publicInvoiceApi.attachmentUrl(token.value, attId)
+}
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} kB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
 onMounted(async () => {
   try {
     data.value = await publicInvoiceApi.get(token.value)
@@ -354,6 +363,25 @@ onMounted(async () => {
             </div>
 
             <div v-if="inv.note_below_items" class="px-6 pb-4 text-sm text-neutral-600 whitespace-pre-wrap">{{ inv.note_below_items }}</div>
+          </div>
+
+          <!-- Přílohy -->
+          <div v-if="data.attachments.length" class="bg-surface border border-neutral-200 rounded-xl shadow-sm p-6">
+            <h2 class="text-xs font-semibold uppercase tracking-wide text-neutral-500 mb-3">
+              {{ tt('Přílohy', 'Attachments') }}
+            </h2>
+            <ul class="divide-y divide-neutral-100">
+              <li v-for="a in data.attachments" :key="a.id">
+                <a :href="attachmentUrl(a.id)"
+                  class="flex items-center gap-3 py-2 group" download>
+                  <svg class="w-4 h-4 text-neutral-400 shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.172 7l-6.586 6.586a2 2 0 1 0 2.828 2.828l6.414-6.586a4 4 0 0 0-5.656-5.656l-6.415 6.585a6 6 0 1 0 8.486 8.486L20.5 13" />
+                  </svg>
+                  <span class="text-sm text-primary-700 group-hover:underline break-all">{{ a.original_name }}</span>
+                  <span class="text-xs text-neutral-500 shrink-0 ml-auto">{{ fmtBytes(a.size_bytes) }}</span>
+                </a>
+              </li>
+            </ul>
           </div>
 
           <!-- Kontakt na dodavatele -->

--- a/web/src/pages/InvoicePublic.vue
+++ b/web/src/pages/InvoicePublic.vue
@@ -1,0 +1,374 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { publicInvoiceApi, type PublicInvoiceData, type PublicInvoiceItem, type PublicInvoiceParty } from '@/api/publicInvoice'
+
+const route = useRoute()
+const token = computed(() => String(route.params.token || ''))
+
+const data = ref<PublicInvoiceData | null>(null)
+const loading = ref(true)
+const loadError = ref<string>('')
+
+const lang = computed(() => data.value?.invoice.language || 'cs')
+const inv = computed(() => data.value?.invoice ?? null)
+const isVatPayer = computed(() => !!data.value?.supplier.is_vat_payer)
+
+function tt(cs: string, en: string): string {
+  return lang.value === 'en' ? en : cs
+}
+
+const typeLabel = computed(() => {
+  switch (inv.value?.invoice_type) {
+    case 'proforma':     return tt('Zálohová faktura', 'Proforma invoice')
+    case 'credit_note':  return tt('Opravný daňový doklad', 'Credit note')
+    case 'tax_document': return tt('Daňový doklad k přijaté platbě', 'Tax document for payment received')
+    case 'cancellation': return tt('Storno doklad', 'Cancellation document')
+    default:             return isVatPayer.value ? tt('Faktura — daňový doklad', 'Invoice — tax document') : tt('Faktura', 'Invoice')
+  }
+})
+
+const isPaid = computed(() => inv.value?.status === 'paid')
+const isCancelled = computed(() => inv.value?.status === 'cancelled')
+const remaining = computed(() => {
+  if (!inv.value) return 0
+  return Math.round((inv.value.amount_to_pay - inv.value.paid_total) * 100) / 100
+})
+const isOverdue = computed(() => {
+  if (!inv.value || isPaid.value || isCancelled.value || remaining.value <= 0) return false
+  return inv.value.due_date < new Date().toISOString().slice(0, 10)
+})
+
+const statusBadge = computed(() => {
+  if (isCancelled.value) return { text: tt('Stornováno', 'Cancelled'), cls: 'bg-neutral-100 text-neutral-600' }
+  if (isPaid.value)      return { text: tt('Uhrazeno', 'Paid'), cls: 'bg-success-50 text-success-600' }
+  if (isOverdue.value)   return { text: tt('Po splatnosti', 'Overdue'), cls: 'bg-danger-50 text-danger-500' }
+  if (inv.value?.payment_status === 'partially_paid')
+    return { text: tt('Částečně uhrazeno', 'Partially paid'), cls: 'bg-warning-50 text-warning-600' }
+  return { text: tt('Neuhrazeno', 'Unpaid'), cls: 'bg-primary-50 text-primary-700' }
+})
+
+// ─── formátování (vzor ApprovalPublic) ───
+const decimals = computed(() => inv.value?.currency_decimals ?? (inv.value?.currency === 'JPY' ? 0 : 2))
+function fmtMoney(n: number, dec?: number): string {
+  const d = dec ?? decimals.value
+  const locale = lang.value === 'en' ? 'en-US' : 'cs-CZ'
+  return n.toLocaleString(locale, { minimumFractionDigits: d, maximumFractionDigits: d }) + ' ' + (inv.value?.currency || '')
+}
+function fmtQty(n: number): string {
+  const locale = lang.value === 'en' ? 'en-US' : 'cs-CZ'
+  return n.toLocaleString(locale, { maximumFractionDigits: 3 })
+}
+function fmtRate(r: number): string {
+  const locale = lang.value === 'en' ? 'en-US' : 'cs-CZ'
+  return r.toLocaleString(locale, { maximumFractionDigits: 2 }) + ' %'
+}
+function fmtDate(d: string | null): string {
+  if (!d) return ''
+  const parts = d.slice(0, 10).split('-')
+  if (parts.length !== 3) return d
+  return lang.value === 'en'
+    ? `${parts[2]}.${parts[1]}.${parts[0]}`
+    : `${Number(parts[2])}. ${Number(parts[1])}. ${parts[0]}`
+}
+
+/** V režimu „ceny s DPH" nese unit_price_without_vat brutto — netto dopočítáme z řádkového základu (vzor PDF šablony). */
+function unitPrice(it: PublicInvoiceItem): number {
+  return inv.value?.prices_include_vat && it.quantity !== 0
+    ? it.total_without_vat / it.quantity
+    : it.unit_price_without_vat
+}
+
+function partyLines(p?: PublicInvoiceParty | null): string[] {
+  if (!p) return []
+  const cityLine = [p.zip, p.city].filter(Boolean).join(' ')
+  return [p.street || '', cityLine].filter(Boolean) as string[]
+}
+function partyCountry(p?: PublicInvoiceParty | null): string {
+  if (!p) return ''
+  return String((lang.value === 'en' ? p.country_name_en : p.country_name_cs) || '')
+}
+function partyName(p?: PublicInvoiceParty | null): string {
+  if (!p) return ''
+  return String(p.company_name || [p.first_name, p.last_name].filter(Boolean).join(' '))
+}
+
+const showPayPanel = computed(() =>
+  !!inv.value && !isCancelled.value
+  && (isPaid.value || inv.value.payment_method !== 'bank_transfer' || !!data.value?.bank))
+
+const pdfUrl = computed(() => publicInvoiceApi.pdfUrl(token.value, true))
+
+onMounted(async () => {
+  try {
+    data.value = await publicInvoiceApi.get(token.value)
+    document.title = `${typeLabel.value} ${inv.value?.varsymbol || ''} — MyInvoice.cz`
+  } catch (e: any) {
+    loadError.value = e?.response?.data?.error?.message
+      || 'Tento odkaz není platný nebo byl zneplatněn. / This link is invalid or has been revoked.'
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="min-h-screen bg-neutral-50 flex flex-col">
+    <!-- Hlavička -->
+    <header class="bg-surface border-b border-neutral-200 px-4 py-3">
+      <div class="max-w-3xl mx-auto flex items-center gap-3">
+        <div class="w-8 h-8 bg-primary-600 rounded-md flex items-center justify-center text-white font-bold">M</div>
+        <div class="text-sm">
+          <div class="font-semibold">My<span class="text-primary-700">Invoice</span><span class="text-neutral-500">.cz</span></div>
+          <div class="text-xs text-neutral-500">{{ tt('Online náhled faktury', 'Online invoice view') }}</div>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1 px-4 py-8">
+      <div class="max-w-3xl mx-auto">
+
+        <!-- Loading -->
+        <div v-if="loading" class="text-center text-neutral-500 py-16">
+          {{ tt('Načítám…', 'Loading…') }}
+        </div>
+
+        <!-- Token error -->
+        <div v-else-if="loadError" class="bg-surface border border-danger-500/40 rounded-xl p-8 text-center shadow-sm">
+          <div class="text-4xl mb-3">⚠</div>
+          <h1 class="text-xl font-semibold mb-2">{{ tt('Odkaz není platný', 'Link not valid') }}</h1>
+          <p class="text-neutral-600 text-sm">{{ loadError }}</p>
+          <p class="text-xs text-neutral-500 mt-4">
+            {{ tt('Pokud máte dotaz, kontaktujte prosím dodavatele.', 'If you have a question, please contact the supplier.') }}
+          </p>
+        </div>
+
+        <div v-else-if="data && inv" class="space-y-4">
+          <!-- Hlavička dokladu + PDF -->
+          <div class="bg-surface border border-neutral-200 rounded-xl p-6 shadow-sm">
+            <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+              <div>
+                <div class="text-sm text-neutral-500">{{ typeLabel }}</div>
+                <h1 class="text-2xl font-semibold font-mono">{{ inv.varsymbol || '—' }}</h1>
+                <span class="inline-block mt-2 text-xs px-2 py-0.5 rounded font-medium" :class="statusBadge.cls">
+                  {{ statusBadge.text }}
+                </span>
+              </div>
+              <a :href="pdfUrl"
+                class="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-primary-600 hover:bg-primary-700 text-white text-sm font-semibold rounded-lg shadow-sm transition shrink-0">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                </svg>
+                {{ tt('Stáhnout PDF', 'Download PDF') }}
+              </a>
+            </div>
+            <div class="mt-4 grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-1 text-sm">
+              <div>
+                <span class="text-neutral-500 text-xs block">{{ tt('Datum vystavení', 'Issue date') }}</span>
+                {{ fmtDate(inv.issue_date) }}
+              </div>
+              <div v-if="isVatPayer && inv.tax_date && inv.invoice_type !== 'proforma'">
+                <span class="text-neutral-500 text-xs block">{{ tt('Datum zdan. plnění', 'Tax date') }}</span>
+                {{ fmtDate(inv.tax_date) }}
+              </div>
+              <div>
+                <span class="text-neutral-500 text-xs block">{{ tt('Datum splatnosti', 'Due date') }}</span>
+                <span :class="isOverdue ? 'text-danger-500 font-semibold' : ''">{{ fmtDate(inv.due_date) }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Dodavatel / odběratel -->
+          <div class="bg-surface border border-neutral-200 rounded-xl shadow-sm grid sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-neutral-200">
+            <div class="p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-wide text-neutral-500 mb-2">{{ tt('Dodavatel', 'Supplier') }}</h2>
+              <div class="font-semibold text-neutral-900">{{ partyName(data.supplier) }}</div>
+              <div class="text-sm text-neutral-600">
+                <div v-for="line in partyLines(data.supplier)" :key="line">{{ line }}</div>
+                <div v-if="partyCountry(data.supplier)">{{ partyCountry(data.supplier) }}</div>
+              </div>
+              <div class="text-sm text-neutral-600 mt-2 space-y-0.5">
+                <div v-if="data.supplier.ic"><span class="text-neutral-500">{{ tt('IČ', 'Company ID') }}:</span> {{ data.supplier.ic }}</div>
+                <div v-if="data.supplier.dic"><span class="text-neutral-500">{{ tt('DIČ', 'VAT ID') }}:</span> {{ data.supplier.dic }}</div>
+                <div v-if="!data.supplier.is_vat_payer" class="text-xs text-neutral-500">{{ tt('Neplátce DPH', 'Not a VAT payer') }}</div>
+                <div v-if="data.supplier.commercial_register" class="text-xs text-neutral-500">{{ data.supplier.commercial_register }}</div>
+              </div>
+            </div>
+            <div class="p-6">
+              <h2 class="text-xs font-semibold uppercase tracking-wide text-neutral-500 mb-2">{{ tt('Odběratel', 'Customer') }}</h2>
+              <div class="font-semibold text-neutral-900">{{ partyName(data.client) }}</div>
+              <div class="text-sm text-neutral-600">
+                <div v-for="line in partyLines(data.client)" :key="line">{{ line }}</div>
+                <div v-if="partyCountry(data.client)">{{ partyCountry(data.client) }}</div>
+              </div>
+              <div class="text-sm text-neutral-600 mt-2 space-y-0.5">
+                <div v-if="data.client.ic"><span class="text-neutral-500">{{ tt('IČ', 'Company ID') }}:</span> {{ data.client.ic }}</div>
+                <div v-if="data.client.dic"><span class="text-neutral-500">{{ tt('DIČ', 'VAT ID') }}:</span> {{ data.client.dic }}</div>
+                <div v-if="data.client.tax_number"><span class="text-neutral-500">{{ tt('Daňové číslo', 'Tax number') }}:</span> {{ data.client.tax_number }}</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Platební panel -->
+          <div v-if="showPayPanel" class="bg-surface border rounded-xl p-6 shadow-sm"
+            :class="isPaid ? 'border-success-500/40' : 'border-neutral-200'">
+            <div class="flex flex-col sm:flex-row gap-6 items-start">
+              <div v-if="data.qr_data_uri && !isPaid" class="shrink-0 text-center mx-auto sm:mx-0">
+                <img :src="data.qr_data_uri" alt="QR" class="w-36 h-36 border border-neutral-200 rounded-lg bg-white" />
+                <div class="text-[11px] text-neutral-500 uppercase tracking-wide mt-1">{{ tt('QR platba', 'QR payment') }}</div>
+              </div>
+              <div class="flex-1 w-full">
+                <template v-if="isPaid">
+                  <h2 class="text-lg font-semibold text-success-600 mb-1">✓ {{ tt('Uhrazeno', 'Paid') }}</h2>
+                  <p class="text-sm text-neutral-600">
+                    {{ inv.payment_method === 'card' ? tt('Platba proběhla kartou online.', 'Paid online by card.')
+                      : inv.payment_method === 'cash' ? tt('Platba proběhla v hotovosti.', 'Paid in cash.')
+                      : tt('Neplaťte prosím znovu.', 'Please do not pay again.') }}
+                    <span v-if="inv.paid_at"> {{ tt('Datum úhrady', 'Paid on') }}: {{ fmtDate(inv.paid_at) }}</span>
+                  </p>
+                </template>
+                <template v-else>
+                  <div class="flex items-baseline justify-between flex-wrap gap-2 mb-3">
+                    <h2 class="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                      {{ tt('Platební údaje', 'Payment details') }}
+                    </h2>
+                    <div class="text-xl font-bold font-mono" :class="isOverdue ? 'text-danger-500' : 'text-neutral-900'">
+                      {{ fmtMoney(remaining) }}
+                    </div>
+                  </div>
+                  <div v-if="inv.payment_method === 'card'" class="text-sm text-neutral-600">
+                    {{ tt('Úhrada platební kartou — bankovní převod se nepoužije.', 'Card payment — bank transfer is not used.') }}
+                  </div>
+                  <div v-else-if="inv.payment_method === 'cash'" class="text-sm text-neutral-600">
+                    {{ tt('Úhrada v hotovosti.', 'Cash payment.') }}
+                  </div>
+                  <div v-else-if="data.bank" class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5 text-sm">
+                    <div v-if="data.bank.account_number">
+                      <span class="text-neutral-500 text-xs block">{{ tt('Číslo účtu', 'Account number') }}</span>
+                      <span class="font-mono">{{ data.bank.account_number }}<template v-if="data.bank.bank_code"> / {{ data.bank.bank_code }}</template></span>
+                    </div>
+                    <div v-if="inv.varsymbol">
+                      <span class="text-neutral-500 text-xs block">{{ tt('Variabilní symbol', 'Variable symbol') }}</span>
+                      <span class="font-mono">{{ inv.varsymbol }}</span>
+                    </div>
+                    <div v-if="data.bank.iban">
+                      <span class="text-neutral-500 text-xs block">IBAN</span>
+                      <span class="font-mono break-all">{{ data.bank.iban }}</span>
+                    </div>
+                    <div v-if="data.bank.bic">
+                      <span class="text-neutral-500 text-xs block">BIC / SWIFT</span>
+                      <span class="font-mono">{{ data.bank.bic }}</span>
+                    </div>
+                    <div v-if="data.bank.bank_name" class="sm:col-span-2 text-xs text-neutral-500">
+                      {{ tt('Banka', 'Bank') }}: {{ data.bank.bank_name }}
+                    </div>
+                  </div>
+                  <div v-if="inv.paid_total > 0" class="mt-2 text-xs text-warning-600">
+                    {{ tt('Částečně uhrazeno', 'Partially paid') }}: {{ fmtMoney(inv.paid_total) }} —
+                    {{ tt('zbývá uhradit', 'remaining') }} {{ fmtMoney(remaining) }}
+                  </div>
+                </template>
+              </div>
+            </div>
+          </div>
+
+          <!-- Položky + součty -->
+          <div class="bg-surface border border-neutral-200 rounded-xl shadow-sm overflow-hidden">
+            <div v-if="inv.note_above_items" class="px-6 pt-4 text-sm text-neutral-700 whitespace-pre-wrap">{{ inv.note_above_items }}</div>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead class="bg-neutral-50 text-xs text-neutral-500 uppercase tracking-wide">
+                  <tr>
+                    <th class="px-4 py-2 text-left font-medium">{{ tt('Popis', 'Description') }}</th>
+                    <th class="px-3 py-2 text-right font-medium whitespace-nowrap">{{ tt('Množství', 'Qty') }}</th>
+                    <th class="px-3 py-2 text-left font-medium">{{ tt('MJ', 'Unit') }}</th>
+                    <th class="px-3 py-2 text-right font-medium whitespace-nowrap">{{ tt('Cena/MJ', 'Unit price') }}</th>
+                    <th v-if="isVatPayer" class="px-3 py-2 text-center font-medium whitespace-nowrap">{{ tt('DPH', 'VAT') }}</th>
+                    <th v-if="isVatPayer" class="px-3 py-2 text-right font-medium whitespace-nowrap">{{ tt('Bez DPH', 'Excl. VAT') }}</th>
+                    <th class="px-3 py-2 text-right font-medium whitespace-nowrap">{{ isVatPayer ? tt('S DPH', 'Incl. VAT') : tt('Celkem', 'Total') }}</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-neutral-100">
+                  <tr v-for="(it, i) in inv.items" :key="i">
+                    <td class="px-4 py-2 whitespace-pre-wrap text-neutral-800">{{ it.description }}</td>
+                    <template v-if="it.item_kind === 'discount'">
+                      <td></td><td></td><td></td>
+                    </template>
+                    <template v-else>
+                      <td class="px-3 py-2 text-right font-mono whitespace-nowrap">{{ fmtQty(it.quantity) }}</td>
+                      <td class="px-3 py-2 text-neutral-600">{{ it.unit }}</td>
+                      <td class="px-3 py-2 text-right font-mono whitespace-nowrap">{{ fmtMoney(unitPrice(it), 2) }}</td>
+                    </template>
+                    <td v-if="isVatPayer" class="px-3 py-2 text-center whitespace-nowrap text-neutral-600">{{ fmtRate(it.vat_rate_snapshot) }}</td>
+                    <td v-if="isVatPayer" class="px-3 py-2 text-right font-mono whitespace-nowrap">{{ fmtMoney(it.total_without_vat, 2) }}</td>
+                    <td class="px-3 py-2 text-right font-mono whitespace-nowrap">{{ fmtMoney(isVatPayer ? it.total_with_vat : it.total_without_vat, 2) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div v-if="inv.reverse_charge" class="px-6 py-3 text-xs text-neutral-600 border-t border-neutral-100">
+              {{ (data.client.country_iso2 || 'CZ') === 'CZ'
+                  ? tt('Daň odvede zákazník (přenesená daňová povinnost dle § 92a zákona o DPH).',
+                       'Reverse charge — VAT to be accounted for by the customer.')
+                  : tt('Daň odvede zákazník (přenesení daňové povinnosti dle čl. 196 směrnice 2006/112/ES).',
+                       'Reverse charge — VAT to be accounted for by the customer pursuant to Article 196 of Council Directive 2006/112/EC.') }}
+            </div>
+
+            <!-- Součty -->
+            <div class="border-t border-neutral-200 px-6 py-4 flex justify-end">
+              <div class="w-full sm:w-80 space-y-1 text-sm">
+                <template v-if="isVatPayer && inv.invoice_type !== 'proforma'">
+                  <div v-for="b in inv.vat_breakdown" :key="b.rate" class="contents">
+                    <div class="flex justify-between text-neutral-600">
+                      <span>{{ tt('Základ', 'Base') }} {{ fmtRate(b.rate) }}</span>
+                      <span class="font-mono">{{ fmtMoney(b.base, 2) }}</span>
+                    </div>
+                    <div v-if="b.vat > 0" class="flex justify-between text-neutral-600">
+                      <span>{{ tt('DPH', 'VAT') }} {{ fmtRate(b.rate) }}</span>
+                      <span class="font-mono">{{ fmtMoney(b.vat, 2) }}</span>
+                    </div>
+                  </div>
+                  <div v-if="inv.vat_breakdown.length > 1" class="flex justify-between text-neutral-600 pt-1 border-t border-neutral-100">
+                    <span>{{ tt('Celkem bez DPH', 'Total without VAT') }}</span>
+                    <span class="font-mono">{{ fmtMoney(inv.totals.without_vat, 2) }}</span>
+                  </div>
+                </template>
+                <div v-if="inv.totals.rounding" class="flex justify-between text-neutral-600">
+                  <span>{{ tt('Zaokrouhlení', 'Rounding') }}</span>
+                  <span class="font-mono">{{ fmtMoney(inv.totals.rounding, 2) }}</span>
+                </div>
+                <div v-if="inv.totals.advance_paid_amount" class="flex justify-between text-neutral-600">
+                  <span>{{ tt('Uhrazená záloha', 'Advance paid') }}</span>
+                  <span class="font-mono">−{{ fmtMoney(inv.totals.advance_paid_amount, 2) }}</span>
+                </div>
+                <div class="flex justify-between items-baseline pt-2 border-t border-neutral-200 font-semibold text-neutral-900">
+                  <span>{{ tt('Celkem k úhradě', 'Total due') }}</span>
+                  <span class="font-mono text-lg">{{ fmtMoney(inv.totals.amount_to_pay) }}</span>
+                </div>
+                <div v-if="inv.czk_recap" class="flex justify-between text-xs text-neutral-500 pt-1">
+                  <span>{{ tt('Přepočet', 'Converted') }} ({{ tt('kurz', 'rate') }} {{ inv.czk_recap.rate }} / {{ fmtDate(inv.czk_recap.rate_date) }})</span>
+                  <span class="font-mono">{{ inv.czk_recap.total_with_vat_czk.toLocaleString(lang === 'en' ? 'en-US' : 'cs-CZ', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }} CZK</span>
+                </div>
+              </div>
+            </div>
+
+            <div v-if="inv.note_below_items" class="px-6 pb-4 text-sm text-neutral-600 whitespace-pre-wrap">{{ inv.note_below_items }}</div>
+          </div>
+
+          <!-- Kontakt na dodavatele -->
+          <div v-if="data.supplier.email || data.supplier.web" class="text-center text-xs text-neutral-500">
+            {{ tt('Dotazy k faktuře', 'Invoice questions') }}:
+            <a v-if="data.supplier.email" :href="`mailto:${data.supplier.email}`" class="text-primary-700 hover:underline">{{ data.supplier.email }}</a>
+            <template v-if="data.supplier.email && data.supplier.web"> · </template>
+            <a v-if="data.supplier.web" :href="data.supplier.web" target="_blank" rel="noopener" class="text-primary-700 hover:underline">{{ data.supplier.web }}</a>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <footer class="border-t border-neutral-200 bg-surface px-4 py-3 text-center text-xs text-neutral-500">
+      MyInvoice.cz · {{ tt('Online náhled faktury', 'Online invoice view') }}
+    </footer>
+  </div>
+</template>

--- a/web/src/pages/invoices/InvoiceDetail.vue
+++ b/web/src/pages/invoices/InvoiceDetail.vue
@@ -493,6 +493,7 @@ function actionLabel(a: string): string {
     'invoice.public_link_regenerated': 'invoice.actions.public_link_regenerated',
     'invoice.public_viewed':           'invoice.actions.public_viewed',
     'invoice.public_pdf_downloaded':   'invoice.actions.public_pdf_downloaded',
+    'invoice.public_attachment_downloaded': 'invoice.actions.public_attachment_downloaded',
     'proforma.final_issued':          'invoice.actions.proforma_final_issued',
   }
   return map[a] ? (t(map[a]) as string) : a

--- a/web/src/pages/invoices/InvoiceDetail.vue
+++ b/web/src/pages/invoices/InvoiceDetail.vue
@@ -77,6 +77,12 @@ const approvalStatusOpen = ref(false)
 const approvalStatusDraft = ref<ApprovalStatus>('none')
 const approvalRejectReason = ref('')
 
+// Web faktura (trvalý veřejný odkaz) — modal
+const publicLinkOpen = ref(false)
+const publicLinkUrl = ref('')
+const publicLinkViewedAt = ref<string | null>(null)
+const publicLinkBusy = ref(false)
+
 const activity = ref<Array<{ id: number; user_email: string | null; user_name: string | null; action: string; payload: any; ip: string | null; created_at: string }>>([])
 const activityOpen = ref(false)
 const pdfHistory = ref<Array<{ id: number; filename: string; size_bytes: number; sha256: string; was_sent: boolean; sent_to: string[] | null; reason: string; archived_at: string }>>([])
@@ -483,6 +489,10 @@ function actionLabel(a: string): string {
     'invoice.approval_approved':      'invoice.actions.approval_approved',
     'invoice.approval_rejected':      'invoice.actions.approval_rejected',
     'invoice.approval_reset':         'invoice.actions.approval_reset',
+    'invoice.public_link_created':     'invoice.actions.public_link_created',
+    'invoice.public_link_regenerated': 'invoice.actions.public_link_regenerated',
+    'invoice.public_viewed':           'invoice.actions.public_viewed',
+    'invoice.public_pdf_downloaded':   'invoice.actions.public_pdf_downloaded',
     'proforma.final_issued':          'invoice.actions.proforma_final_issued',
   }
   return map[a] ? (t(map[a]) as string) : a
@@ -617,6 +627,7 @@ useHotkey('escape', () => {
   else if (sendOpen.value)    sendOpen.value = false
   else if (reminderOpen.value) reminderOpen.value = false
   else if (approvalStatusOpen.value) approvalStatusOpen.value = false
+  else if (publicLinkOpen.value) publicLinkOpen.value = false
 })
 
 // Děkovný e-mail za úhradu (issue #57)
@@ -870,6 +881,52 @@ async function sendTestReminder() {
     toast.error( e?.response?.data?.error?.message || t('invoice.send_test_reminder_failed'))
   } finally {
     busy.value = null
+  }
+}
+
+// ─── Web faktura — trvalý veřejný odkaz (kopírovat / regenerovat / stav zobrazení) ───
+async function openPublicLink() {
+  if (!invoice.value) return
+  publicLinkOpen.value = true
+  publicLinkBusy.value = true
+  publicLinkUrl.value = ''
+  try {
+    const r = await invoicesApi.publicLink(invoice.value.id)
+    publicLinkUrl.value = r.url
+    publicLinkViewedAt.value = r.public_viewed_at
+  } catch (e: any) {
+    publicLinkOpen.value = false
+    toast.error(e?.response?.data?.error?.message || t('invoice.public_link.load_failed'))
+  } finally {
+    publicLinkBusy.value = false
+  }
+}
+
+async function copyPublicLink() {
+  if (!publicLinkUrl.value) return
+  try {
+    await navigator.clipboard.writeText(publicLinkUrl.value)
+    toast.success(t('invoice.public_link.copied'))
+  } catch {
+    toast.error(t('invoice.public_link.copy_failed'))
+  }
+}
+
+async function regeneratePublicLink() {
+  if (!invoice.value) return
+  if (!confirm(t('invoice.public_link.regenerate_confirm'))) return
+  publicLinkBusy.value = true
+  try {
+    const r = await invoicesApi.regeneratePublicLink(invoice.value.id)
+    publicLinkUrl.value = r.url
+    publicLinkViewedAt.value = null
+    invoice.value.public_viewed_at = null
+    toast.success(t('invoice.public_link.regenerated'))
+    invoicesApi.activity(invoice.value.id).then(a => { activity.value = a }).catch(() => {})
+  } catch (e: any) {
+    toast.error(e?.response?.data?.error?.message || t('invoice.public_link.regenerate_failed'))
+  } finally {
+    publicLinkBusy.value = false
   }
 }
 
@@ -1176,6 +1233,9 @@ const invoiceActions = computed<ActionItem[]>(() => {
     { key: 'wr', label: t('invoice.wr_btn'), icon: 'chart', tier: 'secondary', variant: 'primary',
       show: isDraft.value && inv.invoice_type !== 'tax_document' && w,
       title: t('invoice.wr_btn') as string, run: () => { wrModalOpen.value = true } },
+    { key: 'public-link', label: t('invoice.public_link.btn'), icon: 'link', tier: 'secondary', variant: 'primary',
+      show: !isDraft.value && w, disabled: b,
+      title: t('invoice.public_link.btn_title') as string, run: openPublicLink },
     // ── overflow ──
     { key: 'clone', label: t('invoice.clone'), icon: 'copy', tier: 'overflow', variant: 'primary',
       show: !isDraft.value && !['cancellation', 'credit_note'].includes(inv.invoice_type) && w,
@@ -1245,6 +1305,11 @@ const invoiceActions = computed<ActionItem[]>(() => {
               ? t('invoice.approval.status_expired')
               : t('invoice.approval.status_' + approvalStatus) }}
         </span>
+        <span v-if="invoice.public_viewed_at"
+          class="text-xs px-2 py-0.5 rounded font-normal bg-success-50 text-success-600"
+          :title="t('invoice.public_link.viewed_at', { date: invoice.public_viewed_at.replace('T', ' ').slice(0, 16) })">
+          👁 {{ t('invoice.public_link.viewed_badge') }}
+        </span>
       </h1>
       <ActionBar :actions="invoiceActions" />
     </div>
@@ -1296,6 +1361,51 @@ const invoiceActions = computed<ActionItem[]>(() => {
             {{ busy === 'paid' ? '…' : t('common.confirm') }}
           </button>
         </div>
+      </div>
+    </div>
+
+    <!-- Modal web faktury (trvalý veřejný odkaz) -->
+    <div v-if="publicLinkOpen" class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
+      <div class="bg-surface rounded-xl shadow-lg max-w-lg w-full p-5">
+        <h3 class="text-lg font-semibold mb-1">{{ t('invoice.public_link.modal_title') }}</h3>
+        <p class="text-xs text-neutral-500 mb-4">{{ t('invoice.public_link.modal_hint') }}</p>
+
+        <div v-if="publicLinkBusy && !publicLinkUrl" class="text-sm text-neutral-500 py-4 text-center">…</div>
+        <template v-else-if="publicLinkUrl">
+          <div class="flex gap-2 mb-3">
+            <input :value="publicLinkUrl" readonly @focus="($event.target as HTMLInputElement).select()"
+              class="flex-1 h-10 px-3 border border-neutral-300 rounded-md text-sm font-mono bg-neutral-50 min-w-0" />
+            <button @click="copyPublicLink"
+              class="cursor-pointer px-3 h-10 text-sm bg-primary-600 hover:bg-primary-700 text-white font-medium rounded-md shrink-0">
+              {{ t('invoice.public_link.copy') }}
+            </button>
+          </div>
+
+          <p class="text-xs mb-4" :class="publicLinkViewedAt ? 'text-success-600' : 'text-neutral-500'">
+            {{ publicLinkViewedAt
+                ? t('invoice.public_link.viewed_at', { date: publicLinkViewedAt.replace('T', ' ').slice(0, 16) })
+                : t('invoice.public_link.not_viewed') }}
+          </p>
+          <p class="text-xs text-neutral-500 mb-4">{{ t('invoice.public_link.email_note') }}</p>
+
+          <div class="flex flex-wrap justify-between gap-2">
+            <button @click="regeneratePublicLink" :disabled="publicLinkBusy"
+              class="cursor-pointer px-3 h-9 text-sm border border-warning-500/50 rounded-md text-warning-600 hover:bg-warning-50 disabled:opacity-50"
+              :title="t('invoice.public_link.regenerate_title')">
+              {{ publicLinkBusy ? '…' : t('invoice.public_link.regenerate') }}
+            </button>
+            <div class="flex gap-2">
+              <a :href="publicLinkUrl" target="_blank" rel="noopener"
+                class="px-3 h-9 inline-flex items-center text-sm border border-neutral-300 rounded-md text-neutral-700 hover:bg-neutral-50">
+                {{ t('invoice.public_link.open') }}
+              </a>
+              <button @click="publicLinkOpen = false"
+                class="cursor-pointer px-3 h-9 text-sm border border-neutral-300 rounded-md text-neutral-700 hover:bg-neutral-50">
+                {{ t('common.close') }}
+              </button>
+            </div>
+          </div>
+        </template>
       </div>
     </div>
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -98,6 +98,9 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/pages/ApprovalPublic.vue'), meta: { public: true } },
   { path: '/work-report/:token([a-f0-9]{32,128})', name: 'work-report-tracking',
     component: () => import('@/pages/WorkReportTrackingPublic.vue'), meta: { public: true } },
+  // Web faktura — veřejný náhled vystavené faktury (singular /invoice/…, interní UI je /invoices/…)
+  { path: '/invoice/:token([a-f0-9]{32,128})', name: 'invoice-public',
+    component: () => import('@/pages/InvoicePublic.vue'), meta: { public: true } },
   {
     path: '/:pathMatch(.*)*',
     name: 'not-found',


### PR DESCRIPTION
## Co to je

Obdoba „web faktury" z Fakturoidu: každá vystavená faktura (i proforma, dobropis…) může mít trvalý veřejný odkaz `/invoice/{token}`, na kterém si ji klient **bez přihlášení** prohlédne v HTML, stáhne PDF a přílohy e-mailu. Odkaz se automaticky vkládá do e-mailu při odeslání faktury klientovi.

## Funkce

- **Veřejná stránka** `/invoice/{token}` — vlastní minimální chrome mimo AppLayout (vzor `ApprovalPublic.vue`), dvojjazyčná podle `invoice.language`: dodavatel/odběratel, položky s rozpadem DPH (pro plátce), součty, platební panel s QR kódem a bankovním spojením, poznámky z dokladu, přílohy e-mailu, stav úhrady živě (Uhrazeno / Částečně uhrazeno / Po splatnosti), tlačítko Stáhnout PDF. Responzivní.
- **Detail faktury** — tlačítko **Web faktura**: modal s odkazem (kopírovat / otevřít), stavem „zobrazeno klientem" a revokací (**Vygenerovat nový odkaz** — starý okamžitě přestane platit). V hlavičce badge 👁 po prvním zobrazení klientem; zobrazení, stažení PDF i přílohy se zapisují do historie akcí.
- **E-mail** — `invoice_send` šablony (cs/en, html/txt) dostaly tlačítko „Zobrazit fakturu online"; token vzniká lazy při prvním odeslání/použití.

## Implementace

- migrace `0133`: `invoices.public_token CHAR(48)` + UNIQUE KEY, `public_viewed_at` (idempotentní, jeden ALTER)
- token `bin2hex(random_bytes(24))` — stejný vzor jako `approval_token`; validace formátu reusem `ApprovalTokenValidator` před DB lookupem
- `GET /api/public/invoice/{token}` (+ `/pdf`, `/attachment/{id}`) pod `/api/public/*` (AuthMiddleware pouští bez loginu); pravidlo „draft se nezobrazuje" je přímo v SQL lookupu
- data pro HTML náhled se resolvují **snapshot-first přes `InvoicePdfRenderer::resolveSupplier/Client/Bank`** (zveřejněné metody) — náhled ukazuje totéž co PDF; QR reusem `InvoiceEmailVarsBuilder::paymentQrDataUri`
- payload je striktní whitelist (unit test hlídá, že ven nejdou tokeny, snapshoty, interní ID, disk filename ani e-maily klienta)
- stažení přílohy: vazba `attId ↔ invoice_id` v repository dotazu (žádný cross-invoice přístup), vždy attachment disposition + nosniff/CSP sandbox (parita s `DownloadAttachmentAction`)
- management `POST /api/invoices/{id}/public-link` (idempotentní ensure) a `/regenerate` — dokumentováno v `openapi.yaml`; `public_viewed_at` nastavuje jen anonymní přístup, takže si dodavatel indikaci nekazí vlastním náhledem
- `InvoicePublicLinkService` — jediný vlastník formátu URL (e-mail i UI)
- manuál: nová sekce 11.5 v kapitole Faktura — PDF

## Testováno

- PHPUnit: nový `PublicInvoicePayloadTest` (whitelist), celá Unit suita zelená
- `pnpm build` (vue-tsc + vite) OK
- ověřeno na živé instanci: náhled, PDF, přílohy, revokace odkazu, 404 pro neplatný/draft token, IDOR guard na přílohách