### PR TITLE
fix(tests): izolovat bankovní a EPO scénáře

### DIFF
--- a/api/tests/Integration/Bank/BankMatchPaymentThanksTest.php
+++ b/api/tests/Integration/Bank/BankMatchPaymentThanksTest.php
@@ -132,9 +132,9 @@ final class BankMatchPaymentThanksTest extends TestCase
         $pdo->prepare(
             "INSERT INTO invoices
                 (invoice_type, varsymbol, client_id, supplier_id, issue_date, tax_date, due_date,
-                 currency_id, status, amount_to_pay, total_without_vat, total_with_vat, created_by)
-             VALUES ('invoice', ?, ?, ?, CURDATE(), CURDATE(), CURDATE(), ?, 'issued', ?, 1000, ?, ?)"
-        )->execute([$this->varsymbol, $this->clientId, $this->supplierId, $this->currencyId, $amount, $amount, $userId]);
+                 currency_id, status, total_without_vat, total_with_vat, created_by)
+             VALUES ('invoice', ?, ?, ?, CURDATE(), CURDATE(), CURDATE(), ?, 'issued', 1000, ?, ?)"
+        )->execute([$this->varsymbol, $this->clientId, $this->supplierId, $this->currencyId, $amount, $userId]);
         $this->invoiceId = (int) $pdo->lastInsertId();
 
         // Bankovní výpis + příchozí transakce přesně na VS + částku faktury.

--- a/api/tests/Integration/Bank/PurchaseMatchActivityLogTest.php
+++ b/api/tests/Integration/Bank/PurchaseMatchActivityLogTest.php
@@ -126,11 +126,11 @@ final class PurchaseMatchActivityLogTest extends TestCase
             "INSERT INTO purchase_invoices
                 (supplier_id, vendor_id, varsymbol, vendor_invoice_number, document_kind,
                  issue_date, tax_date, due_date, received_at, currency_id, vendor_snapshot,
-                 total_without_vat, total_with_vat, amount_to_pay, status, created_by)
-             VALUES (?, ?, ?, ?, 'invoice', ?, ?, ?, ?, ?, '{}', ?, ?, ?, ?, ?)"
+                 total_without_vat, total_with_vat, status, created_by)
+             VALUES (?, ?, ?, ?, 'invoice', ?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)"
         )->execute([
             $this->supplierId, $this->vendorId, self::TEST_VS, self::TEST_VS,
-            $d, $d, $d, $d, $this->currencyId, $amount, $amount, $amount, $status, $this->userId,
+            $d, $d, $d, $d, $this->currencyId, $amount, $amount, $status, $this->userId,
         ]);
         $this->purchaseId = (int) $pdo->lastInsertId();
 
@@ -209,11 +209,11 @@ final class PurchaseMatchActivityLogTest extends TestCase
             "INSERT INTO purchase_invoices
                 (supplier_id, vendor_id, varsymbol, vendor_invoice_number, document_kind,
                  issue_date, tax_date, due_date, received_at, currency_id, vendor_snapshot,
-                 total_without_vat, total_with_vat, amount_to_pay, status, created_by)
-             VALUES (?, ?, ?, ?, 'invoice', '2099-06-15','2099-06-15','2099-06-15','2099-06-15', ?, '{}', ?, ?, ?, 'paid', ?)"
+                 total_without_vat, total_with_vat, status, created_by)
+             VALUES (?, ?, ?, ?, 'invoice', '2099-06-15','2099-06-15','2099-06-15','2099-06-15', ?, '{}', ?, ?, 'paid', ?)"
         )->execute([
             $this->supplierId, $this->vendorId, $secondVno, $secondVno,
-            $this->currencyId, 2500.00, 2500.00, 2500.00, $this->userId,
+            $this->currencyId, 2500.00, 2500.00, $this->userId,
         ]);
         $secondId = (int) $pdo->lastInsertId();
 

--- a/api/tests/Integration/Bank/SplitPaymentTest.php
+++ b/api/tests/Integration/Bank/SplitPaymentTest.php
@@ -129,11 +129,11 @@ final class SplitPaymentTest extends TestCase
         $pdo->prepare(
             "INSERT INTO invoices
                 (invoice_type, varsymbol, client_id, supplier_id, issue_date, tax_date, due_date,
-                 currency_id, status, total_without_vat, total_with_vat, amount_to_pay, paid_total, created_by)
-             VALUES ('invoice', ?, ?, ?, ?, ?, ?, ?, 'issued', ?, ?, ?, 0, ?)"
+                 currency_id, status, total_without_vat, total_with_vat, paid_total, created_by)
+             VALUES ('invoice', ?, ?, ?, ?, ?, ?, ?, 'issued', ?, ?, 0, ?)"
         )->execute([
             $vs, $clientId, $this->supplierId, $d, $d, $d,
-            $this->currencyId, $amount, $amount, $amount, $this->userId,
+            $this->currencyId, $amount, $amount, $this->userId,
         ]);
         return (int) $pdo->lastInsertId();
     }

