### PR TITLE
fix(api): označit hlavní e-mail klienta jako volitelný

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5566,7 +5566,7 @@ components:
         zip: { type: string }
         country_id: { type: integer }
         country_iso2: { type: string, description: "Denormalizovaný ISO2 kód země (alias z countries)" }
-        main_email: { type: string, format: email, description: "Hlavní email klienta — povinný. Bez e-mailových kontaktů (email_contacts) na něj chodí všechny zprávy; s kontakty slouží jako fallback a pro běžnou komunikaci." }
+        main_email: { type: string, format: email, nullable: true, description: "Volitelný hlavní email klienta. Bez e-mailových kontaktů (email_contacts) na něj chodí všechny zprávy; s kontakty slouží jako fallback a pro běžnou komunikaci." }
         phone: { type: string, nullable: true }
         language: { type: string, enum: [cs, en], description: "Jazyk faktur a emailů. Default cs." }
         currency_default_id: { type: integer, nullable: true, description: "Výchozí měna pro faktury klienta. Default = supplier.default_currency_id." }
@@ -5668,7 +5668,7 @@ components:
 
     ClientInput:
       type: object
-      required: [company_name, street, city, zip, main_email]
+      required: [company_name, street, city, zip]
       properties:
         company_name: { type: string }
         first_name: { type: string, nullable: true }
@@ -5680,7 +5680,7 @@ components:
         city: { type: string }
         zip: { type: string }
         country_iso2: { type: string, default: CZ, description: "ISO2 kód země (resolvuje se na country_id). POZOR: vstup je `country_iso2`, ne `country_id`." }
-        main_email: { type: string, format: email, description: "Hlavní email — povinný (POZOR: backend pole se jmenuje `main_email`, ne `email`)" }
+        main_email: { type: string, format: email, nullable: true, description: "Volitelný hlavní email (POZOR: backend pole se jmenuje `main_email`, ne `email`)" }
         phone: { type: string, nullable: true, maxLength: 40 }
         language: { type: string, enum: [cs, en], default: cs }
         currency_default_id: { type: integer, nullable: true, description: "Výchozí měna klienta. Pokud chybí, použije se výchozí měna supplier-a." }

--- a/api/src/Service/Import/ClientResolver.php
+++ b/api/src/Service/Import/ClientResolver.php
@@ -16,7 +16,7 @@ use MyInvoice\Service\Ares\AresClient;
  *   4. Vytvoří nový clients row, vrátí id.
  *
  * Vstup: array z parseru (`company_name, ic, dic, street, city, zip, country_iso2, email, phone`).
- * Email se použije jako `main_email` (povinné pole).
+ * Pokud je email dostupný, použije se jako volitelný `main_email`.
  */
 final class ClientResolver
 {

--- a/source/02-database.md
+++ b/source/02-database.md
@@ -216,7 +216,7 @@ CREATE TABLE clients (
 
 ## 8. `project_billing_emails`
 
-Fakturační emaily jsou na úrovni **zakázky**, ne klienta — každá zakázka může mít vlastní účetní/PM/asistentku. Klient má jen `main_email` (povinný hlavní kontakt).
+Fakturační emaily jsou na úrovni **zakázky**, ne klienta — každá zakázka může mít vlastní účetní/PM/asistentku. Klient má volitelný `main_email` jako hlavní kontakt.
 
 Při odeslání faktury: `client.main_email + project_billing_emails[]`. Pokud faktura nemá `project_id`, jdou maily jen na `client.main_email`.
 

--- a/source/04-api.md
+++ b/source/04-api.md
@@ -153,7 +153,7 @@ POST /api/bank-transactions/{id}/ignore
     "code": "validation_failed",
     "message": "Validace selhala",
     "fields": {
-      "main_email": ["Email je povinný"],
+      "main_email": ["Hlavní email musí být platný"],
       "ic": ["IČO musí mít 8 číslic"]
     }
   }


### PR DESCRIPTION
Oprava #221 umožnila vytvořit klienta bez hlavního e-mailu, ale veřejná OpenAPI specifikace stále uváděla `main_email` jako povinné pole.

Tento PR synchronizuje API kontrakt s aktuálním chováním backendu:

- odstraňuje `main_email` z povinných polí `ClientInput`,
- označuje hodnotu jako nullable,
- aktualizuje související popisy a vývojářskou dokumentaci.

Ověřeno striktním načtením YAML, kontrolou duplicitních klíčů a všech interních `$ref`.