### PR TITLE
feat(bank): systémový parser e-mailových avíz MONETA Money Bank

### DIFF
--- a/api/src/Infrastructure/Config/Config.php
+++ b/api/src/Infrastructure/Config/Config.php
@@ -229,6 +229,7 @@ final class Config
                     'csob' => \MyInvoice\Service\Bank\EmailNotice\Parser\CsobBankEmailNoticeParser::class,
                     'fio' => \MyInvoice\Service\Bank\EmailNotice\Parser\FioBankEmailNoticeParser::class,
                     'creditas' => \MyInvoice\Service\Bank\EmailNotice\Parser\CreditasBankEmailNoticeParser::class,
+                    'moneta' => \MyInvoice\Service\Bank\EmailNotice\Parser\MonetaBankEmailNoticeParser::class,
                 ],
             ],
         ];

--- a/api/src/Service/Bank/AccountNumberNormalizer.php
+++ b/api/src/Service/Bank/AccountNumberNormalizer.php
@@ -9,6 +9,7 @@ namespace MyInvoice\Service\Bank;
  *  - GPC výpisem (zero-padded 16 cifer, např. `0000000123456789`)
  *  - currencies.account_number (uložené bez padding, např. `123456789`)
  *  - CZ účty s prefixem (`19-2000145399` → `192000145399`)
+ *  - e-mailovými avízy s maskovaným číslem (Moneta Info Servis: `238***891`)
  *
  * Strip non-digits + ltrim '0'. Po normalize se dva různé zápisy stejného účtu
  * shodují.
@@ -25,10 +26,56 @@ final class AccountNumberNormalizer
         return ltrim($digitsOnly, '0');
     }
 