--- a/api/tests/Integration/Bank/StatementMatcherVarsymbolTest.php
+++ b/api/tests/Integration/Bank/StatementMatcherVarsymbolTest.php
@@ -116,11 +116,11 @@ final class StatementMatcherVarsymbolTest extends TestCase
         $pdo->prepare(
             "INSERT INTO invoices
                 (invoice_type, varsymbol, client_id, supplier_id, issue_date, tax_date, due_date,
-                 currency_id, status, total_without_vat, total_with_vat, amount_to_pay, paid_total, created_by)
-             VALUES ('invoice', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                 currency_id, status, total_without_vat, total_with_vat, paid_total, created_by)
+             VALUES ('invoice', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )->execute([
             $varsymbol, $this->clientId, $this->supplierId, $d, $d, $d,
-            $this->currencyId, $status, $amount, $amount, $amount, $paidTotal, $this->userId,
+            $this->currencyId, $status, $amount, $amount, $paidTotal, $this->userId,
         ]);
         $this->invoiceId = (int) $pdo->lastInsertId();
 
@@ -217,11 +217,11 @@ final class StatementMatcherVarsymbolTest extends TestCase
         $pdo->prepare(
             "INSERT INTO invoices
                 (invoice_type, varsymbol, client_id, supplier_id, issue_date, tax_date, due_date,
-                 currency_id, status, total_without_vat, total_with_vat, amount_to_pay, paid_total, created_by)
-             VALUES ('proforma', '2099000260', ?, ?, ?, ?, ?, ?, 'paid', ?, ?, ?, ?, ?)"
+                 currency_id, status, total_without_vat, total_with_vat, paid_total, created_by)
+             VALUES ('proforma', '2099000260', ?, ?, ?, ?, ?, ?, 'paid', ?, ?, ?, ?)"
         )->execute([
             $this->clientId, $this->supplierId, $d, $d, $d, $this->currencyId,
-            $amount, $amount, $amount, $amount, $this->userId,
+            $amount, $amount, $amount, $this->userId,
         ]);
         $proformaId = (int) $pdo->lastInsertId();
         $this->invoiceId = $proformaId;
