### PR TITLE
fix(bank): IMAP „označit jako přečtené" se nikdy nespustilo

### DIFF
--- a/api/src/Service/Bank/EmailNotice/WebklexImapMailboxClient.php
+++ b/api/src/Service/Bank/EmailNotice/WebklexImapMailboxClient.php
@@ -25,28 +25,36 @@ final class WebklexImapMailboxClient implements ImapMailboxClientInterface
 
             $out = [];
             foreach ($messages as $message) {
-                $html = (string) $message->getHTMLBody();
-                $text = (string) $message->getTextBody();
-                $rawBody = method_exists($message, 'getRawBody') ? (string) $message->getRawBody() : ($html !== '' ? $html : $text);
-                $body = $text !== '' ? $text : ($html !== '' ? $html : $rawBody);
-                $date = $this->messageDate($message);
-                $out[] = new BankEmailNoticeMessage(
-                    uid: method_exists($message, 'getUid') ? (int) $message->getUid() : null,
-                    messageId: trim((string) $message->getMessageId()) ?: null,
-                    date: $date,
-                    sender: MimeHeaderDecoder::decode((string) $message->getFrom()),
-                    subject: MimeHeaderDecoder::decode((string) $message->getSubject()),
-                    text: $this->normalizer->normalize($body),
-                    raw: $rawBody,
-                    authResults: $this->authenticationResults($message),
-                    allowForwarded: (bool) ($settings['allow_forwarded'] ?? false),
-                    forwardedFrom: trim((string) ($settings['forwarded_from'] ?? '')),
-                );
+                $out[] = $this->toNoticeMessage($message, $settings);
             }
             return $out;
         } finally {
             $client->disconnect();
         }
+    }
+
+    /**
+     * @param array<string,mixed> $settings
+     */
+    private function toNoticeMessage(object $message, array $settings): BankEmailNoticeMessage
+    {
+        $html = (string) $message->getHTMLBody();
+        $text = (string) $message->getTextBody();
+        $rawBody = method_exists($message, 'getRawBody') ? (string) $message->getRawBody() : ($html !== '' ? $html : $text);
+        $body = $text !== '' ? $text : ($html !== '' ? $html : $rawBody);
+
+        return new BankEmailNoticeMessage(
+            uid: (int) $message->getUid() ?: null,
+            messageId: trim((string) $message->getMessageId()) ?: null,
+            date: $this->messageDate($message),
+            sender: MimeHeaderDecoder::decode((string) $message->getFrom()),
+            subject: MimeHeaderDecoder::decode((string) $message->getSubject()),
+            text: $this->normalizer->normalize($body),
+            raw: $rawBody,
+            authResults: $this->authenticationResults($message),
+            allowForwarded: (bool) ($settings['allow_forwarded'] ?? false),
+            forwardedFrom: trim((string) ($settings['forwarded_from'] ?? '')),
+        );
     }
 
     public function test(array $settings): array

--- a/api/tests/Unit/Service/Bank/EmailNotice/WebklexImapMailboxClientTest.php
+++ b/api/tests/Unit/Service/Bank/EmailNotice/WebklexImapMailboxClientTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Bank\EmailNotice;
+
+use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\EmailNoticeTextNormalizer;
+use MyInvoice\Service\Bank\EmailNotice\WebklexImapMailboxClient;
+use PHPUnit\Framework\TestCase;
+
+final class WebklexImapMailboxClientTest extends TestCase
+{
+    /**
+     * Regrese: ve Webklexu je getUid() magická metoda (jen @method + __call), takže
+     * method_exists($msg, 'getUid') === false. Guard `method_exists(...) ? ... : null`
+     * proto zapisoval uid = null pro každou zprávu → postProcess se hned vrátil a
+     * „označit jako přečtené" (a add_flag/move) se nikdy nespustilo.
+     */
+    public function testUidIsReadFromMagicGetUidAccessor(): void
+    {
+        $message = new MagicWebklexMessageStub([
+            'getUid' => 42,
+            'getMessageId' => '<mid@bank.cz>',
+            'getFrom' => 'noreply@bank.cz',
+            'getSubject' => 'Avízo o platbě',
+            'getDate' => '2026-01-15 10:00:00',
+            'getHTMLBody' => '',
+            'getTextBody' => 'Přijatá platba 1000 CZK',
+        ]);
+
+        // Přesně vlastnost, která bug způsobila: magickou getUid() method_exists nevidí.
+        self::assertFalse(method_exists($message, 'getUid'));
+
+        $client = new WebklexImapMailboxClient(new EmailNoticeTextNormalizer());
+        $toNoticeMessage = new \ReflectionMethod(WebklexImapMailboxClient::class, 'toNoticeMessage');
+
+        /** @var BankEmailNoticeMessage $notice */
+        $notice = $toNoticeMessage->invoke($client, $message, ['allow_forwarded' => false, 'forwarded_from' => '']);
+
+        self::assertSame(42, $notice->uid);
+        self::assertSame('<mid@bank.cz>', $notice->messageId);
+    }
+}
+
+/**
+ * Napodobuje Webklex\PHPIMAP\Message: accessory (getUid, getFrom, …) existují jen
+ * přes magické __call, takže method_exists() je na ně false — přesně jako v knihovně.
+ */
+final class MagicWebklexMessageStub
+{
+    /** @param array<string,mixed> $values */
+    public function __construct(private readonly array $values) {}
+
+    public function __call(string $method, array $arguments): mixed
+    {
+        return $this->values[$method] ?? '';
+    }
+}


### PR DESCRIPTION
getUid(…) je magická metoda

WebklexImapMailboxClient::latest() četl UID přes
`method_exists($message, 'getUid') ? (int) $message->getUid() : null`. Ve webklex/php-imap 6.2 je getUid() magická metoda (@method + __call), takže method_exists() vrací false → uid byl vždy null. postProcess() se pak na `$message->uid === null` okamžitě vrátil, a mark_seen (i add_flag/move) se nikdy neprovedly — tiše, bez chyby. Ostatní magické accessory (getMessageId, getFrom, …) se přitom volají přímo a fungují; guard byl jen u getUid a backfiroval.

- getUid() se volá přímo jako ostatní accessory
- mapování zprávy vytaženo do toNoticeMessage() (čistý přesun) kvůli testovatelnosti
- regresní test s fake Webklex zprávou, kde getUid() existuje jen přes __call