-    /** True pokud dvě account number stringy odkazují na stejný účet (po normalize). */
+    /**
+     * True pokud dvě account number stringy odkazují na stejný účet.
+     *
+     * Nejdřív přes normalize (GPC padding / pomlčky). Když nesedí, zkusí
+     * maskovanou shodu — Moneta v avízu posílá `238***891` místo plného čísla,
+     * a mapování e-mailových notifikací by jinak spadlo na match_failed.
+     */
     public static function equals(string $a, string $b): bool
     {
-        return self::normalize($a) === self::normalize($b);
+        if (self::normalize($a) === self::normalize($b)) {
+            return true;
+        }
+        return self::matchesMasked($a, $b) || self::matchesMasked($b, $a);
+    }
+
+    /**
+     * Maskovaný zápis (číslice + `*`) vs. plné číslo stejné délky.
+     *
+     * Každá `*` zastupuje právě jednu číslici. Pomlčky a kód banky za `/`
+     * se ignorují. Obě strany s `*` → false (dvě masky se neporovnávají).
+     *
+     * Příklad: `238***891` sedí na `238456891` i `238456891/0600`,
+     * ale ne na `239456891` (jiný prefix) ani `2384567891` (jiná délka).
+     */
+    private static function matchesMasked(string $masked, string $full): bool
+    {
+        $maskPart = explode('/', trim($masked), 2)[0];
+        if ($maskPart === '' || !str_contains($maskPart, '*')) {
+            return false;
+        }
+        if (str_contains($full, '*')) {
+            return false;
+        }
+
+        $maskPattern = preg_replace('/[^0-9*]/', '', $maskPart) ?? '';
+        $fullDigits = preg_replace('/\D/', '', explode('/', trim($full), 2)[0]) ?? '';
+        if ($maskPattern === '' || $fullDigits === '' || strlen($maskPattern) !== strlen($fullDigits)) {
+            return false;
+        }
+
+        $len = strlen($maskPattern);
+        for ($i = 0; $i < $len; $i++) {
+            if ($maskPattern[$i] === '*') {
+                continue;
+            }
+            if ($maskPattern[$i] !== $fullDigits[$i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/api/src/Service/Bank/EmailNotice/Parser/AbstractBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/AbstractBankEmailNoticeParser.php
@@ -403,7 +403,8 @@ abstract class AbstractBankEmailNoticeParser implements BankEmailNoticeParserInt
         if ($direction === '') {
             return $amount;
         }
-        if (preg_match('/odchoz|výdej|vydej|výdaj|vydaj|debet|odepsán|odepsan|outgoing/u', $direction) === 1) {
+        // Moneta Info Servis: předmět/nadpis „Odešly peníze" (ne „odchozí").
+        if (preg_match('/odchoz|ode[sš]l|výdej|vydej|výdaj|vydaj|debet|odepsán|odepsan|outgoing/u', $direction) === 1) {
             return -abs($amount);
         }
         return abs($amount);

--- a/api/src/Service/Bank/EmailNotice/Parser/MonetaBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/MonetaBankEmailNoticeParser.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Bank\EmailNotice\Parser;
+
+use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
+
+/**
+ * MONETA Money Bank — Info Servis avízo „Přišly peníze" / „Odešly peníze"
+ * (infoservis@moneta.cz, Evypis@moneta.cz).
+ *
+ * HTML šablona se po strip_tags zploští na labely:
+ *   Účet: 238***891          (prostředek maskovaný — mapování přes AccountNumberNormalizer)
+ *   Datum: 01.07.2026
+ *   Částka: 35 000,00 Kč
+ *   Popis: … VS: 202600009
+ *   Od: 264555317/0300
+ *   Disponibilní zůstatek: 64 831,42 Kč
+ *
+ * Kód banky u vlastního účtu v avízu chybí → doplní se /0600 (MONETA).
+ * Směr nese nadpis/předmět (Přišly = příchozí, Odešly = odchozí/záporná částka).
+ */
+final class MonetaBankEmailNoticeParser extends AbstractBankEmailNoticeParser
+{
+    private const BANK_CODE = '0600';
+
+    public function key(): string
+    {
+        return 'moneta';
+    }
+
+    protected function parserLabel(): string
+    {
+        return 'MONETA Money Bank';
+    }
+
+    public function defaultProvider(): ?BankEmailNoticeProvider
+    {
+        return new BankEmailNoticeProvider(
+            id: null,
+            supplierId: null,
+            providerRef: 'system:' . $this->key(),
+            code: $this->key(),
+            name: 'MONETA Money Bank - Přišly/Odešly peníze',
+            parserType: $this->key(),
+            enabled: true,
+            senderWhitelist: 'infoservis@moneta.cz Evypis@moneta.cz',
+            subjectPattern: 'Přišly\\s+peníze|Odešly\\s+peníze|Prisly\\s+penize|Odesly\\s+penize',
+            bodyPattern: 'Účet:|Ucet:',
+            fieldPatterns: [],
+            normalizerConfig: [],
+            system: true,
+        );
+    }
+
+    public function supports(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): bool
+    {
+        if (!$this->senderMatchesDomain($message, 'moneta.cz')) {
+            return false;
+        }
+
+        $subject = $this->compact(mb_strtolower($this->foldDiacritics($message->subject), 'UTF-8'));
+        if (
+            !str_contains($subject, 'prisly penize')
+            && !str_contains($subject, 'odesly penize')
+        ) {
+            return false;
+        }
+
+        $text = $this->compact(mb_strtolower($this->foldDiacritics($this->normalizeText($message->text)), 'UTF-8'));
+        return str_contains($text, 'ucet:')
+            && str_contains($text, 'castka:')
+            && (str_contains($text, 'prisly penize') || str_contains($text, 'odesly penize'));
+    }
+
+    public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
+    {
+        $text = $this->normalizeText($message->text);
+        $folded = $this->foldDiacritics($text);
+
+        $account = $this->required(
+            $folded,
+            '/(?:^|\R)\s*Ucet:\s*(?<value>[0-9*]+(?:\/[0-9]{4})?)/iu',
+            'cílový účet',
+        );
+        $postedAt = $this->required(
+            $folded,
+            '/(?:^|\R)\s*Datum:\s*(?<value>\d{1,2}\.\d{1,2}\.\d{4})/iu',
+            'datum',
+        );
+        $amountCurrency = $this->match(
+            $folded,
+            '/(?:^|\R)\s*Castka:\s*(?<amount>[+\-]?[0-9][0-9 ]*,[0-9]{2})\s*(?<currency>Kc|CZK|EUR|USD|€|[A-Z]{3})/iu',
+        );
+        if ($amountCurrency === null) {
+            throw new \RuntimeException($this->parserLabel() . ' parser nenašel částku a měnu.');
+        }
+
+        $variableSymbol = $this->optional($text, '/\bVS:\s*(?<value>[0-9]+)/iu')
+            ?? $this->optional($folded, '/\bVS:\s*(?<value>[0-9]+)/iu');
+        $counterparty = $this->optional(
+            $text,
+            '/(?:^|\R)\s*Od:\s*(?<value>[0-9\-]+\/[0-9]{4})/iu',
+        );
+        // Popis ber z původního textu (ne folded), ať zůstane diakritika ve zprávě.
+        $note = $this->optional(
+            $text,
+            '/(?:^|\R)\s*Popis:\s*(?<value>.+?)(?=\n\s*Od:)/isu',
+        );
+        $balance = $this->optional(
+            $folded,
+            '/(?:^|\R)\s*Disponibilni\s+zustatek:\s*(?<value>[+\-]?[0-9][0-9 ]*,[0-9]{2})/iu',
+        );
+
+        [$recipientAccount, $recipientBank] = $this->splitAccount($account);
+        // Maskovaný účet (238***891) neprojde regexem splitAccount — nech číslo + doplň /0600.
+        if ($recipientAccount === null || $recipientAccount === '' || str_contains($recipientAccount, '*')) {
+            $recipientAccount = preg_replace('/[^0-9*]/', '', explode('/', $account, 2)[0]) ?? $account;
+            $recipientBank = null;
+        }
+        [$cpAccount, $cpBank] = $this->splitAccount((string) $counterparty);
+
+        $direction = preg_match('/odesly\s+penize/iu', $folded) === 1 ? 'Odešly peníze' : 'Přišly peníze';
+
+        return new ParsedBankEmailNotice(
+            variableSymbol: $this->normalizeSymbol((string) $variableSymbol),
+            amount: $this->applyDirection($this->parseAmount((string) $amountCurrency['amount']), $direction),
+            currency: $this->normalizeCurrency((string) ($amountCurrency['currency'] ?? 'CZK')),
+            postedAt: $this->parseDate($postedAt),
+            recipientAccount: $recipientAccount . '/' . ($recipientBank ?? self::BANK_CODE),
+            counterpartyAccount: $cpAccount,
+            counterpartyBank: $cpBank,
+            message: $note,
+            balance: $balance !== null ? $this->parseAmount($balance) : null,
+        );
+    }
+}

--- a/api/tests/Unit/Bank/MonetaBankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/MonetaBankEmailNoticeParserTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Bank;
+
+use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeProvider;
+use MyInvoice\Service\Bank\EmailNotice\Parser\MonetaBankEmailNoticeParser;
+use PHPUnit\Framework\TestCase;
+
+final class MonetaBankEmailNoticeParserTest extends TestCase
+{
+    public function testParsesIncomingNoticeWithMaskedAccount(): void
+    {
+        $body = <<<TEXT
+Dobrý den,
+zasíláme Vám nové upozornění. Na tento e-mail prosím neodpovídejte, jedná se o automaticky generovaný e-mail.
+Přišly peníze
+
+Účet:
+238***891
+
+Datum:
+01.07.2026
+
+Částka:
+35 000,00 Kč
+
+Popis:
+OKAMŽITÁ ÚHRADA, DOM-AVIZO:202600009 FIRMA DEMO S.R.O., VS: 202600009
+
+Od:
+264555317/0300
+
+Disponibilní zůstatek:
+64 831,42 Kč
+
+Účetní zůstatek:
+64 831,42 Kč
+TEXT;
+
+        $parser = new MonetaBankEmailNoticeParser();
+        $message = $this->message($body, 'Přišly peníze');
+        $provider = $this->provider($parser);
+
+        self::assertTrue($parser->supports($message, $provider));
+
+        $parsed = $parser->parse($message, $provider);
+
+        self::assertSame('202600009', $parsed->variableSymbol);
+        self::assertSame(35000.0, $parsed->amount);
+        self::assertSame('CZK', $parsed->currency);
+        self::assertSame('2026-07-01', $parsed->postedAt);
+        self::assertSame('238***891/0600', $parsed->recipientAccount);
+        self::assertSame('264555317', $parsed->counterpartyAccount);
+        self::assertSame('0300', $parsed->counterpartyBank);
+        self::assertSame('OKAMŽITÁ ÚHRADA, DOM-AVIZO:202600009 FIRMA DEMO S.R.O., VS: 202600009', $parsed->message);
+        self::assertSame(64831.42, $parsed->balance);
+    }
+
+    public function testParsesOutgoingNoticeAsNegativeAmount(): void
+    {
+        $body = <<<TEXT
+Odešly peníze
+
+Účet:
+238***891
+
+Datum:
+15.07.2026
+
+Částka:
+1 250,50 Kč
+
+Popis:
+Platba faktury VS: 2607001
+
+Od:
+123456789/0100
+
+Disponibilní zůstatek:
+10 000,00 Kč
+TEXT;
+
+        $parser = new MonetaBankEmailNoticeParser();
+        $message = $this->message($body, 'Odešly peníze');
+        $provider = $this->provider($parser);
+
+        self::assertTrue($parser->supports($message, $provider));
+
+        $parsed = $parser->parse($message, $provider);
+
+        self::assertSame('2607001', $parsed->variableSymbol);
+        self::assertSame(-1250.50, $parsed->amount);
+        self::assertSame('CZK', $parsed->currency);
+        self::assertSame('2026-07-15', $parsed->postedAt);
+        self::assertSame('238***891/0600', $parsed->recipientAccount);
+        self::assertSame('123456789', $parsed->counterpartyAccount);
+        self::assertSame('0100', $parsed->counterpartyBank);
+    }
+
+    public function testSupportsDiacriticFoldedSubjectAndBody(): void
+    {
+        $body = <<<TEXT
+Prisly penize
+Ucet: 238***891
+Datum: 01.07.2026
+Castka: 100,00 Kc
+Popis: VS: 1
+Od: 1000000005/0100
+Disponibilni zustatek: 1,00 Kc
+TEXT;
+
+        $parser = new MonetaBankEmailNoticeParser();
+        $message = $this->message($body, 'Prisly penize');
+        self::assertTrue($parser->supports($message, $this->provider($parser)));
+    }
+
+    public function testRejectsSpoofedSenderDomain(): void
+    {
+        $parser = new MonetaBankEmailNoticeParser();
+        $message = new BankEmailNoticeMessage(
+            uid: 1,
+            messageId: '<spoof@evil.com>',
+            date: new \DateTimeImmutable('2026-07-01 12:49:00'),
+            sender: 'MONETA <attacker@moneta.cz.evil.com>',
+            subject: 'Přišly peníze',
+            text: "Přišly peníze\nÚčet: 238***891\nČástka: 1,00 Kč",
+            raw: '',
+        );
+        self::assertFalse($parser->supports($message, $this->provider($parser)));
+    }
+
+    public function testThrowsWithoutAmount(): void
+    {
+        $body = "Přišly peníze\nÚčet: 238***891\nDatum: 01.07.2026\nPopis: VS: 1";
+        $parser = new MonetaBankEmailNoticeParser();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('částku');
+        $parser->parse($this->message($body, 'Přišly peníze'), $this->provider($parser));
+    }
+
+    private function message(string $body, string $subject): BankEmailNoticeMessage
+    {
+        return new BankEmailNoticeMessage(
+            uid: 1,
+            messageId: '<sanitized-sample@moneta.cz>',
+            date: new \DateTimeImmutable('2026-07-01 12:49:00'),
+            sender: 'infoservis@moneta.cz',
+            subject: $subject,
+            text: $body,
+            raw: $body,
+        );
+    }
+
+    private function provider(MonetaBankEmailNoticeParser $parser): BankEmailNoticeProvider
+    {
+        $provider = $parser->defaultProvider();
+        self::assertInstanceOf(BankEmailNoticeProvider::class, $provider);
+        return $provider;
+    }
+}

--- a/api/tests/Unit/Service/Bank/AccountNumberNormalizerTest.php
+++ b/api/tests/Unit/Service/Bank/AccountNumberNormalizerTest.php
@@ -53,6 +53,24 @@ final class AccountNumberNormalizerTest extends TestCase
         self::assertTrue(AccountNumberNormalizer::equals('0000', ''));
     }
 
+    public function testEqualsMonetaMaskedAccount(): void
+    {
+        // Moneta Info Servis: „Účet: 238***891" vs. plné číslo stejné délky.
+        self::assertTrue(AccountNumberNormalizer::equals('238***891', '238456891'));
+        self::assertTrue(AccountNumberNormalizer::equals('238456891', '238***891'));
+        self::assertTrue(AccountNumberNormalizer::equals('238***891/0600', '238456891'));
+        self::assertTrue(AccountNumberNormalizer::equals('238***891', '238456891/0600'));
+        self::assertFalse(AccountNumberNormalizer::equals('238***891', '239456891'));
+        self::assertFalse(AccountNumberNormalizer::equals('238***891', '2384567891')); // jiná délka
+        self::assertFalse(AccountNumberNormalizer::equals('238***891', '238***892')); // dvě masky
+    }
+
+    public function testMatchesAnyViaMonetaMaskedAccount(): void
+    {
+        self::assertTrue(AccountNumberNormalizer::matchesAny('238***891', '238456891', null));
+        self::assertFalse(AccountNumberNormalizer::matchesAny('238***891', '239456891', null));
+    }
+
     // ── IBAN podpora (#109 — EUR účty evidované jen IBANem vs GPC výpis) ──
 
     #[DataProvider('ibanAccountPartCases')]

--- a/manual/37_Bankovni_ucty.md
+++ b/manual/37_Bankovni_ucty.md
@@ -100,7 +100,7 @@ Provider říká, jak poznat e-mail dané banky a jak z něj vytěžit platební
 
 Typy providerů:
 
-- **Systémový provider** — dodaný aplikací, např. Raiffeisenbank, UniCredit Bank, ČSOB, Česká spořitelna, Fio banka nebo Banka CREDITAS.
+- **Systémový provider** — dodaný aplikací, např. Raiffeisenbank, UniCredit Bank, ČSOB, Česká spořitelna, Fio banka, Banka CREDITAS nebo MONETA Money Bank.
 - **Regex provider** — vlastní provider dodavatele, konfigurovaný v UI.
 
 Systémový provider se přímo needituje (je společný pro všechny). Když ho chceš

--- a/web/src/pages/admin/BankAccounts.vue
+++ b/web/src/pages/admin/BankAccounts.vue
@@ -551,6 +551,7 @@ function parserTypeLabel(parserType: BankEmailProvider['parser_type']): string {
     case 'csob': return 'ČSOB'
     case 'fio': return 'Fio banka'
     case 'creditas': return 'Creditas'
+    case 'moneta': return 'MONETA Money Bank'
     default: return t('bank_accounts.parser_builtin')
   }
 }


### PR DESCRIPTION
## Summary
- Systémový parser Info Servisu MONETA (`Přišly` / `Odešly peníze`), včetně maskovaného čísla účtu a doplnění kódu banky `/0600`.
- `AccountNumberNormalizer` umí mask matching (`238***891` ↔ plné číslo), aby mapování avíz nepadalo na `match_failed`.
- Registrace parseru v configu, label ve FE a zmínka v manuálu.

## Test plan
- [ ] `cd api && php vendor/bin/phpunit --filter 'MonetaBankEmailNoticeParserTest|AccountNumberNormalizerTest'`
- [ ] V UI: Bankovní účty → mapování Moneta účtu na systémový provider MONETA
- [ ] Test parseru / IMAP scan s avízem „Přišly peníze“ → transakce bez `match_failed`


Made with [Cursor](https://cursor.com)