### PR TITLE
feat(bank): zobrazit vazbu faktury na bankovní operaci

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -630,9 +630,13 @@ paths:
       tags: [Invoices]
       summary: Evidované platby faktury
       description: |
-        Seznam plateb (částečných úhrad) faktury nebo zálohové faktury + souhrn:
+        Seznam plateb (částečných úhrad), přímo spárovaných bankovních operací
+        a souhrn faktury nebo zálohové faktury:
         `paid_total`, `remaining` (= `amount_to_pay - paid_total`) a odvozený
         `payment_status` (`unpaid` / `partially_paid` / `paid` / `overpaid`).
+        `bank_transactions` je informační vazba a samo o sobě se nezapočítává
+        do `paid_total`; využívá se mimo jiné pro historické doklady importované
+        jako uhrazené z externího systému.
       responses:
         '200':
           description: OK
@@ -644,6 +648,9 @@ paths:
                   payments:
                     type: array
                     items: { $ref: '#/components/schemas/InvoicePayment' }
+                  bank_transactions:
+                    type: array
+                    items: { $ref: '#/components/schemas/InvoiceRelatedBankTransaction' }
                   paid_total: { type: number, format: float }
                   amount_to_pay: { type: number, format: float }
                   remaining: { type: number, format: float }
@@ -6635,6 +6642,26 @@ components:
         tax_document_status: { type: string, nullable: true, enum: [draft, issued, sent, reminded, paid, cancelled] }
         created_by: { type: integer, nullable: true }
         created_at: { type: string, format: date-time }
+
+    InvoiceRelatedBankTransaction:
+      type: object
+      description: "Bankovní operace přímo spárovaná s fakturou přes matched_invoice_id. Jde o dohledatelnou vazbu; bez odpovídajícího InvoicePayment se nezapočítává do paid_total."
+      properties:
+        id: { type: integer, format: int64 }
+        statement_id: { type: integer, format: int64 }
+        statement_source: { type: string, enum: [gpc, pdf, email_notice, idoklad] }
+        posted_at: { type: string, format: date }
+        amount: { type: number, format: float }
+        currency: { type: string, nullable: true }
+        variable_symbol: { type: string, nullable: true }
+        constant_symbol: { type: string, nullable: true }
+        specific_symbol: { type: string, nullable: true }
+        counterparty_account: { type: string, nullable: true }
+        counterparty_bank: { type: string, nullable: true }
+        counterparty_name: { type: string, nullable: true }
+        description: { type: string, nullable: true }
+        bank_ref: { type: string, nullable: true }
+        match_status: { type: string, enum: [unmatched, auto_exact, auto_partial, manual, ignored] }
 
     InvoiceItem:
       type: object

--- a/api/src/Action/Invoice/ListPaymentsAction.php
+++ b/api/src/Action/Invoice/ListPaymentsAction.php
@@ -12,8 +12,8 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 /**
- * GET /api/invoices/{id}/payments — evidované platby faktury + souhrn
- * (paid_total, zbývá k úhradě, odvozený payment_status).
+ * GET /api/invoices/{id}/payments — evidované platby faktury, přímo spárované
+ * bankovní operace a souhrn (paid_total, zbývá k úhradě, payment_status).
  */
 final class ListPaymentsAction
 {
@@ -31,10 +31,11 @@ final class ListPaymentsAction
         }
 
         return Json::ok($response, [
-            'payments'       => $this->payments->listFor($id),
-            'paid_total'     => (float) ($invoice['paid_total'] ?? 0),
-            'amount_to_pay'  => (float) ($invoice['amount_to_pay'] ?? 0),
-            'remaining'      => round((float) ($invoice['amount_to_pay'] ?? 0) - (float) ($invoice['paid_total'] ?? 0), 2),
+            'payments'          => $this->payments->listFor($id),
+            'bank_transactions' => $this->payments->listRelatedBankTransactions($id),
+            'paid_total'        => (float) ($invoice['paid_total'] ?? 0),
+            'amount_to_pay'     => (float) ($invoice['amount_to_pay'] ?? 0),
+            'remaining'         => round((float) ($invoice['amount_to_pay'] ?? 0) - (float) ($invoice['paid_total'] ?? 0), 2),
             'payment_status' => InvoicePaymentService::paymentStatus($invoice),
         ]);
     }

