### PR TITLE
feat(tax): odhad čistého příjmu za minulý měsíc v daňovém optimalizátoru

### DIFF
--- a/api/src/Action/Tax/TaxAction.php
+++ b/api/src/Action/Tax/TaxAction.php
@@ -60,6 +60,7 @@ final class TaxAction
             // výpočtu daně ani pojistného NEvstupují (jsou už vyloučené v annualIncome);
             // tady jen pro transparentní zobrazení „z toho vyloučeno" v UI.
             'exempt_income'   => $this->profiles->annualExemptIncome($sid, $year, $isVat),
+            'last_month'      => $this->lastMonthEstimate($sid, $isVat, $flags),
         ];
 
         if ($year < $currentYear) {
@@ -162,6 +163,28 @@ final class TaxAction
             $elapsed = max(1, $withData);
         }
         return [round($ytd, 2), $elapsed];
+    }
+
+    /**
+     * Pravděpodobný čistý příjem za minulý kalendářní měsíc — vždy nezávisle na
+     * zvoleném roce v přepínači (viz {@see TaxOptimizer::estimateMonthly()}).
+     * @param array{is_vat_payer: bool, flat_tax_band: string} $flags
+     * @return array<string,mixed>
+     */
+    private function lastMonthEstimate(int $sid, bool $isVat, array $flags): array
+    {
+        $lastMonth = new \DateTimeImmutable('first day of last month');
+        $lmYear = (int) $lastMonth->format('Y');
+        $lmYm   = $lastMonth->format('Y-m');
+
+        $profileRow = $this->profiles->find($sid, $lmYear);
+        $engineProfile = $this->publicProfile($profileRow, $flags) + ['is_vat_payer' => $isVat];
+        $c = $this->constants->forYear($lmYear);
+
+        $income   = $this->profiles->monthIncome($sid, $lmYm, $isVat);
+        $expenses = $this->profiles->monthExpenses($sid, $lmYm, $isVat);
+
+        return ['ym' => $lmYm] + $this->optimizer->estimateMonthly($engineProfile, $income, $expenses, $c);
     }
 
     /**

--- a/api/src/Repository/TaxProfileRepository.php
+++ b/api/src/Repository/TaxProfileRepository.php
@@ -154,6 +154,52 @@ final class TaxProfileRepository
     }
 
     /**
+     * Příjem za konkrétní měsíc (zaplacené faktury, 'YYYY-MM', kasová metoda).
+     * Pro odhad "čistý příjem za minulý měsíc" v daňovém optimalizátoru.
+     */
+    public function monthIncome(int $supplierId, string $ym, bool $isVatPayer): float
+    {
+        $col = $isVatPayer ? 'i.total_without_vat' : 'i.total_with_vat';
+        $stmt = $this->db->pdo()->prepare(
+            "SELECT COALESCE(SUM({$col} * COALESCE(IF(cur.code = 'CZK', 1, i.exchange_rate), 1)), 0)
+               FROM invoices i
+          LEFT JOIN currencies cur ON cur.id = i.currency_id
+              WHERE i.supplier_id = ?
+                AND i.status = 'paid'
+                AND i.paid_at IS NOT NULL
+                AND i.invoice_type IN ('invoice', 'credit_note', 'tax_document')
+                AND COALESCE(i.income_tax_exempt, 0) = 0
+                AND DATE_FORMAT(i.paid_at, '%Y-%m') = ?"
+        );
+        $stmt->execute([$supplierId, $ym]);
+        return round((float) $stmt->fetchColumn(), 2);
+    }
+
+    /**
+     * Náklady za konkrétní měsíc (zaplacené přijaté faktury, 'YYYY-MM', kasová metoda).
+     * Stejná konvence jako PurchaseSummaryAction::advanceCostExclude() — zaplacenou
+     * zálohu spárovanou s vyúčtovací fakturou nepočítej dvakrát.
+     */
+    public function monthExpenses(int $supplierId, string $ym, bool $isVatPayer): float
+    {
+        $col = $isVatPayer ? 'pi.total_without_vat' : 'pi.total_with_vat';
+        $stmt = $this->db->pdo()->prepare(
+            "SELECT COALESCE(SUM({$col} * COALESCE(IF(cur.code = 'CZK', 1, pi.exchange_rate), 1)), 0)
+               FROM purchase_invoices pi
+          LEFT JOIN currencies cur ON cur.id = pi.currency_id
+              WHERE pi.supplier_id = ?
+                AND pi.status = 'paid'
+                AND pi.paid_at IS NOT NULL
+                AND DATE_FORMAT(pi.paid_at, '%Y-%m') = ?
+                AND NOT (COALESCE(pi.document_kind, '') = 'advance'
+                     AND EXISTS (SELECT 1 FROM purchase_invoices adv_s
+                                 WHERE adv_s.advance_purchase_invoice_id = pi.id))"
+        );
+        $stmt->execute([$supplierId, $ym]);
+        return round((float) $stmt->fetchColumn(), 2);
+    }
+
+    /**
      * Roky, za které existují zaplacené faktury (pro přepínač roku).
      * @return list<int>
      */

