### PR TITLE
fix(idoklad): zachovat účet vydané faktury při importu

### DIFF
--- a/api/src/Service/Import/IdokladImportService.php
+++ b/api/src/Service/Import/IdokladImportService.php
@@ -10,6 +10,7 @@ use MyInvoice\Repository\ImportJobRepository;
 use MyInvoice\Infrastructure\Config\Config;
 use MyInvoice\Repository\InvoiceRepository;
 use MyInvoice\Repository\PurchaseInvoiceRepository;
+use MyInvoice\Service\Bank\AccountNumberNormalizer;
 use MyInvoice\Service\Invoice\InvoiceCalculator;
 use MyInvoice\Service\Invoice\PurchaseInvoiceCalculator;
 use MyInvoice\Service\Invoice\SnapshotBuilder;
@@ -302,7 +303,7 @@ final class IdokladImportService
             'issue_date'       => (string) ($i['DateOfIssue'] ?? date('Y-m-d')),
             'tax_date'         => $invoiceType === 'proforma' ? null : (string) ($i['DateOfTaxing'] ?? $i['DateOfIssue'] ?? date('Y-m-d')),
             'due_date'         => (string) ($i['DateOfMaturity'] ?? $i['DateOfIssue'] ?? date('Y-m-d')),
-            'currency_id'      => $this->resolveCurrencyId($this->idokladCurrencyCode($i, $supplierId), $supplierId, isActive: true),
+            'currency_id'      => $this->resolveIssuedCurrencyId($i, $supplierId),
             'reverse_charge'   => false,
             'language'         => 'cs',
             // varsymbol = číslo dokladu (unikátní per dodavatel), NE platební VariableSymbol (#196).
@@ -890,6 +891,78 @@ final class IdokladImportService
     }
 
     /**
+     * Účet vydané faktury podle historických údajů `MyAddress` z iDokladu.
+     *
+     * Jedna měna může mít v MyInvoice více bankovních účtů. Samotný CurrencyId
+     * proto nestačí: nejprve hledáme přesnou dvojici číslo účtu + kód banky
+     * uloženou na konkrétní faktuře. Výchozí účet měny je pouze fallback pro
+     * doklady bez bankovních údajů nebo bez jednoznačné lokální shody.
+     *
+     * @param array<string,mixed> $doc
+     */
+    private function resolveIssuedCurrencyId(array $doc, int $supplierId): int
+    {
+        $code = $this->idokladCurrencyCode($doc, $supplierId);
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT id, account_number, bank_code, iban FROM currencies
+              WHERE supplier_id = ? AND code = ? AND is_active = 1
+              ORDER BY is_default DESC, id ASC'
+        );
+        $stmt->execute([$supplierId, strtoupper(trim($code)) ?: 'CZK']);
+        $accounts = $stmt->fetchAll(\PDO::FETCH_ASSOC) ?: [];
+
+        $matchedId = self::matchIssuedBankAccount($doc, $accounts);
+        if ($matchedId !== null) {
+            return $matchedId;
+        }
+
+        $address = is_array($doc['MyAddress'] ?? null) ? $doc['MyAddress'] : [];
+        if (trim((string) ($address['AccountNumber'] ?? '')) !== '') {
+            $this->logger->warning('iDoklad issued invoice bank account was not matched uniquely; using currency default', [
+                'supplier_id' => $supplierId,
+                'idoklad_id'  => (int) ($doc['Id'] ?? 0),
+                'bank_code'   => trim((string) ($address['BankCode'] ?? '')) ?: null,
+                'currency'    => strtoupper(trim($code)) ?: 'CZK',
+            ]);
+        }
+
+        return $this->resolveCurrencyId($code, $supplierId, isActive: true);
+    }
+
+    /**
+     * @param array<string,mixed> $doc
+     * @param list<array{id:mixed,account_number:mixed,bank_code:mixed,iban?:mixed}> $accounts
+     */
+    public static function matchIssuedBankAccount(array $doc, array $accounts): ?int
+    {
+        $address = is_array($doc['MyAddress'] ?? null) ? $doc['MyAddress'] : [];
+        $accountNumber = trim((string) ($address['AccountNumber'] ?? ''));
+        $bankCode = preg_replace('/\D/', '', (string) ($address['BankCode'] ?? '')) ?? '';
+        if ($accountNumber === '') {
+            return null;
+        }
+
+        $matches = [];
+        foreach ($accounts as $account) {
+            $iban = isset($account['iban']) && is_string($account['iban']) ? $account['iban'] : null;
+            if (!AccountNumberNormalizer::matchesAny($accountNumber, $account['account_number'] ?? null, $iban)) {
+                continue;
+            }
+
+            $candidateBank = preg_replace('/\D/', '', (string) ($account['bank_code'] ?? '')) ?? '';
+            if ($candidateBank === '' && $iban !== null) {
+                $candidateBank = AccountNumberNormalizer::czechIbanBankCode($iban) ?? '';
+            }
+            if ($bankCode !== '' && $candidateBank !== $bankCode) {
+                continue;
+            }
+            $matches[] = (int) $account['id'];
+        }
+
+        return count($matches) === 1 ? $matches[0] : null;
+    }
+
+    /**
      * ISO kód měny dokladu. iDoklad list endpointy vrací jen `CurrencyId` (int) — přeložíme
      * přes /Currencies mapu. Fallback na legacy nested `Currency.Code` / `CurrencyCode`, pak CZK.
      */
