### PR TITLE
fix(bank): filtrovat výpisy také podle kódu banky

### DIFF
--- a/api/src/Action/Bank/BankStatementAction.php
+++ b/api/src/Action/Bank/BankStatementAction.php
@@ -363,6 +363,7 @@ final class BankStatementAction
         $year    = isset($filter['year'])  && $filter['year']  !== '' ? (int) $filter['year']  : null;
         $month   = isset($filter['month']) && $filter['month'] !== '' ? (int) $filter['month'] : null;
         $account = isset($filter['account']) ? trim((string) $filter['account']) : '';
+        $bankCode = isset($filter['bank_code']) ? trim((string) $filter['bank_code']) : '';
 
         // Společný scope filtr (account_number/bank_code z currencies dodavatele).
         $scopeSql = "EXISTS (
@@ -383,6 +384,20 @@ final class BankStatementAction
             $filterSql .= " AND TRIM(LEADING '0' FROM REGEXP_REPLACE(IFNULL(bs.account_number, ''), '[^0-9]', ''))
                               = TRIM(LEADING '0' FROM REGEXP_REPLACE(?, '[^0-9]', ''))";
             $filterParams[] = $account;
+            if ($bankCode !== '') {
+                $accountCountStmt = $this->db->pdo()->prepare(
+                    "SELECT COUNT(*) FROM currencies cur
+                      WHERE cur.supplier_id = ?
+                        AND TRIM(LEADING '0' FROM REGEXP_REPLACE(IFNULL(cur.account_number, ''), '[^0-9]', ''))
+                          = TRIM(LEADING '0' FROM REGEXP_REPLACE(?, '[^0-9]', ''))"
+                );
+                $accountCountStmt->execute([$sid, $account]);
+                $allowMissingBankCode = (int) $accountCountStmt->fetchColumn() === 1 ? 1 : 0;
+                $filterSql .= " AND (bs.bank_code = ?
+                                  OR ((bs.bank_code IS NULL OR bs.bank_code = '') AND ? = 1))";
+                $filterParams[] = $bankCode;
+                $filterParams[] = $allowMissingBankCode;
+            }
         }
 
         $countStmt = $this->db->pdo()->prepare("SELECT COUNT(*) FROM bank_statements bs WHERE $scopeSql$filterSql");

--- a/api/tests/Integration/Bank/StatementAccountResolutionTest.php
+++ b/api/tests/Integration/Bank/StatementAccountResolutionTest.php
@@ -136,11 +136,25 @@ final class StatementAccountResolutionTest extends TestCase
         $stmt->execute([$sid]);
         $this->assertSame('2010', (string) $stmt->fetchColumn(), 'výpis musí být pod zvoleným Fio účtem (2010), ne výchozím RB (5500)');
 
+        $this->db->pdo()->prepare(
+            'INSERT INTO bank_statements
+                (source, file_name, file_hash, account_number, bank_code, currency,
+                 statement_date, curr_balance)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+        )->execute([
+            'pdf', 'TEST-206-filter-rb.pdf', hash('sha256', 'test-206-filter-rb'),
+            $account, '5500', 'CZK', '2026-06-30', 2000.00,
+        ]);
+        $rbStatementId = (int) $this->db->pdo()->lastInsertId();
+        $this->statementIds[] = $rbStatementId;
+
         // Regrese seznamu výpisů: list dříve přepsal správné bs.bank_code prvním
         // currencies.bank_code pro stejné číslo účtu (bez ORDER BY), takže zobrazil
         // např. /5500 společně s labelem Fio. Detail přitom správně ukazoval /2010.
         $listResponse = $this->action->list(
-            $this->mockRequest($this->supplierId, 'admin', [], [], ['filter' => ['account' => $account]]),
+            $this->mockRequest($this->supplierId, 'admin', [], [], [
+                'filter' => ['account' => $account, 'bank_code' => '2010'],
+            ]),
             new Response()
         );
         /** @var array{items?:list<array<string,mixed>>} $listBody */
@@ -152,6 +166,8 @@ final class StatementAccountResolutionTest extends TestCase
         $this->assertCount(1, $listed, 'importovaný výpis musí být v seznamu');
         $this->assertSame('2010', (string) ($listed[0]['bank_code'] ?? ''), 'seznam musí respektovat autoritativní bank_code výpisu');
         $this->assertStringContainsString('2010', (string) ($listed[0]['account_label'] ?? ''), 'label seznamu musí patřit ke stejnému účtu');
+        $listedIds = array_map(static fn (array $item): int => (int) ($item['id'] ?? 0), $listBody['items'] ?? []);
+        $this->assertNotContains($rbStatementId, $listedIds, 'filtr Fio /2010 nesmí vrátit RB /5500 se stejným číslem účtu');
     }
 
     /**

--- a/web/src/api/bank.ts
+++ b/web/src/api/bank.ts
@@ -165,6 +165,7 @@ export interface BankListParams {
   year?: number | ''
   month?: number | ''
   account?: string
+  bank_code?: string
 }
 
 /** Jeden bod měsíční řady zůstatku (nativní měna účtu). */
@@ -214,6 +215,7 @@ export const bankApi = {
       ...(params.year !== undefined && params.year !== '' ? { 'filter[year]': params.year } : {}),
       ...(params.month !== undefined && params.month !== '' ? { 'filter[month]': params.month } : {}),
       ...(params.account ? { 'filter[account]': params.account } : {}),
+      ...(params.bank_code ? { 'filter[bank_code]': params.bank_code } : {}),
     } }).then(r => r.data),
   get: (id: number) => api.get<BankStatementDetail>(`/bank-statements/${id}`).then(r => r.data),
   /** Přehled zůstatků na účtech dle GPC výpisů (tabulka + měsíční vývoj + CZK součet). */