@@ -230,11 +230,11 @@ final class StatementMatcherVarsymbolTest extends TestCase
         $pdo->prepare(
             "INSERT INTO invoices
                 (invoice_type, parent_invoice_id, varsymbol, client_id, supplier_id, issue_date, tax_date, due_date,
-                 currency_id, status, total_without_vat, total_with_vat, amount_to_pay, paid_total, created_by)
-             VALUES ('invoice', ?, '2099000261', ?, ?, ?, ?, ?, ?, 'paid', ?, ?, 0, 0, ?)"
+                 currency_id, status, total_without_vat, total_with_vat, advance_paid_amount, paid_total, created_by)
+             VALUES ('invoice', ?, '2099000261', ?, ?, ?, ?, ?, ?, 'paid', ?, ?, ?, 0, ?)"
         )->execute([
             $proformaId, $this->clientId, $this->supplierId, $d, $d, $d, $this->currencyId,
-            $amount, $amount, $this->userId,
+            $amount, $amount, $amount, $this->userId,
         ]);
 
         $pdo->prepare(

--- a/api/tests/Integration/Report/EpoXsdValidationTest.php
+++ b/api/tests/Integration/Report/EpoXsdValidationTest.php
@@ -19,19 +19,23 @@ use PHPUnit\Framework\TestCase;
  * **Soft skip** pokud schema chybí v storage/xsd/ (production deploy nemusí mít).
  * Lokálně + CI po `bash cmd/download-xsd.sh` test fakticky validuje.
  *
- * Pozn.: vyžaduje validní supplier_id=1 s alespoň pár fakturami (smoke data).
- * Tj. test je **Integration** (DB-touching), ne Unit.
+ * Používá vlastního syntetického dodavatele, takže výsledek nezávisí na datech
+ * konkrétní vývojové instalace. Test je **Integration** (DB-touching), ne Unit.
  */
 final class EpoXsdValidationTest extends TestCase
 {
     private XmlSchemaValidator $validator;
     private ?\MyInvoice\Infrastructure\Database\Connection $conn = null;
+    private int $supplierId = 0;
 
     /** @var array<string, callable(): array{xml: string, summary: array, warnings: array}> */
     private array $builders = [];
 
     protected function tearDown(): void
     {
+        if ($this->conn !== null && $this->supplierId > 0) {
+            $this->conn->pdo()->prepare('DELETE FROM supplier WHERE id = ?')->execute([$this->supplierId]);
+        }
         // Uvolni MySQL connection (per-metodu container by jinak kumuloval connections
         // přes celý běh → MariaDB max_connections).
         $this->conn?->close();
@@ -56,23 +60,23 @@ final class EpoXsdValidationTest extends TestCase
         $container = Bootstrap::buildApp()->getContainer();
         $this->validator = $container->get(XmlSchemaValidator::class);
         $this->conn = $container->get(\MyInvoice\Infrastructure\Database\Connection::class);
+        $this->supplierId = $this->createSyntheticSupplier();
 
-        $supplierId = 1;
         $year = (int) date('Y');
         $month = (int) date('n');
 
         // Lazy builders — každý test si volá svůj
         $this->builders = [
             'dphdp3' => fn () => $container->get(DphPriznaniBuilder::class)
-                ->build($supplierId, $year, $month, 'monthly'),
+                ->build($this->supplierId, $year, $month, 'monthly'),
             'dphkh1' => fn () => $container->get(KontrolniHlaseniBuilder::class)
-                ->build($supplierId, $year, $month),
+                ->build($this->supplierId, $year, $month),
             'dphshv' => fn () => $container->get(SouhrnneHlaseniBuilder::class)
-                ->build($supplierId, $year, $month),
+                ->build($this->supplierId, $year, $month),
             'dpfdp5' => fn () => $container->get(IncomeTaxBuilder::class)
-                ->build($supplierId, $year - 1, 'fo'),
+                ->build($this->supplierId, $year - 1, 'fo'),
             'dppdp9' => fn () => $container->get(IncomeTaxBuilder::class)
-                ->build($supplierId, $year - 1, 'po'),
+                ->build($this->supplierId, $year - 1, 'po'),
         ];
     }
 
@@ -153,12 +157,14 @@ final class EpoXsdValidationTest extends TestCase
         // JEN když má supplier odpovídající sloupec vyplněný. FO bez sestavitele
         // legitimně nemá opr_*/sest_*, OSVČ nemá zkrobchjm — proto podmíněně (jinak by
         // test padal na neúplných, ale validních profilech).
-        $sup = $this->conn?->pdo()->query(
+        $stmt = $this->conn?->pdo()->prepare(
             'SELECT financial_office_code, workplace_code, dic, taxpayer_type, company_name,
                     street_number_pop, street_number_orient, email, phone, cz_nace_code,
                     opr_jmeno, opr_prijmeni, opr_postaveni, sest_jmeno, sest_prijmeni, sest_telefon
-               FROM supplier WHERE id = 1'
-        )->fetch(\PDO::FETCH_ASSOC) ?: [];
+               FROM supplier WHERE id = ?'
+        );
+        $stmt?->execute([$this->supplierId]);
+        $sup = $stmt?->fetch(\PDO::FETCH_ASSOC) ?: [];
 
         // Vždy povinné (struktura každého validního plátce).
         $expected = ['c_ufo', 'dic', 'typ_ds', 'ulice', 'naz_obce', 'psc', 'stat'];
@@ -249,5 +255,29 @@ final class EpoXsdValidationTest extends TestCase
             "XSD validation pro {$formCode} selhala s chybami:\n  - " . implode("\n  - ", $validation['errors']),
         );
         $this->assertEmpty($validation['errors'], "XSD errors v {$formCode}: " . print_r($validation['errors'], true));
+    }
+
+    private function createSyntheticSupplier(): int
+    {
+        $pdo = $this->conn?->pdo() ?? throw new \RuntimeException('DB connection není inicializované.');
+        $countryId = (int) ($pdo->query("SELECT id FROM countries WHERE iso2 = 'CZ' LIMIT 1")->fetchColumn() ?: 0);
+        $currencyId = (int) ($pdo->query("SELECT id FROM currencies WHERE code = 'CZK' ORDER BY id LIMIT 1")->fetchColumn() ?: 0);
+        $vatRateId = (int) ($pdo->query("SELECT id FROM vat_rates WHERE country = 'CZ' ORDER BY is_default DESC, id LIMIT 1")->fetchColumn() ?: 0);
+        if ($countryId === 0 || $currencyId === 0 || $vatRateId === 0) {
+            $this->markTestSkipped('Chybí základní CZ číselníky pro syntetického EPO dodavatele.');
+        }
+
+        $pdo->prepare(
+            'INSERT INTO supplier
+                (company_name, street, city, zip, country_id, ic, dic, is_vat_payer, email, phone,
+                 default_currency_id, default_vat_rate_id, taxpayer_type, financial_office_code,
+                 workplace_code, street_number_pop, street_number_orient)
+             VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        )->execute([
+            'TEST EPO s.r.o.', 'Testovací', 'Praha', '11000', $countryId,
+            '00000019', 'CZ12345678', 'epo-test@example.invalid', '123456789',
+            $currencyId, $vatRateId, 'po', '451', '2001', '42', '7',
+        ]);
+        return (int) $pdo->lastInsertId();
     }
 }

