### PR TITLE
fix(import): podporovat ISDOC 5.x namespace při importu (#208)

### DIFF
--- a/api/src/Service/Import/IsdocParser.php
+++ b/api/src/Service/Import/IsdocParser.php
@@ -15,7 +15,12 @@ namespace MyInvoice\Service\Import;
  */
 final class IsdocParser
 {
-    private const NS = 'http://isdoc.cz/namespace/2013';
+    /** ISDOC 6.x namespace (náš exporter, iDoklad, Fakturoid…). */
+    private const NS_2013 = 'http://isdoc.cz/namespace/2013';
+    /** Starší ISDOC 5.x namespace — struktura čtených elementů je kompatibilní. */
+    private const NS_LEGACY = 'http://isdoc.cz/namespace/invoice';
+    /** Namespace, které parser umí — prefix `i:` se navazuje na ten z kořene dokladu. */
+    private const SUPPORTED_NS = [self::NS_2013, self::NS_LEGACY];
 
     /**
      * @return array{supplier_ic:?string, invoices:list<array<string,mixed>>}
@@ -45,8 +50,22 @@ final class IsdocParser
             throw new \RuntimeException('Není ISDOC — root není Invoice.');
         }
 
+        // Namespace bereme z kořene dokladu, ať funguje ISDOC 6.x (…/2013) i starší
+        // 5.x (…/invoice) — struktura čtených elementů je shodná, liší se jen NS.
+        // Dřív byl NS natvrdo 2013, takže 5.2 doklad nenašel ani <ID> a spadl na
+        // zavádějící „Chybí ISDOC ID" (issue #208).
+        $ns = (string) $root->namespaceURI;
+        if (!in_array($ns, self::SUPPORTED_NS, true)) {
+            throw new \RuntimeException(sprintf(
+                'Nepodporovaný ISDOC namespace „%s". Podporováno je ISDOC 6.x (%s) a 5.x (%s).',
+                $ns !== '' ? $ns : '(žádný)',
+                self::NS_2013,
+                self::NS_LEGACY,
+            ));
+        }
+
         $xpath = new \DOMXPath($dom);
-        $xpath->registerNamespace('i', self::NS);
+        $xpath->registerNamespace('i', $ns);
 
         try {
             $parsed = $this->parseInvoice($root, $xpath);

--- a/api/tests/Unit/Service/Import/IsdocParserTest.php
+++ b/api/tests/Unit/Service/Import/IsdocParserTest.php
@@ -92,6 +92,35 @@ XML;
         self::assertSame(21.0, $inv['items'][0]['vat_rate']);
     }
 
+    public function testParsesLegacyIsdoc52Namespace(): void
+    {
+        // ISDOC 5.2 nese starší namespace .../invoice místo 6.x .../2013; struktura
+        // čtených elementů je shodná, takže se doklad musí naparsovat identicky.
+        // Dřív byl NS natvrdo 2013 → 5.2 nenašel ani <ID> a spadl na zavádějící
+        // „Chybí ISDOC ID" (issue #208).
+        $xml = str_replace(self::NS, 'http://isdoc.cz/namespace/invoice', $this->minimalIsdoc());
+        $result = $this->parser->parse($xml);
+
+        self::assertSame('21370362', $result['supplier_ic']);
+        $inv = $result['invoices'][0];
+        self::assertArrayNotHasKey('__error', $inv);
+        self::assertSame('2605001', $inv['varsymbol']);
+        self::assertSame('Test Klient s.r.o.', $inv['client']['company_name']);
+        self::assertCount(1, $inv['items']);
+        self::assertSame(21.0, $inv['items'][0]['vat_rate']);
+    }
+
+    public function testUnknownNamespaceThrowsClearMessage(): void
+    {
+        // Neznámý namespace nesmí skončit zavádějící „Chybí ISDOC ID", ale jasnou
+        // hláškou o nepodporovaném ISDOC namespace (issue #208).
+        $xml = str_replace(self::NS, 'http://example.com/not-isdoc', $this->minimalIsdoc());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Nepodporovaný ISDOC namespace');
+        $this->parser->parse($xml);
+    }
+
     public function testPayableAmountNullWhenNoMonetaryTotal(): void
     {
         $inv = $this->parser->parse($this->minimalIsdoc())['invoices'][0];


### PR DESCRIPTION
Fixes #208.

## Příčina

`IsdocParser` měl namespace natvrdo na 6.x (`http://isdoc.cz/namespace/2013`). Starší **ISDOC 5.2** používá `http://isdoc.cz/namespace/invoice`, takže všechny `i:`-prefixované xpath dotazy nic nevrátily — parser nenašel ani `<ID>` a spadl na zavádějící **„Chybí ISDOC ID (varsymbol)"**, přestože doklad `<ID>` i `<VariableSymbol>` obsahoval.

## Oprava

- Namespace se bere z **kořene dokladu** a prefix `i:` se na něj naváže. Struktura čtených elementů je mezi 5.x a 6.x shodná (ID, DocumentType, party, InvoiceLines, TaxTotal, PaymentMeans…), takže se 5.2 doklad naparsuje identicky.
- U **skutečně neznámého** namespace parser vrací jasnou hlášku **„Nepodporovaný ISDOC namespace …"** místo matoucí o chybějícím VS — přesně jak issue navrhuje.

## Ověření

- Puštěno na **reálném 5.2 dokladu z issue** (`emas-faktura-9142603234.isdoc`): korektně vytěženo `varsymbol` 9142603234, dodavatel JANČA a EMAS group s.r.o. (IČ 25907069), 14 položek, DPH rekapitulace 21 % (base 4355,07 / daň 914,56), platební účet 2112259948/2700, k úhradě 5270,00.
- Nové unit testy: parsování 5.x namespace + jasná chyba u neznámého namespace.
- 6.x beze změny — celý `IsdocParserTest` + `IsdocParserTaxRecapTest` zeleně (**35 testů, 75 assertions**, PHP 8.5.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
