### PR TITLE
feat(idoklad): synchronizovat mapování bankovních účtů

### DIFF
--- a/api/src/Action/Admin/Import/StartIdokladImportAction.php
+++ b/api/src/Action/Admin/Import/StartIdokladImportAction.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 /**
  * POST /api/admin/imports/idoklad/start
  *
- * Body: { include_clients?: bool, include_issued?: bool, include_received?: bool, include_receipts?: bool, dry_run?: bool }
+ * Body: { include_bank_accounts?: bool, include_clients?: bool, include_issued?: bool, include_received?: bool, include_receipts?: bool, dry_run?: bool }
  *
  * Vytvoří import_jobs řádek se status='queued' a spustí background worker
  * (detached process — Windows DETACHED_PROCESS, Linux nohup). UI pak polluje
@@ -71,6 +71,7 @@ final class StartIdokladImportAction
 
         $body = (array) ($request->getParsedBody() ?? []);
         $params = [
+            'include_bank_accounts'=> $body['include_bank_accounts'] ?? true,
             'include_clients'      => $body['include_clients']      ?? true,
             'include_issued'       => $body['include_issued']       ?? true,
             'include_received'     => $body['include_received']     ?? true,

--- a/api/src/Service/Import/IdokladImportService.php
+++ b/api/src/Service/Import/IdokladImportService.php
@@ -10,6 +10,7 @@ use MyInvoice\Repository\ImportJobRepository;
 use MyInvoice\Infrastructure\Config\Config;
 use MyInvoice\Repository\InvoiceRepository;
 use MyInvoice\Repository\PurchaseInvoiceRepository;
+use MyInvoice\Service\Bank\AccountNumberNormalizer;
 use MyInvoice\Service\Invoice\InvoiceCalculator;
 use MyInvoice\Service\Invoice\PurchaseInvoiceCalculator;
 use MyInvoice\Service\Invoice\SnapshotBuilder;
@@ -60,6 +61,7 @@ final class IdokladImportService
      *   - include_clients: bool (default true)
      *   - include_issued: bool (default true)
      *   - include_received: bool (default true)
+     *   - include_bank_accounts: bool (default true)
      *   - include_receipts: bool (default true) — přijaté účtenky/paragony
      *   - dry_run: bool (default false)
      */
@@ -85,6 +87,11 @@ final class IdokladImportService
             if ($incremental && $bookmarkSince !== null) $msg .= ', incremental od ' . $bookmarkSince;
             if ($downloadAttachments) $msg .= ', s přílohami';
             $this->jobs->appendLog($jobId, $msg . '.');