--- a/api/tests/Integration/Report/KhDphTaxScenariosTest.php
+++ b/api/tests/Integration/Report/KhDphTaxScenariosTest.php
@@ -99,10 +99,10 @@ final class KhDphTaxScenariosTest extends TestCase
         // řádků — reálné nastavení dodavatele v dev DB by testy rozbilo. Vynutit
         // plátce a v tearDown vrátit (IO režim kryje IdentifiedPersonDphTest).
         $flags = $pdo->query(
-            "SELECT is_vat_payer, is_identified FROM supplier WHERE id = {$this->supplierId}"
+            "SELECT is_vat_payer, is_identified, dic FROM supplier WHERE id = {$this->supplierId}"
         )->fetch(\PDO::FETCH_ASSOC) ?: [];
         $this->origVatFlags = $flags;
-        $pdo->prepare('UPDATE supplier SET is_vat_payer = 1, is_identified = 0 WHERE id = ?')
+        $pdo->prepare("UPDATE supplier SET is_vat_payer = 1, is_identified = 0, dic = 'CZ12345678' WHERE id = ?")
             ->execute([$this->supplierId]);
     }
 
@@ -113,10 +113,11 @@ final class KhDphTaxScenariosTest extends TestCase
         }
         $pdo = $this->db->pdo();
         if ($this->origVatFlags !== null && $this->supplierId > 0) {
-            $pdo->prepare('UPDATE supplier SET is_vat_payer = ?, is_identified = ? WHERE id = ?')
+            $pdo->prepare('UPDATE supplier SET is_vat_payer = ?, is_identified = ?, dic = ? WHERE id = ?')
                 ->execute([
                     (int) ($this->origVatFlags['is_vat_payer'] ?? 1),
                     (int) ($this->origVatFlags['is_identified'] ?? 0),
+                    $this->origVatFlags['dic'] ?? null,
                     $this->supplierId,
                 ]);
         }


### PR DESCRIPTION
## Co se opravuje

- bankovní integrační testy už nezapisují do generovaného sloupce `amount_to_pay`; hodnotu nechávají dopočítat MariaDB z částek dokladu,
- scénář finální faktury kryté zálohou nastavuje vstupní `advance_paid_amount`, takže stále ověřuje nulovou pohledávku,
- EPO/XSD test vytváří vlastního syntetického dodavatele s validními daňovými údaji a po testu jej odstraní,
- KH/DPH scénáře dočasně nastaví syntetické DIČ a v `tearDown` obnoví původní hodnotu.

## Proč

Při ověřování brandingového PR #229 celý lokální PHPUnit běh odhalil dvě závislosti testů na prostředí:

1. MariaDB 11 odmítá explicitní zápis do generovaného `amount_to_pay`.
2. EPO test používal dodavatele `id=1` z konkrétní instalace a padal, pokud neměl vyplněné DIČ.

Nejde o změnu produkční logiky. Cílem je, aby integrační testy ověřovaly skutečné vstupy a nebyly závislé na obsahu vývojové databáze.

## Ověření

Testováno proti jednorázové MariaDB 11 s migracemi aplikovanými výhradně přes `api/bin/migrate.php`:

- cíleně: **71 testů, 424 assertions — OK**,
- celý balík: **1 634 testů, 5 067 assertions — OK**, 27 podmíněně přeskočených testů,
- PHP syntaxe změněných testů — OK.

Navazuje na přípravu a ověření #229, ale je záměrně oddělené, aby brandingový PR zůstal tematicky čistý.