@@ -1115,7 +1188,7 @@ final class IdokladImportService
                     'issue_date'        => (string) ($i['DateOfIssue'] ?? date('Y-m-d')),
                     'tax_date'          => (string) ($i['DateOfTaxing'] ?? $i['DateOfIssue'] ?? date('Y-m-d')),
                     'due_date'          => (string) ($i['DateOfMaturity'] ?? $i['DateOfIssue'] ?? date('Y-m-d')),
-                    'currency_id'       => $this->resolveCurrencyId($this->idokladCurrencyCode($i, $supplierId), $supplierId, isActive: true),
+                    'currency_id'       => $this->resolveIssuedCurrencyId($i, $supplierId),
                     'reverse_charge'    => false,
                     'language'          => 'cs',
                     // varsymbol = číslo dokladu (unikátní per dodavatel), NE platební VariableSymbol (#196).

--- a/api/tests/Unit/Service/Import/IdokladIssuedBankAccountTest.php
+++ b/api/tests/Unit/Service/Import/IdokladIssuedBankAccountTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Import;
+
+use MyInvoice\Service\Import\IdokladImportService;
+use PHPUnit\Framework\TestCase;
+
+final class IdokladIssuedBankAccountTest extends TestCase
+{
+    /** @return list<array{id:int,account_number:string,bank_code:string,iban:null}> */
+    private static function accounts(): array
+    {
+        return [
+            ['id' => 10, 'account_number' => '1000000005', 'bank_code' => '0100', 'iban' => null],
+            ['id' => 20, 'account_number' => '1000000005', 'bank_code' => '2010', 'iban' => null],
+        ];
+    }
+
+    public function testMatchesAccountAndBankCodeFromInvoiceAddress(): void
+    {
+        $doc = ['MyAddress' => ['AccountNumber' => '1000000005', 'BankCode' => '2010']];
+
+        self::assertSame(20, IdokladImportService::matchIssuedBankAccount($doc, self::accounts()));
+    }
+
+    public function testNormalizesAccountNumberAndBankCodeFormatting(): void
+    {
+        $doc = ['MyAddress' => ['AccountNumber' => '0000001000000005', 'BankCode' => '/0100']];
+
+        self::assertSame(10, IdokladImportService::matchIssuedBankAccount($doc, self::accounts()));
+    }
+
+    public function testDoesNotGuessWhenBankCodeIsMissingAndNumberIsAmbiguous(): void
+    {
+        $doc = ['MyAddress' => ['AccountNumber' => '1000000005', 'BankCode' => '']];
+
+        self::assertNull(IdokladImportService::matchIssuedBankAccount($doc, self::accounts()));
+    }
+
+    public function testReturnsNullWhenInvoiceHasNoAccount(): void
+    {
+        self::assertNull(IdokladImportService::matchIssuedBankAccount(['MyAddress' => []], self::accounts()));
+    }
+}