--- a/web/src/pages/bank/StatementList.vue
+++ b/web/src/pages/bank/StatementList.vue
@@ -31,8 +31,17 @@ const DEFAULT_YEAR = new Date().getFullYear()
 const yearFilter = ref<number | ''>('')
 const monthFilter = ref<number | ''>('')
 const accountFilter = ref<string>('')
+const bankCodeFilter = ref<string>('')
 const years = ref<number[]>([])
 const accounts = ref<BankAccountOption[]>([])
+const accountFilterKey = computed({
+  get: () => accountFilter.value ? `${accountFilter.value}|${bankCodeFilter.value}` : '',
+  set: (value: string) => {
+    const separator = value.lastIndexOf('|')
+    accountFilter.value = separator >= 0 ? value.slice(0, separator) : value
+    bankCodeFilter.value = separator >= 0 ? value.slice(separator + 1) : ''
+  },
+})
 
 // `tm()` vrací raw pole zpráv, `rt()` zformátuje jednotlivé položky (interpolace).
 const monthOptions = computed(() => (tm('common.months_short') as unknown as string[]).map(m => rt(m)))
@@ -59,6 +68,7 @@ function resetFilters() {
   yearFilter.value = ''
   monthFilter.value = ''
   accountFilter.value = ''
+  bankCodeFilter.value = ''
 }
 const uploading = ref(false)
 const scanning = ref(false)
@@ -131,6 +141,7 @@ async function load() {
       year: yearFilter.value,
       month: monthFilter.value,
       account: accountFilter.value || undefined,
+      bank_code: bankCodeFilter.value || undefined,
     })
     statements.value = r.items
     total.value = r.total
@@ -153,6 +164,7 @@ function loadFiltersFromQuery(q: typeof route.query) {
     : ''
   monthFilter.value = typeof q.month === 'string' && q.month !== '' ? Number(q.month) : ''
   accountFilter.value = typeof q.account === 'string' ? q.account : ''
+  bankCodeFilter.value = typeof q.bank === 'string' ? q.bank : ''
 }
 function syncFiltersToUrl() {
   if (suppressUrlSync) return
@@ -160,10 +172,11 @@ function syncFiltersToUrl() {
   if (yearFilter.value !== '') q.year = String(yearFilter.value)
   if (monthFilter.value !== '') q.month = String(monthFilter.value)
   if (accountFilter.value) q.account = accountFilter.value
+  if (bankCodeFilter.value) q.bank = bankCodeFilter.value
   router.replace({ query: q })
 }
 
-watch([yearFilter, monthFilter, accountFilter], () => {
+watch([yearFilter, monthFilter, accountFilter, bankCodeFilter], () => {
   page.value = 1
   syncFiltersToUrl()
   load()
@@ -178,6 +191,7 @@ watch(() => route.query, (newQ) => {
     yearFilter.value = ''
     monthFilter.value = ''
     accountFilter.value = ''
+    bankCodeFilter.value = ''
     page.value = 1
     load()
     setTimeout(() => { suppressUrlSync = false }, 0)
@@ -337,10 +351,14 @@ async function onFileSelected(e: Event) {
         <option :value="''">{{ t('bank.all_months') }}</option>
         <option v-for="(label, i) in monthOptions" :key="i + 1" :value="i + 1">{{ label }}</option>
       </select>
-      <select v-if="accounts.length > 1" v-model="accountFilter"
+      <select v-if="accounts.length > 1" v-model="accountFilterKey"
         class="h-9 px-3 border border-neutral-300 rounded-md bg-surface text-sm">
         <option value="">{{ t('bank.all_accounts') }}</option>
-        <option v-for="a in accounts" :key="a.account_number" :value="a.account_number">{{ accountLabel(a) }}</option>
+        <option
+          v-for="a in accounts"
+          :key="`${a.account_number}|${a.bank_code ?? ''}`"
+          :value="`${a.account_number}|${a.bank_code ?? ''}`"
+        >{{ accountLabel(a) }}</option>
       </select>
     </FilterBar>
 


### PR DESCRIPTION
## Co oprava řeší

Filtr bankovních výpisů podle účtu nerozlišoval účty se stejným číslem, ale odlišným kódem banky, například:

- `1234567890 / 2010` — Fio
- `1234567890 / 5500` — RB

Po výběru jednoho účtu proto seznam nadále zobrazoval výpisy obou bank.

## Příčina

Frontend odesílal do API pouze číslo účtu (`filter[account]`). Kód banky z vybrané položky se zahodil, takže backend filtroval oba účty jako totožné.

## Řešení

- hodnota filtru nyní zachovává číslo účtu i kód banky
- URL ukládá kód banky samostatně, takže filtr zůstává sdílitelný
- API přijímá `filter[bank_code]`
- backend porovnává výpis také podle přesného kódu banky
- starší výpis bez kódu banky se použije jen u jednoznačného čísla účtu
- klíče položek ve výběru zahrnují číslo i kód banky

## Ověření

- integrační test se dvěma syntetickými účty stejného čísla u bank `/2010` a `/5500`
- ověřeno, že filtr Fio nevrátí výpis RB
- PHPUnit: 3 testy, 14 assertions
- TypeScript kontrola
- produkční frontendový build
- ověřeno v Dockeru