### PR TITLE
fix(bank): zachovat kód banky v seznamu výpisů

### DIFF
--- a/api/src/Action/Bank/BankStatementAction.php
+++ b/api/src/Action/Bank/BankStatementAction.php
@@ -393,16 +393,22 @@ final class BankStatementAction
         // přes scalar subselect (LIMIT 1 — sup. může mít jen 1 záznam per account_number+bank_code).
         $stmt = $this->db->pdo()->prepare(
             "SELECT bs.id, bs.source, bs.file_name, bs.account_number,
-                    -- Kód banky autoritativně z konfigurovaného účtu (currencies); GPC výpisy
-                    -- ho neukládají (na rozdíl od e-mailových avíz), tak ať se zobrazí všude.
+                    -- Kód uložený na výpisu je autoritativní. U starších záznamů bez
+                    -- bank_code doplň kód z currencies jen tehdy, když je pro dané číslo
+                    -- účtu jednoznačný; LIMIT 1 by při shodném čísle u více bank zobrazil
+                    -- náhodnou banku (#206).
                     COALESCE(
-                      (SELECT cur.bank_code FROM currencies cur
+                      bs.bank_code,
+                      (SELECT CASE
+                                WHEN COUNT(DISTINCT NULLIF(cur.bank_code, '')) = 1
+                                THEN MAX(NULLIF(cur.bank_code, ''))
+                                ELSE NULL
+                              END
+                         FROM currencies cur
                         WHERE cur.supplier_id = ?
                           AND TRIM(LEADING '0' FROM REGEXP_REPLACE(IFNULL(cur.account_number, ''), '[^0-9]', ''))
                             = TRIM(LEADING '0' FROM REGEXP_REPLACE(IFNULL(bs.account_number, ''),  '[^0-9]', ''))
-                          AND cur.bank_code IS NOT NULL AND cur.bank_code <> ''
-                        LIMIT 1),
-                      bs.bank_code
+                      )
                     ) AS bank_code,
                     bs.currency, bs.statement_date, bs.statement_number,
                     bs.prev_balance, bs.curr_balance, bs.transaction_count, bs.matched_count, bs.imported_at,

--- a/api/tests/Integration/Bank/StatementAccountResolutionTest.php
+++ b/api/tests/Integration/Bank/StatementAccountResolutionTest.php
@@ -135,6 +135,23 @@ final class StatementAccountResolutionTest extends TestCase
         $stmt = $this->db->pdo()->prepare('SELECT bank_code FROM bank_statements WHERE id = ?');
         $stmt->execute([$sid]);
         $this->assertSame('2010', (string) $stmt->fetchColumn(), 'výpis musí být pod zvoleným Fio účtem (2010), ne výchozím RB (5500)');
+
+        // Regrese seznamu výpisů: list dříve přepsal správné bs.bank_code prvním
+        // currencies.bank_code pro stejné číslo účtu (bez ORDER BY), takže zobrazil
+        // např. /5500 společně s labelem Fio. Detail přitom správně ukazoval /2010.
+        $listResponse = $this->action->list(
+            $this->mockRequest($this->supplierId, 'admin', [], [], ['filter' => ['account' => $account]]),
+            new Response()
+        );
+        /** @var array{items?:list<array<string,mixed>>} $listBody */
+        $listBody = json_decode((string) $listResponse->getBody(), true) ?: [];
+        $listed = array_values(array_filter(
+            $listBody['items'] ?? [],
+            static fn (array $item): bool => (int) ($item['id'] ?? 0) === $sid
+        ));
+        $this->assertCount(1, $listed, 'importovaný výpis musí být v seznamu');
+        $this->assertSame('2010', (string) ($listed[0]['bank_code'] ?? ''), 'seznam musí respektovat autoritativní bank_code výpisu');
+        $this->assertStringContainsString('2010', (string) ($listed[0]['account_label'] ?? ''), 'label seznamu musí patřit ke stejnému účtu');
     }
 
     /**
@@ -188,7 +205,7 @@ final class StatementAccountResolutionTest extends TestCase
         return [$resp, $body];
     }
 
-    private function mockRequest(int $sid, string $role, array $files, array $parsedBody): ServerRequestInterface
+    private function mockRequest(int $sid, string $role, array $files, array $parsedBody, array $queryParams = []): ServerRequestInterface
     {
         $req = $this->createStub(ServerRequestInterface::class);
         $req->method('getAttribute')->willReturnCallback(function (string $name, $default = null) use ($sid, $role) {
@@ -198,6 +215,7 @@ final class StatementAccountResolutionTest extends TestCase
         });
         $req->method('getUploadedFiles')->willReturn($files);
         $req->method('getParsedBody')->willReturn($parsedBody);
+        $req->method('getQueryParams')->willReturn($queryParams);
         $req->method('getServerParams')->willReturn([]);
         $req->method('getHeaderLine')->willReturn('');
         return $req;


### PR DESCRIPTION
## Problém

Seznam bankovních výpisů mohl zobrazit nesprávný kód banky, pokud měl dodavatel více účtů se stejným číslem účtu a různými kódy bank.

Například výpis uložený jako `1234567890/2010` se v seznamu zobrazil jako `1234567890/5500`, zatímco jeho detail správně ukazoval `/2010`. Název účtu přitom zůstal `CZK - FIO`, takže seznam zobrazoval nekonzistentní kombinaci:

`1234567890/5500 — CZK - FIO`

Příčinou byl poddotaz nad tabulkou `currencies`, který vybíral `bank_code` pouze podle čísla účtu pomocí `LIMIT 1`. Nalezenou hodnotou následně přepsal správný kód uložený v `bank_statements.bank_code`.

## Řešení

- `bank_statements.bank_code` je nyní autoritativní.
- Fallback z `currencies` se používá pouze u starších výpisů, které vlastní `bank_code` nemají.
- Fallback se doplní jen tehdy, pokud pro dané číslo účtu existuje právě jeden jednoznačný kód banky.
- Pokud stejné číslo používá více bank, žádný kód se svévolně nevybere.

## Testy

Doplněn regresní integrační test pro dva CZK účty se stejným číslem:

- Raiffeisenbank `1234567890/5500`
- Fio `1234567890/2010`

Test ověřuje, že list endpoint pro výpis importovaný pod účtem Fio vrátí `bank_code = 2010` a odpovídající label účtu.

Manuálně ověřeno v Docker testovacím prostředí:

- Fio výpisy se v seznamu zobrazují s `/2010`.
- Raiffeisenbank výpisy se zobrazují s `/5500`.
- Seznam a detail výpisu nyní zobrazují shodný účet.

Souvisí s #206.