--- a/api/src/Service/Tax/TaxOptimizer.php
+++ b/api/src/Service/Tax/TaxOptimizer.php
@@ -289,6 +289,75 @@ final class TaxOptimizer
         ];
     }
 
+    /**
+     * Pravděpodobný čistý příjem za konkrétní (uzavřený) měsíc — odhad.
+     *
+     * Nejde přesně spočítat: daň z příjmu i minima pojistného se počítají z
+     * ROČNÍHO základu, ne po měsících. Proto se měsíc anualizuje (× 12) a
+     * spočítá stejnou logikou jako {@see computeRegular()} (výdajový paušál
+     * NEBO skutečné náklady, odpočty, dětské slevy, minimální vyměřovací
+     * základy pojistného), výsledek se pak vydělí 12. Je to "kdyby tenhle
+     * měsíc reprezentoval celý rok" — nikdy ne přesná částka, jen orientační
+     * odhad (proto `$monthExpenses` = skutečné zaplacené náklady daného
+     * měsíce, ne paušál — reálnější cashflow obrázek).
+     *
+     * @param array<string,mixed> $profile
+     * @param array<string,mixed> $c konstanty roku
+     * @return array<string,mixed>
+     */
+    public function estimateMonthly(array $profile, float $monthIncome, float $monthExpenses, array $c): array
+    {
+        $annualIncome = $monthIncome * 12;
+
+        // Výdaje pro DAŇOVÝ ZÁKLAD (a tím i pro vyměřovací základ pojistného):
+        // stejná volba jako computeRegular() — buď výdajový paušál % z příjmu (se
+        // stropem), nebo skutečné výdaje. Paušál není reálný cashflow, proto se pro
+        // zobrazení "náklady"/"zisk" (informativní, reálná hotovost) níže vždy bere
+        // $monthExpenses (skutečně zaplacené přijaté faktury), bez ohledu na režim.
+        $rate = (int) ($profile['activity_rate'] ?? 40);
+        $useActual = !empty($profile['use_actual_expenses']);
+        $taxExpensesAnnual = $useActual
+            ? $monthExpenses * 12
+            : min($annualIncome * $rate / 100, (float) ($c['expense_caps'][$rate] ?? PHP_INT_MAX));
+
+        $deductions = min((float) ($profile['mortgage_interest'] ?? 0), (float) $c['mortgage_cap'])
+            + min((float) ($profile['pension_contrib'] ?? 0), (float) $c['pension_cap'])
+            + (float) ($profile['life_insurance'] ?? 0)
+            + (float) ($profile['donations'] ?? 0);
+
+        $base = max(0.0, $annualIncome - $taxExpensesAnnual - $deductions);
+
+        $thr = (float) $c['tax_high_threshold'];
+        $tax = $base <= $thr
+            ? $base * $c['tax_rate_low']
+            : $thr * $c['tax_rate_low'] + ($base - $thr) * $c['tax_rate_high'];
+
+        $nonRefundable = (float) $c['credit_taxpayer'] + (!empty($profile['spouse_credit']) ? (float) $c['credit_spouse'] : 0.0);
+        $taxAfterCredits = max(0.0, $tax - $nonRefundable);
+
+        $childTotal = $this->childCreditTotal((int) ($profile['children_count'] ?? 0), $c['child_credits']);
+        $annualIncomeTax = $taxAfterCredits - $childTotal;
+
+        $taxProfit = $annualIncome - $taxExpensesAnnual;
+        $socMin = !empty($profile['is_secondary']) ? (float) $c['social_min_base_secondary'] : (float) $c['social_min_base_main'];
+        $socialBase = max($taxProfit * (float) $c['social_assessment_pct'], $socMin);
+        $healthBase = max($taxProfit * (float) $c['health_assessment_pct'], (float) $c['health_min_base']);
+        $annualSocial = $socialBase * $c['social_rate'];
+        $annualHealth = $healthBase * $c['health_rate'];
+
+        $annualTotal = $annualIncomeTax + $annualSocial + $annualHealth;
+
+        return [
+            'revenue'    => round($monthIncome, 0),
+            'expenses'   => round($monthExpenses, 0),
+            'profit'     => round($monthIncome - $monthExpenses, 0),
+            'income_tax' => round($annualIncomeTax / 12, 0),
+            'social'     => round($annualSocial / 12, 0),
+            'health'     => round($annualHealth / 12, 0),
+            'net_income' => round(($annualIncome - $annualTotal) / 12, 0),
+        ];
+    }
+
     /** @param array<int,int> $credits */
     private function childCreditTotal(int $n, array $credits): float
     {

--- a/api/tests/Unit/Tax/TaxOptimizerTest.php
+++ b/api/tests/Unit/Tax/TaxOptimizerTest.php
@@ -88,6 +88,57 @@ final class TaxOptimizerTest extends TestCase
         self::assertSame(17951.0, $r['social']);        // 61 476 × 29,2 % (ne 195 540)
     }
 