+
+            if (!empty($params['include_bank_accounts']) || ($params['include_bank_accounts'] ?? null) === null) {
+                $this->importBankAccounts($jobId, $supplierId, $dryRun);
+                $this->checkCancel($jobId);
+            }
 
             if (!empty($params['include_clients']) || ($params['include_clients'] ?? null) === null) {
                 $this->importClients($jobId, $supplierId, $userId, $dryRun, $bookmarkSince);
@@ -139,6 +146,85 @@ final class IdokladImportService
         if ($this->jobs->isCancelRequested($jobId)) {
             throw new CancelledException();
         }
+    }
+
+    private function importBankAccounts(int $jobId, int $supplierId, bool $dryRun): void
+    {
+        $this->jobs->appendLog($jobId, 'Synchronizuji bankovní účty z iDokladu…');
+        $pdo = $this->db->pdo();
+        $upsert = $pdo->prepare(
+            "INSERT INTO external_bank_account_mappings
+                (supplier_id, provider, external_account_id, currency_id, external_currency_id,
+                 external_bank_id, account_number, iban, name, is_default, sync_status, synced_at)
+             VALUES (?, 'idoklad', ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
+             ON DUPLICATE KEY UPDATE
+                currency_id = VALUES(currency_id), external_currency_id = VALUES(external_currency_id),
+                external_bank_id = VALUES(external_bank_id), account_number = VALUES(account_number),
+                iban = VALUES(iban), name = VALUES(name), is_default = VALUES(is_default),
+                sync_status = VALUES(sync_status), synced_at = NOW()"
+        );
+
+        $matched = 0; $unmatched = 0; $ambiguous = 0;
+        foreach ($this->idoklad->getAll($supplierId, 'BankAccounts') as $external) {
+            $externalId = (int) ($external['Id'] ?? 0);
+            if ($externalId <= 0) continue;
+            $code = $this->idokladCurrencyCode($external, $supplierId);
+            $stmt = $pdo->prepare(
+                'SELECT id, account_number, bank_code, iban FROM currencies
+                  WHERE supplier_id = ? AND code = ? AND is_active = 1 ORDER BY id'
+            );
+            $stmt->execute([$supplierId, strtoupper($code)]);
+            $selection = self::matchExternalBankAccount($external, $stmt->fetchAll(\PDO::FETCH_ASSOC) ?: []);
+            if ($selection['status'] === 'matched') $matched++;
+            elseif ($selection['status'] === 'ambiguous') $ambiguous++;
+            else $unmatched++;
+            if ($dryRun) continue;
+            $upsert->execute([
+                $supplierId, (string) $externalId, $selection['currency_id'],
+                (string) ($external['CurrencyId'] ?? ''), (string) ($external['BankId'] ?? ''),
+                self::nullableString($external['AccountNumber'] ?? null),
+                self::nullableString($external['Iban'] ?? null),
+                self::nullableString($external['Name'] ?? null),
+                !empty($external['IsDefault']) ? 1 : 0, $selection['status'],
+            ]);
+        }
+        $this->jobs->appendLog($jobId, "Bankovní účty: spárováno {$matched}, bez shody {$unmatched}, nejednoznačné {$ambiguous}." . ($dryRun ? ' (dry-run)' : ''));
+    }
+
+    /**
+     * @param array<string,mixed> $external
+     * @param list<array<string,mixed>> $candidates
+     * @return array{currency_id:?int,status:'matched'|'unmatched'|'ambiguous'}
+     */
+    public static function matchExternalBankAccount(array $external, array $candidates): array
+    {
+        $number = trim((string) ($external['AccountNumber'] ?? ''));
+        $iban = trim((string) ($external['Iban'] ?? ''));
+        $externalBank = AccountNumberNormalizer::czechIbanBankCode($iban) ?? '';
+        $matches = [];
+        foreach ($candidates as $candidate) {
+            $candidateIban = self::nullableString($candidate['iban'] ?? null);
+            $numberMatches = $number !== ''
+                && AccountNumberNormalizer::matchesAny($number, $candidate['account_number'] ?? null, $candidateIban);
+            $ibanMatches = $iban !== '' && $candidateIban !== null
+                && strtoupper(preg_replace('/\s+/', '', $iban) ?? '') === strtoupper(preg_replace('/\s+/', '', $candidateIban) ?? '');
+            if (!$numberMatches && !$ibanMatches) continue;
+            $candidateBank = trim((string) ($candidate['bank_code'] ?? ''));
+            if ($candidateBank === '' && $candidateIban !== null) {
+                $candidateBank = AccountNumberNormalizer::czechIbanBankCode($candidateIban) ?? '';
+            }
+            if ($externalBank !== '' && $candidateBank !== '' && $externalBank !== $candidateBank) continue;
+            $matches[] = (int) $candidate['id'];
+        }
+        if (count($matches) === 1) return ['currency_id' => $matches[0], 'status' => 'matched'];
+        if (count($matches) > 1) return ['currency_id' => null, 'status' => 'ambiguous'];
+        return ['currency_id' => null, 'status' => 'unmatched'];
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        $value = trim((string) ($value ?? ''));
+        return $value === '' ? null : $value;
     }
 
     /**

--- a/api/tests/Unit/Service/Import/IdokladBankAccountMappingTest.php
+++ b/api/tests/Unit/Service/Import/IdokladBankAccountMappingTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Import;
+
+use MyInvoice\Service\Import\IdokladImportService;
+use PHPUnit\Framework\TestCase;
+
+final class IdokladBankAccountMappingTest extends TestCase
+{
+    public function testMatchesSingleAccountByNumberAndIbanBankCode(): void
+    {
+        $external = [
+            'AccountNumber' => '1000000005',
+            'Iban' => 'CZ0001000000001000000005',
+        ];
+        $candidates = [
+            ['id' => 10, 'account_number' => '1000000005', 'bank_code' => '0100', 'iban' => null],
+            ['id' => 20, 'account_number' => '1000000005', 'bank_code' => '2010', 'iban' => null],
+        ];
+
+        self::assertSame(
+            ['currency_id' => 10, 'status' => 'matched'],
+            IdokladImportService::matchExternalBankAccount($external, $candidates),
+        );
+    }
+
+    public function testReportsAmbiguousNumberWithoutBankIdentification(): void
+    {
+        $external = ['AccountNumber' => '1000000005', 'Iban' => ''];
+        $candidates = [
+            ['id' => 10, 'account_number' => '1000000005', 'bank_code' => '0100', 'iban' => null],
+            ['id' => 20, 'account_number' => '1000000005', 'bank_code' => '2010', 'iban' => null],
+        ];
+
+        self::assertSame(
+            ['currency_id' => null, 'status' => 'ambiguous'],
+            IdokladImportService::matchExternalBankAccount($external, $candidates),
+        );
+    }
+
+    public function testReportsUnmatchedAccount(): void
+    {
+        self::assertSame(
+            ['currency_id' => null, 'status' => 'unmatched'],
+            IdokladImportService::matchExternalBankAccount(
+                ['AccountNumber' => '1000000005'],
+                [['id' => 10, 'account_number' => '1000000006', 'bank_code' => '0100', 'iban' => null]],
+            ),
+        );
+    }
+}

--- a/db/migrations/0135_external_bank_account_mappings.sql
+++ b/db/migrations/0135_external_bank_account_mappings.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE IF NOT EXISTS external_bank_account_mappings (
     id                  BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    supplier_id         BIGINT UNSIGNED NOT NULL,
+    supplier_id         INT UNSIGNED NOT NULL,
     provider            VARCHAR(32) NOT NULL,
     external_account_id VARCHAR(100) NOT NULL,
     currency_id         INT UNSIGNED NULL,

--- a/db/migrations/0135_external_bank_account_mappings.sql
+++ b/db/migrations/0135_external_bank_account_mappings.sql
@@ -1,0 +1,28 @@
+-- Mapování bankovních účtů externích integrací na účty MyInvoice.
+-- Externí synchronizace účty v currencies nevytváří ani nepřepisuje.
+
+CREATE TABLE IF NOT EXISTS external_bank_account_mappings (
+    id                  BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    supplier_id         BIGINT UNSIGNED NOT NULL,
+    provider            VARCHAR(32) NOT NULL,
+    external_account_id VARCHAR(100) NOT NULL,
+    currency_id         INT UNSIGNED NULL,
+    external_currency_id VARCHAR(100) NULL,
+    external_bank_id    VARCHAR(100) NULL,
+    account_number      VARCHAR(50) NULL,
+    iban                VARCHAR(50) NULL,
+    name                VARCHAR(100) NULL,
+    is_default          TINYINT(1) NOT NULL DEFAULT 0,
+    sync_status         ENUM('matched','unmatched','ambiguous') NOT NULL DEFAULT 'unmatched',
+    synced_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_external_bank_account (supplier_id, provider, external_account_id),
+    KEY idx_external_bank_currency (currency_id),
+    KEY idx_external_bank_status (supplier_id, provider, sync_status),
+    CONSTRAINT fk_external_bank_supplier FOREIGN KEY (supplier_id)
+        REFERENCES supplier(id) ON DELETE CASCADE,
+    CONSTRAINT fk_external_bank_currency FOREIGN KEY (currency_id)
+        REFERENCES currencies(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/manual/16_Importy.md
+++ b/manual/16_Importy.md
@@ -186,6 +186,11 @@ Na téže stránce, sekce **Spustit import**:
 
 Klikni **Spustit import**.
 
+Volba **Bankovní účty** synchronizuje číselník účtů z iDokladu a bezpečně jej
+mapuje na aktivní účty stejné měny v MyInvoice. Přesná shoda se propojí;
+neznámý nebo nejednoznačný účet se pouze označí ke kontrole. Synchronizace
+nikdy automaticky nezakládá ani nepřepisuje lokální bankovní účet.
+
 ### 16.8.4 Co se importuje
 
 | Sekce | Co se vytvoří |

--- a/web/src/api/integrations.ts
+++ b/web/src/api/integrations.ts
@@ -38,6 +38,7 @@ export interface ImportJob {
 }
 
 export interface IdokladStartParams {
+  include_bank_accounts?: boolean
   include_clients?: boolean
   include_issued?: boolean
   include_received?: boolean

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -3793,6 +3793,7 @@
       "step4": "Copy client_id + client_secret a vložit zde",
       "run_title": "Spustit import",
       "run_hint": "Import běží na pozadí. Stav se polluje každé 2 sekundy. Můžeš zrušit kdykoli.",
+      "include_bank_accounts": "Bankovní účty",
       "include_clients": "Kontakty (clients)",
       "include_issued": "Vydané faktury",
       "include_received": "Přijaté faktury",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -3793,6 +3793,7 @@
       "step4": "Copy client_id + client_secret and paste here",
       "run_title": "Run import",
       "run_hint": "Import runs in background. Status polled every 2 seconds. Can be cancelled.",
+      "include_bank_accounts": "Bank accounts",
       "include_clients": "Contacts (clients)",
       "include_issued": "Issued invoices",
       "include_received": "Received invoices",

--- a/web/src/pages/admin/Integrations.vue
+++ b/web/src/pages/admin/Integrations.vue
@@ -80,6 +80,7 @@ async function deleteIdokladCreds() {
 
 // ── iDoklad import job state ──────────────────────────────────────────
 const startParams = ref({
+  include_bank_accounts: true,
   include_clients: true,
   include_issued: true,
   include_received: true,
@@ -544,6 +545,10 @@ onUnmounted(() => {
         <div v-if="!isJobRunning" class="space-y-3">
           <p class="text-sm text-neutral-600">{{ t('integrations.idoklad.run_hint') }}</p>
           <div class="grid grid-cols-2 gap-3">
+            <label class="flex items-center gap-2 text-sm">
+              <input v-model="startParams.include_bank_accounts" type="checkbox" class="rounded border-neutral-300 text-primary-600" />
+              {{ t('integrations.idoklad.include_bank_accounts') }}
+            </label>
             <label class="flex items-center gap-2 text-sm">
               <input v-model="startParams.include_clients" type="checkbox" class="rounded border-neutral-300 text-primary-600" />
               {{ t('integrations.idoklad.include_clients') }}


### PR DESCRIPTION
## Co se mění

- iDoklad import umí jako samostatnou volbu synchronizovat endpoint `BankAccounts`
- externí účty se ukládají do obecné mapovací tabulky a propojí se s aktivním účtem MyInvoice pouze při právě jedné bezpečné shodě
- neznámé a nejednoznačné účty mají stav `unmatched` / `ambiguous`; lokální `currencies` se nikdy automaticky nezakládají ani nepřepisují
- opakovaná synchronizace je idempotentní přes `(supplier_id, provider, external_account_id)`
- importní log uvádí počty spárovaných, neznámých a nejednoznačných účtů
- přidána volba Bankovní účty do administračního formuláře, český i anglický překlad a dokumentace

## Proč

Bankovní pohyby iDokladu odkazují na vlastní účet přes `BankAccountId`. Před jejich budoucím importem potřebujeme stabilní a tenantově oddělené mapování na konkrétní bankovní účet v MyInvoice. Samotné číslo účtu nestačí, protože více účtů může sdílet stejné normalizované číslo a lišit se bankou nebo měnou.

Tento PR tvoří bezpečný základ pro navazující import pohybů a jejich deduplikaci vůči GPC/IMAP. Bankovní pohyby zatím neimportuje.

## Bezpečnost a chování

- automatické propojení vznikne jen při jediné shodě čísla/IBANu v rámci stejného dodavatele a měny
- u českého IBANu se kontroluje také bankovní kód
- nejednoznačnost se neřeší výběrem prvního řádku
- migrace je idempotentní a vazby používají `ON DELETE CASCADE/SET NULL`

## Ověření

- regresní test přesné shody, nejednoznačnosti a chybějící shody se syntetickými účty
- kompletní backend: 1 587 testů, 3 453 assertions, bez chyb (387 environment-dependent skipped)
- `vue-tsc --noEmit` a produkční Vite build prošly
- manuál vygenerován do HTML a PDF bez chyby

## Navazující práce

Další samostatný PR využije toto mapování pro import `BankStatements` a reconciliation stejné platby mezi iDoklad, IMAP a autoritativním GPC výpisem bez dvojího započtení.