--- a/manual/16_Importy.md
+++ b/manual/16_Importy.md
@@ -196,6 +196,12 @@ Klikni **Spustit import**.
 | **purchases** | `purchase_invoices` + `purchase_invoice_items`. Klient → `clients` s `is_vendor=true`. |
 | **receipts** | Přijaté **účtenky/paragony** (iDoklad `ReceivedReceipts`) → `purchase_invoices` s `document_kind='receipt'`. Účtenka nemá splatnost ani DUZP → `datum vystavení` = DUZP = splatnost. Hrazená na místě → importuje se rovnou jako **Zaplacená**. Hotovostní účtenka **bez dodavatele** viz poznámka níže. |
 
+U vydané faktury se bankovní účet přebírá z historických údajů `MyAddress`
+konkrétního dokladu (číslo účtu a kód banky). Pokud máš pro jednu měnu více
+účtů, import tak zachová účet skutečně uvedený na faktuře; výchozí účet měny se
+použije pouze tehdy, když doklad účet neobsahuje nebo jej nelze jednoznačně
+spárovat s aktivním účtem v MyInvoice.
+
 ### 16.8.5 Platební stav
 
 API import přebírá **skutečný platební stav ze zdrojového systému** — na rozdíl


### PR DESCRIPTION
## Co se mění

- import vydaných faktur a dobropisů z iDokladu nejprve hledá aktivní účet podle historických údajů `MyAddress.AccountNumber` a `MyAddress.BankCode`
- výchozí účet měny se použije jen tehdy, když doklad účet neobsahuje nebo shoda není jednoznačná
- porovnání používá stejnou normalizaci čísla účtu jako bankovní modul a umí bankovní kód odvodit také z českého IBANu
- při fallbacku se zapíše bezpečné varování bez čísla účtu
- uživatelský manuál popisuje nové chování

## Proč

MyInvoice dovoluje více bankovních účtů pro stejnou měnu. Dosavadní import ale používal pouze `CurrencyId` z iDokladu a vždy vybral výchozí účet dané měny. Faktura vystavená například s účtem FIO se proto mohla po importu zobrazit s výchozím účtem RB.

iDoklad přitom na konkrétní faktuře vrací historické bankovní údaje v `MyAddress`, které jsou přesnějším zdrojem než aktuální výchozí účet měny.

## Dopad

Nově importované vydané faktury zachovají účet skutečně uvedený v iDokladu a při přechodu do stavu `paid` se tento účet uloží také do `bank_snapshot`. Existující již importované faktury se nemění, protože iDoklad import je additivní a záznamy se stejným `idoklad_id` přeskakuje.

## Ověření

- nový regresní test se dvěma syntetickými účty se stejným číslem a různým kódem banky
- ověřena normalizace čísla účtu a formátu bankovního kódu
- ověřeno odmítnutí nejednoznačné shody bez kódu banky
- kompletní backend test suite: 1 588 testů, 3 454 assertions, bez chyb (387 environment-dependent skipped)
- manuál vygenerován do HTML a PDF bez chyby

## Mimo rozsah

Tento PR nemění model variabilního symbolu ani neimportuje bankovní pohyby z iDokladu. Tyto změny vyžadují samostatný návrh kvůli deduplikaci vůči GPC a IMAP a kvůli stávající unikátnosti čísla vydané faktury.