--- a/api/src/Service/Import/IdokladBankTransactionImporter.php
+++ b/api/src/Service/Import/IdokladBankTransactionImporter.php
@@ -83,6 +83,12 @@ final class IdokladBankTransactionImporter
                 ]);
                 $txId = (int) $pdo->lastInsertId();
 
+                if ($this->hasPairedIssuedInvoice(
+                    $pdo, $supplierId, $movement, $amount, (string) $account['currency']
+                )) {
+                    $result['document_links']++;
+                }
+
                 $authoritativeTwinId = $this->reconciler->ignoreSecondaryWhenAuthoritativeTwinExists($txId);
                 if ($authoritativeTwinId !== null) {
                     if ($this->reconcileAuthoritativeInvoice(

--- a/api/src/Service/Invoice/InvoicePaymentService.php
+++ b/api/src/Service/Invoice/InvoicePaymentService.php
@@ -83,6 +83,36 @@ final class InvoicePaymentService
         return array_map([self::class, 'castPayment'], $stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
     }
 
+    /**
+     * Bankovní operace přímo spárované s fakturou, nezávisle na účetní evidenci
+     * invoice_payments. Typicky jde o historické faktury importované jako uhrazené
+     * z iDokladu: bankovní matcher zná přesnou vazbu, ale zpětně nevytváří platbu.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function listRelatedBankTransactions(int $invoiceId): array
+    {
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT bt.id, bt.statement_id, bs.source AS statement_source,
+                    bt.posted_at, bt.amount, bt.currency,
+                    bt.variable_symbol, bt.constant_symbol, bt.specific_symbol,
+                    bt.counterparty_account, bt.counterparty_bank, bt.counterparty_name,
+                    bt.description, bt.bank_ref, bt.match_status
+               FROM bank_transactions bt
+               JOIN bank_statements bs ON bs.id = bt.statement_id
+              WHERE bt.matched_invoice_id = ?
+              ORDER BY bt.posted_at, bt.id'
+        );
+        $stmt->execute([$invoiceId]);
+
+        return array_map(static function (array $row): array {
+            $row['id'] = (int) $row['id'];
+            $row['statement_id'] = (int) $row['statement_id'];
+            $row['amount'] = (float) $row['amount'];
+            return $row;
+        }, $stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
+    }
+
     /** @return array<string,mixed>|null */
     public function findPayment(int $paymentId): ?array
     {

--- a/api/tests/Integration/Bank/EmailNoticeReconcilerTest.php
+++ b/api/tests/Integration/Bank/EmailNoticeReconcilerTest.php
@@ -277,6 +277,40 @@ final class EmailNoticeReconcilerTest extends TestCase
         self::assertNull($secondary['matched_invoice_id']);
     }
 
+    public function testRelatedBankTransactionFollowsAuthoritativeTwinWithoutPaymentRow(): void
+    {
+        $invoiceId = $this->insertInvoice(self::VS_A, 1000.00);
+        $this->db->pdo()->prepare(
+            "UPDATE invoices SET status = 'paid', paid_at = '2099-06-15' WHERE id = ?"
+        )->execute([$invoiceId]);
+
+        [, $idokladTx] = $this->insertStatementWithTx('idoklad', 1000.00, self::VS_A, 'idoklad-trace');
+        $this->markTxMatched($idokladTx, $invoiceId, 'auto_exact');
+
+        $before = $this->payments->listRelatedBankTransactions($invoiceId);
+        self::assertCount(1, $before);
+        self::assertSame('idoklad', $before[0]['statement_source']);
+        self::assertSame($idokladTx, $before[0]['id']);
+        self::assertSame(0, $this->paymentCountForTx($idokladTx));
+
+        [, $gpcTx] = $this->insertStatementWithTx('gpc', 1000.00, self::VS_A, 'gpc-trace');
+        self::assertNotNull($this->reconciler->takeOverFromEmailNotice($gpcTx));
+
+        $after = $this->payments->listRelatedBankTransactions($invoiceId);
+        self::assertCount(1, $after);
+        self::assertSame('gpc', $after[0]['statement_source']);
+        self::assertSame($gpcTx, $after[0]['id']);
+        self::assertSame(self::VS_A, $after[0]['variable_symbol']);
+        self::assertSame(1000.0, $after[0]['amount']);
+        self::assertSame(0, $this->paymentCountForTx($gpcTx));
+
+        $secondary = $this->db->pdo()->query(
+            "SELECT match_status, matched_invoice_id FROM bank_transactions WHERE id = $idokladTx"
+        )->fetch(PDO::FETCH_ASSOC);
+        self::assertSame('ignored', $secondary['match_status']);
+        self::assertNull($secondary['matched_invoice_id']);
+    }
+
     public function testIdokladIsIgnoredWhenGpcAlreadyExists(): void
     {
         [, $gpcTx] = $this->insertStatementWithTx('gpc', 1000.00, self::VS_A, 'gpc-first');

--- a/manual/11_Faktura_PDF.md
+++ b/manual/11_Faktura_PDF.md
@@ -54,6 +54,14 @@ stavu *Zaplaceno* mezi pohledávky. Platba navázaná na bankovní transakci se
 maže přes **Zrušit spárování** v detailu výpisu; platba s vystaveným daňovým
 dokladem až po jeho smazání/stornu.
 
+U faktur importovaných z externího systému může být doklad označen jako uhrazený
+ještě před importem bankovních dat. Pokud se později bankovní operace přímo spáruje
+s fakturou, detail zobrazí samostatný box **Související bankovní operace**. Obsahuje
+původní údaje z banky (datum, částku, účet a název protistrany, VS/KS/SS, popis a
+odkaz na výpis). Jde o dohledatelnou vazbu; bez samostatně evidované platby se tato
+operace znovu nezapočítává do uhrazené částky. Při nalezení stejné operace v GPC/PDF
+výpisu se odkaz přesune na tento autoritativní bankovní zdroj.
+
 Stav úhrady ukazuje badge: **Částečně uhrazeno** (přijata část peněz, zbytek
 se dál upomíná a počítá do pohledávek) a **Přeplaceno** (přišlo víc než
 částka k úhradě). V sumaci detailu je řádek **Uhrazeno** a **Zbývá uhradit**;

--- a/web/src/api/invoices.ts
+++ b/web/src/api/invoices.ts
@@ -28,10 +28,30 @@ export interface InvoicePayment {
 
 export interface InvoicePaymentsResponse {
   payments: InvoicePayment[]
+  bank_transactions: RelatedBankTransaction[]
   paid_total: number
   amount_to_pay: number
   remaining: number
   payment_status: PaymentStatus | null
+}
+
+/** Bankovní operace přímo spárovaná s fakturou, i když nevytvořila účetní platbu. */
+export interface RelatedBankTransaction {
+  id: number
+  statement_id: number
+  statement_source: 'gpc' | 'pdf' | 'email_notice' | 'idoklad'
+  posted_at: string
+  amount: number
+  currency: string | null
+  variable_symbol: string | null
+  constant_symbol: string | null
+  specific_symbol: string | null
+  counterparty_account: string | null
+  counterparty_bank: string | null
+  counterparty_name: string | null
+  description: string | null
+  bank_ref: string | null
+  match_status: 'unmatched' | 'auto_exact' | 'auto_partial' | 'manual' | 'ignored'
 }
 
 /** Nespárovaná zálohová faktura (proforma) nabídnutá k propojení s daňovým dokladem. */

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -1419,7 +1419,17 @@
       "recorded_paid": "Platba zaevidována — doklad je plně uhrazen.",
       "deleted": "Platba smazána.",
       "delete_confirm": "Smazat platbu {amount} ze dne {date}?",
-      "locked_bank": "Platba z bankovního párování — ruší se přes „Zrušit spárování“ v detailu výpisu."
+      "locked_bank": "Platba z bankovního párování — ruší se přes „Zrušit spárování“ v detailu výpisu.",
+      "bank_transactions_title": "Související bankovní operace",
+      "bank_transactions_hint": "Operace je přímo spárovaná s fakturou, ale není samostatně započtená v evidenci plateb. Zobrazené údaje odpovídají původnímu bankovnímu záznamu.",
+      "counterparty": "Protistrana",
+      "bank_sources": {
+        "gpc": "GPC",
+        "pdf": "PDF výpis",
+        "email_notice": "E-mailové avízo",
+        "idoklad": "iDoklad"
+      },
+      "imported_without_details": "Doklad je evidován jako uhrazený dne {date}, ale podrobnosti platby nejsou k dispozici."
     },
     "cancel_or_credit": "Storno / dobropis",
     "cancel_credit_note": "Storno dobropisu",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -1419,7 +1419,17 @@
       "recorded_paid": "Payment recorded — the document is fully paid.",
       "deleted": "Payment deleted.",
       "delete_confirm": "Delete payment {amount} from {date}?",
-      "locked_bank": "Payment from bank matching — remove it via “Unmatch” in the statement detail."
+      "locked_bank": "Payment from bank matching — remove it via “Unmatch” in the statement detail.",
+      "bank_transactions_title": "Related bank transactions",
+      "bank_transactions_hint": "The transaction is directly matched to the invoice but is not counted separately in the payment ledger. The displayed details come from the original bank record.",
+      "counterparty": "Counterparty",
+      "bank_sources": {
+        "gpc": "GPC",
+        "pdf": "PDF statement",
+        "email_notice": "Email notice",
+        "idoklad": "iDoklad"
+      },
+      "imported_without_details": "The document is recorded as paid on {date}, but payment details are unavailable."
     },
     "cancel_or_credit": "Cancel / credit note",
     "cancel_credit_note": "Cancel credit note",

--- a/web/src/pages/invoices/InvoiceDetail.vue
+++ b/web/src/pages/invoices/InvoiceDetail.vue
@@ -3,7 +3,7 @@ import LinkedDocumentsPanel from '@/components/documents/LinkedDocumentsPanel.vu
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { invoicesApi, type Invoice, type WorkReport, type ApprovalStatus, type InvoiceAttachment, type AdvanceCandidate, type InvoicePayment } from '@/api/invoices'
+import { invoicesApi, type Invoice, type WorkReport, type ApprovalStatus, type InvoiceAttachment, type AdvanceCandidate, type InvoicePayment, type RelatedBankTransaction } from '@/api/invoices'
 import {
   settingsApi,
   type PdfSignatureDocumentEntityType,
@@ -180,6 +180,7 @@ async function load() {
 
 // ───── Evidence plateb / částečné úhrady (#89) ─────────────────────────
 const payments = ref<InvoicePayment[]>([])
+const bankTransactions = ref<RelatedBankTransaction[]>([])
 
 function paymentsRelevant(): boolean {
   const inv = invoice.value
@@ -189,11 +190,19 @@ function paymentsRelevant(): boolean {
 }
 
 function loadPayments() {
-  if (!invoice.value || !paymentsRelevant()) { payments.value = []; return }
+  if (!invoice.value || !paymentsRelevant()) { payments.value = []; bankTransactions.value = []; return }
   invoicesApi.listPayments(invoice.value.id)
-    .then(r => { payments.value = r.payments })
-    .catch(() => { payments.value = [] })
+    .then(r => {
+      payments.value = r.payments
+      bankTransactions.value = r.bank_transactions ?? []
+    })
+    .catch(() => { payments.value = []; bankTransactions.value = [] })
 }
+
+const unrecordedBankTransactions = computed(() => {
+  const recorded = new Set(payments.value.map(p => p.bank_transaction_id).filter((id): id is number => id !== null))
+  return bankTransactions.value.filter(tx => !recorded.has(tx.id))
+})
 
 const remainingToPay = computed(() => {
   if (!invoice.value) return 0
@@ -1923,6 +1932,94 @@ const invoiceActions = computed<ActionItem[]>(() => {
           </tfoot>
         </table>
       </div>
+    </div>
+
+    <!-- Přímé bankovní vazby bez invoice_payments — typicky historický import iDoklad. -->
+    <div v-if="paymentsRelevant() && unrecordedBankTransactions.length > 0"
+      class="bg-surface border border-neutral-200 rounded-lg shadow-sm overflow-hidden">
+      <div class="px-5 py-3 border-b border-neutral-200">
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-neutral-500">{{ t('invoice.payments.bank_transactions_title') }}</h3>
+        <p class="text-xs text-neutral-500 mt-1">{{ t('invoice.payments.bank_transactions_hint') }}</p>
+      </div>
+      <div class="hidden md:block overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead class="bg-neutral-50 text-xs text-neutral-500 uppercase tracking-wide">
+            <tr>
+              <th class="px-4 py-2 text-left font-medium">{{ t('invoice.payments.paid_on') }}</th>
+              <th class="px-4 py-2 text-right font-medium">{{ t('invoice.payments.amount') }}</th>
+              <th class="px-4 py-2 text-left font-medium">{{ t('invoice.payments.source') }}</th>
+              <th class="px-4 py-2 text-left font-medium">{{ t('invoice.payments.counterparty') }}</th>
+              <th class="px-4 py-2 text-left font-medium">{{ t('invoice.payments.reference') }}</th>
+              <th class="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-neutral-100">
+            <tr v-for="tx in unrecordedBankTransactions" :key="tx.id">
+              <td class="px-4 py-2.5">{{ formatDate(tx.posted_at) }}</td>
+              <td class="px-4 py-2.5 text-right font-mono font-medium">{{ formatMoney(tx.amount, tx.currency ?? invoice.currency) }}</td>
+              <td class="px-4 py-2.5">
+                <span class="text-xs px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-600">
+                  {{ t('invoice.payments.bank_sources.' + tx.statement_source) }}
+                </span>
+              </td>
+              <td class="px-4 py-2.5 text-xs">
+                <div v-if="tx.counterparty_account" class="font-mono text-neutral-700">
+                  {{ tx.counterparty_account }}<span v-if="tx.counterparty_bank">/{{ tx.counterparty_bank }}</span>
+                </div>
+                <div v-if="tx.counterparty_name" class="text-neutral-500">{{ tx.counterparty_name }}</div>
+              </td>
+              <td class="px-4 py-2.5 text-xs text-neutral-500">
+                <div>
+                  <span v-if="tx.variable_symbol" class="font-mono">VS {{ tx.variable_symbol }}</span>
+                  <span v-if="tx.constant_symbol" class="font-mono ml-1">/ KS {{ tx.constant_symbol }}</span>
+                  <span v-if="tx.specific_symbol" class="font-mono ml-1">/ SS {{ tx.specific_symbol }}</span>
+                </div>
+                <div v-if="tx.description">{{ tx.description }}</div>
+                <div v-if="tx.bank_ref" class="text-neutral-400">{{ tx.bank_ref }}</div>
+              </td>
+              <td class="px-4 py-2.5 text-right">
+                <RouterLink :to="`/bank/${tx.statement_id}`" class="text-xs text-primary-700 hover:underline">
+                  {{ t('invoice.payments.statement_link') }}
+                </RouterLink>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="md:hidden divide-y divide-neutral-100">
+        <div v-for="tx in unrecordedBankTransactions" :key="`bank-${tx.id}`" class="p-4 space-y-2 text-sm">
+          <div class="flex items-baseline justify-between gap-3">
+            <span class="text-neutral-500">{{ formatDate(tx.posted_at) }}</span>
+            <span class="font-mono font-medium">{{ formatMoney(tx.amount, tx.currency ?? invoice.currency) }}</span>
+          </div>
+          <div class="flex items-center justify-between gap-3">
+            <span class="text-xs px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-600">
+              {{ t('invoice.payments.bank_sources.' + tx.statement_source) }}
+            </span>
+            <RouterLink :to="`/bank/${tx.statement_id}`" class="text-xs text-primary-700 hover:underline">
+              {{ t('invoice.payments.statement_link') }}
+            </RouterLink>
+          </div>
+          <div class="text-xs">
+            <div v-if="tx.counterparty_account" class="font-mono text-neutral-700">
+              {{ tx.counterparty_account }}<span v-if="tx.counterparty_bank">/{{ tx.counterparty_bank }}</span>
+            </div>
+            <div v-if="tx.counterparty_name" class="text-neutral-500">{{ tx.counterparty_name }}</div>
+          </div>
+          <div class="text-xs text-neutral-500">
+            <span v-if="tx.variable_symbol" class="font-mono">VS {{ tx.variable_symbol }}</span>
+            <span v-if="tx.constant_symbol" class="font-mono ml-1">/ KS {{ tx.constant_symbol }}</span>
+            <span v-if="tx.specific_symbol" class="font-mono ml-1">/ SS {{ tx.specific_symbol }}</span>
+            <div v-if="tx.description">{{ tx.description }}</div>
+            <div v-if="tx.bank_ref" class="text-neutral-400">{{ tx.bank_ref }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else-if="paymentsRelevant() && invoice.status === 'paid' && payments.length === 0"
+      class="bg-neutral-50 border border-neutral-200 rounded-lg px-5 py-4 text-sm text-neutral-600">
+      {{ t('invoice.payments.imported_without_details', { date: invoice.paid_at ? formatDate(invoice.paid_at) : '—' }) }}
     </div>
 
     <!-- CZK přepočet pro faktury v cizí měně -->


### PR DESCRIPTION
## Co se mění

- Detail faktury zobrazuje přímo spárované bankovní operace včetně původních údajů banky a odkazu na výpis.
- Operace, která už má odpovídající řádek v evidenci plateb, se v novém boxu podruhé nezobrazuje.
- Importní protokol iDokladu správně počítá nalezené vazby na doklady.
- Doplněno veřejné API, OpenAPI, česká i anglická lokalizace a manuál.

## Proč

Faktury importované z iDokladu mohou být už označené jako uhrazené, ale nemají řádek v `invoice_payments`. Bankovní matcher přitom zná vazbu přes `bank_transactions.matched_invoice_id`, která dosud nebyla v detailu faktury dohledatelná.

Nové zobrazení je pouze informační: nevytváří zpětně účetní platbu a nezvyšuje `paid_total`. Při nalezení autoritativního GPC/PDF dvojčete zůstává iDoklad transakce ignorovaná a faktura odkazuje na autoritativní bankovní zdroj, takže nevzniká duplicitní úhrada. Číslo faktury a variabilní symbol zůstávají oddělené údaje.

## Ověření

- cílené integrační testy bankovního párování: 13 testů, 54 assertions
- scénář iDoklad → převzetí autoritativním GPC bez vytvoření `invoice_payments`
- frontend `vue-tsc --noEmit` a produkční Vite build
- striktní kontrola OpenAPI: bez duplicitních klíčů a dangling `$ref`
- PHP syntax check a `git diff --check`
- nasazení na vývojový server a HTTP 200