+    /**
+     * estimateMonthly() = anualizace (×12) stejnou logikou jako computeRegular(),
+     * pak /12. Použité měsíční příjmy/náklady (100k/60k) anualizované dají přesně
+     * roční čísla z testRegularBasic60Percent (1,2M příjem, 720k výdaje), takže
+     * roční mezivýsledky (income_tax 41160, social 77088, health 37711) musí sedět.
+     */
+    public function testEstimateMonthlyMatchesAnnualizedRegular(): void
+    {
+        $r = $this->opt->estimateMonthly($this->profile(), 100_000.0, 60_000.0, $this->c);
+        self::assertSame(100000.0, $r['revenue']);
+        self::assertSame(60000.0, $r['expenses']);
+        self::assertSame(40000.0, $r['profit']);
+        self::assertSame(3430.0, $r['income_tax']);   // 41 160 / 12
+        self::assertSame(6424.0, $r['social']);        // 77 088 / 12
+        self::assertSame(3143.0, $r['health']);         // round(37 711 / 12)
+        self::assertSame(87003.0, $r['net_income']);    // round((1 200 000 − 155 959) / 12)
+    }
+
+    /**
+     * Regresní test: v paušálním režimu se daň/pojistné musí počítat z výdajového
+     * paušálu (% z příjmu), NE ze skutečných zaplacených nákladů — i když jsou
+     * skutečné náklady mnohem nižší. Skutečné náklady (10k) se použijí jen pro
+     * zobrazení "expenses"/"profit" (reálná hotovost), ne pro daňový základ.
+     */
+    public function testEstimateMonthlyUsesPausalRateForTaxNotRealExpenses(): void
+    {
+        $r = $this->opt->estimateMonthly($this->profile(), 100_000.0, 10_000.0, $this->c);
+        self::assertSame(10000.0, $r['expenses']);      // reálné náklady, jen pro zobrazení
+        self::assertSame(90000.0, $r['profit']);        // 100k − 10k reálný cashflow
+        // Daň/pojistné počítané ze 60% paušálu (720k), stejně jako by reálné náklady
+        // byly 60k — proto STEJNÉ hodnoty jako testEstimateMonthlyMatchesAnnualizedRegular.
+        self::assertSame(3430.0, $r['income_tax']);
+        self::assertSame(6424.0, $r['social']);
+        self::assertSame(3143.0, $r['health']);
+        self::assertSame(87003.0, $r['net_income']);
+    }
+
+    /**
+     * Strop paušálu: expense_caps[rate] = rate % × 2 000 000 (viz TaxConstants) — takže
+     * i při vysokém anualizovaném příjmu (300k/měsíc = 3,6M/rok) paušální výdaje pro
+     * daňový základ nepřekročí 720 000 (60 % z 2M), NE 60 % ze skutečného příjmu (2,16M).
+     */
+    public function testEstimateMonthlyCapsPausalExpensesAt2MIncome(): void
+    {
+        $r = $this->opt->estimateMonthly($this->profile(), 300_000.0, 0.0, $this->c);
+        // Se stropem (720k, NE 60 % × 3,6M = 2 160 000) je roční daňový základ
+        // 3 600 000 − 720 000 = 2 880 000 → měsíční daň 32 256 (ověřeno computeRegular
+        // logikou). Bez stropu by výdaje byly 3× vyšší a daň citelně nižší.
+        self::assertSame(32256.0, $r['income_tax']);
+    }
+
     /** Skutečné výdaje (daňová evidence) místo paušálu. */
     public function testActualExpensesOverridePausal(): void
     {

--- a/web/src/api/tax.ts
+++ b/web/src/api/tax.ts
@@ -48,6 +48,18 @@ export interface TaxConstantsData {
   kh_item_threshold: number
 }
 
+/** Pravděpodobný čistý příjem za minulý kalendářní měsíc (odhad, viz TaxOptimizer::estimateMonthly). */
+export interface LastMonthEstimate {
+  ym: string
+  revenue: number
+  expenses: number
+  profit: number
+  income_tax: number
+  social: number
+  health: number
+  net_income: number
+}
+
 export interface TaxAnalysis {
   year: number
   mode: 'retrospective' | 'forecast'
@@ -61,6 +73,7 @@ export interface TaxAnalysis {
   months_elapsed?: number
   /** YoY: příjem + konstanty předchozího roku (jen v retrospektivě, pokud loni byl příjem). */
   prev?: { year: number; income: number; constants: TaxConstantsData } | null
+  last_month: LastMonthEstimate
 }
 
 export const taxApi = {

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -4031,7 +4031,16 @@
     "social_secondary_cross": "projekce zisku {profit} ho překročí v {month} — budeš platit sociální pojištění",
     "social_secondary_ok": "projekce zisku {profit} zůstává pod limitem — sociální pojištění neplatíš",
     "defer_tip": "Limit 2 M překročíš až {month}. Posunutím prosincových faktur do ledna zůstaneš pod limitem (neplátce + paušál).",
-    "disclaimer": "Orientační výpočet dle aktuálních konstant — nenahrazuje daňové poradenství. Příjmy z vystavených (zaplacených) faktur."
+    "disclaimer": "Orientační výpočet dle aktuálních konstant — nenahrazuje daňové poradenství. Příjmy z vystavených (zaplacených) faktur.",
+    "last_month_title": "Čistý příjem za minulý měsíc ({month})",
+    "last_month_revenue": "Tržby (zaplacené faktury)",
+    "last_month_expenses": "Náklady (zaplacené faktury)",
+    "last_month_profit": "Zisk",
+    "last_month_tax": "− předpokládaná daň z příjmu",
+    "last_month_social": "− předpokládané sociální pojištění",
+    "last_month_health": "− předpokládané zdravotní pojištění",
+    "last_month_net": "= Pravděpodobný čistý příjem",
+    "last_month_hint": "Odhad: měsíc anualizovaný (× 12) a spočtený stejně jako roční daň (paušál/skutečné výdaje, odpočty, dětské slevy, minimální základy pojistného), pak vydělený 12. Nikdy ne přesná částka."
   },
   "workReportTracking": {
     "button": "Poslat odkaz na sledování výkazu práce",

--- a/web/src/pages/tax/TaxOptimizer.vue
+++ b/web/src/pages/tax/TaxOptimizer.vue
@@ -14,6 +14,7 @@ const saving = ref(false)
 const error = ref('')
 const analysis = ref<TaxAnalysis | null>(null)
 const year = ref<number>(new Date().getFullYear())
+const lastMonthOpen = ref(false)
 
 const profile = reactive<TaxProfile>({
   activity_rate: 60, use_actual_expenses: false, actual_expenses: 0,
@@ -218,6 +219,34 @@ async function save() {
 
       <!-- ── VÝSLEDKY ── -->
       <div>
+        <!-- Čistý příjem za minulý měsíc (odhad, nezávisle na zvoleném roce) -->
+        <div v-if="analysis.last_month" class="bg-surface border border-neutral-200 rounded-lg shadow-sm mb-6 overflow-hidden">
+          <button type="button" @click="lastMonthOpen = !lastMonthOpen"
+            class="w-full flex items-center justify-between gap-3 px-5 py-4 text-left cursor-pointer hover:bg-neutral-50">
+            <div>
+              <div class="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                {{ t('tax.last_month_title', { month: formatMonth(analysis.last_month.ym) }) }}
+              </div>
+              <div class="text-2xl font-bold font-mono text-success-700 mt-1">{{ formatMoney(analysis.last_month.net_income, 'CZK') }}</div>
+            </div>
+            <span class="text-neutral-400 transition-transform shrink-0" :class="lastMonthOpen ? 'rotate-180' : ''">▾</span>
+          </button>
+          <div v-if="lastMonthOpen" class="px-5 pb-5 border-t border-neutral-100">
+            <table class="w-full text-sm mt-3">
+              <tbody>
+                <tr class="border-b border-neutral-100"><td class="py-1.5 text-neutral-600">{{ t('tax.last_month_revenue') }}</td><td class="py-1.5 text-right font-medium font-mono">{{ formatMoney(analysis.last_month.revenue, 'CZK') }}</td></tr>
+                <tr class="border-b border-neutral-100"><td class="py-1.5 text-neutral-600">− {{ t('tax.last_month_expenses') }}</td><td class="py-1.5 text-right font-medium font-mono">{{ formatMoney(analysis.last_month.expenses, 'CZK') }}</td></tr>
+                <tr class="border-b border-neutral-100"><td class="py-1.5 text-neutral-600">= {{ t('tax.last_month_profit') }}</td><td class="py-1.5 text-right font-medium font-mono">{{ formatMoney(analysis.last_month.profit, 'CZK') }}</td></tr>
+                <tr class="border-b border-neutral-100"><td class="py-1.5 text-neutral-600">{{ t('tax.last_month_tax') }}</td><td class="py-1.5 text-right font-medium font-mono">{{ formatMoney(analysis.last_month.income_tax, 'CZK') }}</td></tr>
+                <tr class="border-b border-neutral-100"><td class="py-1.5 text-neutral-600">{{ t('tax.last_month_social') }}</td><td class="py-1.5 text-right font-medium font-mono">{{ formatMoney(analysis.last_month.social, 'CZK') }}</td></tr>
+                <tr class="border-b border-neutral-100"><td class="py-1.5 text-neutral-600">{{ t('tax.last_month_health') }}</td><td class="py-1.5 text-right font-medium font-mono">{{ formatMoney(analysis.last_month.health, 'CZK') }}</td></tr>
+                <tr><td class="pt-2 font-bold text-success-700">{{ t('tax.last_month_net') }}</td><td class="pt-2 text-right font-bold font-mono text-success-700">{{ formatMoney(analysis.last_month.net_income, 'CZK') }}</td></tr>
+              </tbody>
+            </table>
+            <p class="mt-2 text-[11px] text-neutral-400">{{ t('tax.last_month_hint') }}</p>
+          </div>
+        </div>
+
         <!-- RETROSPEKTIVA (uzavřený rok) -->
         <template v-if="cmp">
           <div class="text-sm text-neutral-500 mb-3">


### PR DESCRIPTION
Rozbalovací karta v Daňovém optimalizátoru ukazuje pravděpodobný čistý příjem za poslední uzavřený kalendářní měsíc — reálné zaplacené tržby a náklady, anualizované (×12) přes stejnou logiku jako roční přepočet (výdajový paušál se stropem 2M příjmu, skutečné výdaje, odpočty, dětské slevy, minimální vyměřovací základy pojistného), pak vydělené
12. Paušál ovlivňuje jen daňový základ, ne zobrazenou reálnou hotovost.