### PR TITLE
fix(isdoc): opravit identifikátory přijatých faktur

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3417,7 +3417,13 @@ paths:
       summary: ISDOC 6.0 XML export přijaté faktury
       description: |
         Role inversion — pro přijatou je `AccountingSupplierParty` = vendor,
-        `AccountingCustomerParty` = náš tenant.
+        `AccountingCustomerParty` = náš tenant. Kořenové `ID` obsahuje číslo
+        dokladu dodavatele; interní číslo MyInvoice je v
+        `Extensions/myi:InternalDocumentNumber` s namespace
+        `https://myinvoice.cz/isdoc/extensions/2026`. `PaymentMeans` obsahuje
+        evidovaný bankovní účet dodavatele a platební `VariableSymbol`; pokud
+        samostatný platební VS chybí, použije se jeho číselná podoba odvozená
+        z čísla faktury dodavatele.
       parameters:
         - { in: path, name: id, required: true, schema: { type: integer } }
         - $ref: '#/components/parameters/SupplierIdHeader'
@@ -3897,6 +3903,9 @@ paths:
         Počet rekonstrukcí je v hlavičce `X-Export-Reconstructed`.
 
         `isdoc` / `pohoda`: generují XML z dat faktury (PDF nepotřebují).
+        ISDOC obsahuje také evidovaný bankovní účet dodavatele a platební
+        variabilní symbol. Číslo dokladu dodavatele je v kořenovém `ID`, interní
+        číslo MyInvoice v namespacovaném `Extensions/myi:InternalDocumentNumber`.
 
         Období lze zadat legacy parametrem `month=YYYY-MM`, nebo explicitně
         `period=monthly&year=YYYY&month=M` / `period=quarterly&year=YYYY&quarter=1..4`.

--- a/api/src/Service/Export/IsdocExporter.php
+++ b/api/src/Service/Export/IsdocExporter.php
@@ -30,6 +30,7 @@ final class IsdocExporter
 {
     public const NS = 'http://isdoc.cz/namespace/2013';
     public const VERSION = '6.0.2';
+    public const MYINVOICE_EXTENSION_NS = 'https://myinvoice.cz/isdoc/extensions/2026';
 
     /**
      * Mapa nejčastějších CZ bankovních kódů → BIC (SWIFT). Používá se jako fallback
@@ -183,7 +184,11 @@ final class IsdocExporter
             default        => 1,  // faktura — daňový doklad
         };
         $this->el($dom, $root, 'DocumentType', (string) $docType);
-        $this->el($dom, $root, 'ID', (string) ($invoice['varsymbol'] ?? ('DRAFT-' . $invoice['id'])));
+        $documentNumber = trim((string) ($invoice['document_number'] ?? ''));
+        if ($documentNumber === '') {
+            $documentNumber = (string) ($invoice['varsymbol'] ?? ('DRAFT-' . $invoice['id']));
+        }
+        $this->el($dom, $root, 'ID', $documentNumber);
         $this->el($dom, $root, 'UUID', $this->makeUuid($invoice));
         // IssuingSystem patří v root sekvenci před IssueDate (po EgovClassifiers).
         // Identifikuje generátor faktury — užitečné pro debugging accounting SW.
@@ -214,6 +219,23 @@ final class IsdocExporter
         // CurrRate = počet jednotek místní měny za 1 jednotku faktur. měny (CZK/EUR ≈ 24.36)
         $this->el($dom, $root, 'CurrRate', number_format($rate, 6, '.', ''));
         $this->el($dom, $root, 'RefCurrRate', '1');
+
+        $internalDocumentNumber = trim((string) ($invoice['internal_document_number'] ?? ''));
+        if ($internalDocumentNumber !== '') {
+            $root->setAttributeNS(
+                'http://www.w3.org/2000/xmlns/',
+                'xmlns:myi',
+                self::MYINVOICE_EXTENSION_NS,
+            );
+            $extensions = $dom->createElementNS(self::NS, 'Extensions');
+            $internalNumber = $dom->createElementNS(
+                self::MYINVOICE_EXTENSION_NS,
+                'myi:InternalDocumentNumber',
+            );
+            $internalNumber->appendChild($dom->createTextNode($internalDocumentNumber));
+            $extensions->appendChild($internalNumber);
+            $root->appendChild($extensions);
+        }
 
         // Supplier (snapshot first, then live) — $supplier už vyřešen výše u VATApplicable
         $supParty = $dom->createElementNS(self::NS, 'AccountingSupplierParty');
@@ -378,7 +400,11 @@ final class IsdocExporter
         // (ID, BankCode, Name, IBAN, BIC — všech 5 elementů REQUIRED v schema, posíláme
         // prázdné jako fallback), pak volitelně VariableSymbol/ConstantSymbol/SpecificSymbol.
         $bank = $this->resolveBank($invoice);
-        if ($bank !== null && $payable > 0) {
+        $explicitPaymentVariableSymbol = trim((string) ($invoice['payment_variable_symbol'] ?? ''));
+        $paymentVariableSymbol = $explicitPaymentVariableSymbol !== ''
+            ? $explicitPaymentVariableSymbol
+            : trim((string) ($invoice['varsymbol'] ?? ''));
+        if ($bank !== null && ($payable > 0 || $explicitPaymentVariableSymbol !== '')) {
             $pm = $dom->createElementNS(self::NS, 'PaymentMeans');
             $payment = $dom->createElementNS(self::NS, 'Payment');
             // PaidAmount nemá v ISDOC Curr variantu → lokální měna (CZK).
@@ -407,10 +433,13 @@ final class IsdocExporter
             $this->el($dom, $details, 'Name', (string) ($bank['bank_name'] ?? ''));
             $this->el($dom, $details, 'IBAN', $iban);
             $this->el($dom, $details, 'BIC', $bic);
-            if (!empty($invoice['varsymbol'])) {
-                $this->el($dom, $details, 'VariableSymbol', (string) $invoice['varsymbol']);
+            if ($paymentVariableSymbol !== '') {
+                $this->el($dom, $details, 'VariableSymbol', $paymentVariableSymbol);
             }
-            $this->el($dom, $details, 'ConstantSymbol', '0308');
+            $constantSymbol = trim((string) ($invoice['payment_constant_symbol'] ?? '0308'));
+            if ($constantSymbol !== '') {
+                $this->el($dom, $details, 'ConstantSymbol', $constantSymbol);
+            }
 
             $payment->appendChild($details);
             $pm->appendChild($payment);

--- a/api/src/Service/Export/PurchaseInvoiceExportService.php
+++ b/api/src/Service/Export/PurchaseInvoiceExportService.php
@@ -6,6 +6,7 @@ namespace MyInvoice\Service\Export;
 
 use MyInvoice\Infrastructure\Database\Connection;
 use MyInvoice\Repository\PurchaseInvoiceRepository;
+use MyInvoice\Service\Bank\VariableSymbolNormalizer;
 
 /**
  * Export přijaté faktury do ISDOC / Pohoda XML.
@@ -93,6 +94,7 @@ final class PurchaseInvoiceExportService
         // Náš tenant je v této transakci CUSTOMER (kupující). Vendor je SUPPLIER.
         $ourSnapshot = $this->loadSupplierSnapshot($supplierId);
         $vendorSnapshot = $pi['vendor_snapshot'] ?? $this->loadVendorSnapshot((int) $pi['vendor_id']);
+        $paymentVariableSymbol = $this->paymentVariableSymbol($pi);
 
         // Items mapping — preserve structure (description, quantity, unit_price, vat_rate)
         $items = array_map(function ($it) {
@@ -118,6 +120,8 @@ final class PurchaseInvoiceExportService
                 'advance'     => 'proforma',
                 default       => 'invoice',
             },
+            'document_number' => $pi['vendor_invoice_number'] ?? $pi['varsymbol'] ?? ('P-' . $pi['id']),
+            'internal_document_number' => $pi['varsymbol'] ?? null,
             'varsymbol'       => $pi['varsymbol'] ?? $pi['vendor_invoice_number'] ?? ('P-' . $pi['id']),
             'issue_date'      => $pi['issue_date'],
             'tax_date'        => $pi['tax_date'] ?? $pi['issue_date'],
@@ -137,6 +141,9 @@ final class PurchaseInvoiceExportService
             // Plus pro legacy/fallback code paths v existing exporteru
             'supplier'          => $vendorSnapshot,
             'client'            => $ourSnapshot,
+            'bank_snapshot'     => $this->paymentBankSnapshot($pi, $paymentVariableSymbol),
+            'payment_variable_symbol' => $paymentVariableSymbol !== '' ? $paymentVariableSymbol : null,
+            'payment_constant_symbol' => $pi['payment_constant_symbol'] ?? null,
             'items'             => $items,
             // Rekapitulace DPH + souhrny — oba exportéry je čtou z `vat_breakdown`/`totals`
             // (bez nich byly summary/TaxTotal nulové). Repo je dodává ve find(), ale jiným
@@ -158,6 +165,54 @@ final class PurchaseInvoiceExportService
             // Marker pro export — pomáhá exportérovi vědět, že jde o přijatou
             '_direction'        => 'purchase',
         ];
+    }
+
+    private function paymentVariableSymbol(array $invoice): string
+    {
+        foreach ([
+            (string) ($invoice['payment_variable_symbol'] ?? ''),
+            (string) ($invoice['vendor_invoice_number'] ?? ''),
+            (string) ($invoice['varsymbol'] ?? ''),
+        ] as $candidate) {
+            $normalized = VariableSymbolNormalizer::forPayment($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+        return '';
+    }
+
+    /**
+     * ISDOC drží VS uvnitř PaymentMeans/Details, jehož bankovní skupina je povinná.
+     * Proto vracíme snapshot i při samotném VS; prázdné bankovní elementy XSD dovoluje.
+     *
+     * @return array<string,?string>|null
+     */
+    private function paymentBankSnapshot(array $invoice, string $paymentVariableSymbol): ?array
+    {
+        $accountNumber = self::nullableString($invoice['payment_account_number'] ?? null);
+        $bankCode = self::nullableString($invoice['payment_bank_code'] ?? null);
+        $iban = self::nullableString($invoice['payment_iban'] ?? null);
+        $bic = self::nullableString($invoice['payment_bic'] ?? null);
+
+        if ($accountNumber === null && $bankCode === null && $iban === null && $bic === null
+            && $paymentVariableSymbol === '') {
+            return null;
+        }
+
+        return [
+            'account_number' => $accountNumber,
+            'bank_code'      => $bankCode,
+            'bank_name'      => null,
+            'iban'           => $iban,
+            'bic'            => $bic,
+        ];
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        $string = trim((string) ($value ?? ''));
+        return $string !== '' ? $string : null;
     }
 
     /**

--- a/api/tests/Unit/Service/Export/IsdocReceivedInvoiceSchemaTest.php
+++ b/api/tests/Unit/Service/Export/IsdocReceivedInvoiceSchemaTest.php
@@ -70,6 +70,47 @@ final class IsdocReceivedInvoiceSchemaTest extends TestCase
         self::assertSame('3049.20', $this->xpathOne($xml, '//i:LegalMonetaryTotal/i:TaxInclusiveAmount'));
     }
 
+    public function testPaymentVariableSymbolIsExportedSeparatelyFromDocumentId(): void
+    {
+        $xml = $this->exporter->buildXml($this->receivedInvoice([
+            'varsymbol'                => 'PF2606001',
+            'document_number'          => 'FV-2026-001',
+            'internal_document_number' => 'PF2606001',
+            'payment_variable_symbol'  => '2026001234',
+            'payment_constant_symbol'  => '0558',
+            'bank_snapshot'            => [
+                'account_number' => '1000000005',
+                'bank_code'      => '0100',
+                'bank_name'      => 'Komerční banka',
+            ],
+        ]));
+
+        $this->assertValidIsdoc($xml);
+        self::assertSame('FV-2026-001', $this->xpathOne($xml, '//i:Invoice/i:ID'));
+        self::assertSame('PF2606001', $this->xpathOne(
+            $xml, '//i:Extensions/myi:InternalDocumentNumber'));
+        self::assertSame('2026001234', $this->xpathOne(
+            $xml, '//i:PaymentMeans/i:Payment/i:Details/i:VariableSymbol'));
+        self::assertSame('0558', $this->xpathOne(
+            $xml, '//i:PaymentMeans/i:Payment/i:Details/i:ConstantSymbol'));
+    }
+
+    public function testPaymentVariableSymbolRemainsInPaidInvoice(): void
+    {
+        $xml = $this->exporter->buildXml($this->receivedInvoice([
+            'amount_to_pay'             => 0.0,
+            'payment_variable_symbol'   => '2026001234',
+            'bank_snapshot'             => [
+                'account_number' => '1000000005',
+                'bank_code'      => '0100',
+            ],
+        ]));
+
+        $this->assertValidIsdoc($xml);
+        self::assertSame('2026001234', $this->xpathOne(
+            $xml, '//i:PaymentMeans/i:Payment/i:Details/i:VariableSymbol'));
+    }
+
     public function testReceivedCreditNoteIsSchemaValid(): void
     {
         $this->assertValidIsdoc($this->exporter->buildXml($this->receivedInvoice(['invoice_type' => 'credit_note'])));
@@ -83,6 +124,7 @@ final class IsdocReceivedInvoiceSchemaTest extends TestCase
         $dom->loadXML($xml);
         $xp = new \DOMXPath($dom);
         $xp->registerNamespace('i', 'http://isdoc.cz/namespace/2013');
+        $xp->registerNamespace('myi', IsdocExporter::MYINVOICE_EXTENSION_NS);
         return $xp->query($expr)->item(0)?->textContent;
     }
 
@@ -121,6 +163,8 @@ final class IsdocReceivedInvoiceSchemaTest extends TestCase
             'id'                 => 1,
             'invoice_type'       => 'invoice',
             'varsymbol'          => '2026-VF-1',
+            'document_number'    => 'FV-2026-001',
+            'internal_document_number' => '2026-VF-1',
             'issue_date'         => '2026-06-03',
             'tax_date'           => '2026-06-03',
             'due_date'           => '2026-06-17',

--- a/api/tests/Unit/Service/Export/PurchaseInvoiceIsdocPaymentTest.php
+++ b/api/tests/Unit/Service/Export/PurchaseInvoiceIsdocPaymentTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Export;
+
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Repository\InvoiceRepository;
+use MyInvoice\Repository\PurchaseInvoiceRepository;
+use MyInvoice\Service\Export\IsdocExporter;
+use MyInvoice\Service\Export\PohodaXmlExporter;
+use MyInvoice\Service\Export\PurchaseInvoiceExportService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regrese pro mapování platebních údajů z purchase_invoices do ISDOC.
+ */
+final class PurchaseInvoiceIsdocPaymentTest extends TestCase
+{
+    private const XSD = __DIR__ . '/../../../../xsd/isdoc-invoice-6.0.2.xsd';
+
+    public function testPaymentVariableSymbolAndBankAccountAreExported(): void
+    {
+        $xml = $this->export([
+            'amount_to_pay'            => 0.0,
+            'payment_account_number'   => '1000000005',
+            'payment_bank_code'        => '0100',
+            'payment_variable_symbol'  => '0001234567',
+            'payment_constant_symbol'  => '0558',
+        ]);
+
+        $this->assertValidIsdoc($xml);
+        self::assertSame('FV-2026-001', $this->xpathOne($xml, '//i:Invoice/i:ID'));
+        self::assertSame('PF2607001', $this->xpathOne(
+            $xml, '//i:Extensions/myi:InternalDocumentNumber'));
+        self::assertSame('1000000005', $this->xpathOne(
+            $xml, '//i:PaymentMeans/i:Payment/i:Details/i:ID'));
+        self::assertSame('0100', $this->xpathOne(
+            $xml, '//i:PaymentMeans/i:Payment/i:Details/i:BankCode'));
+        self::assertSame('0001234567', $this->xpathOne(
+            $xml, '//i:PaymentMeans/i:Payment/i:Details/i:VariableSymbol'));
+        self::assertSame('0558', $this->xpathOne(
+            $xml, '//i:PaymentMeans/i:Payment/i:Details/i:ConstantSymbol'));
+    }
+
+    public function testVendorInvoiceNumberIsVariableSymbolFallback(): void
+    {
+        $xml = $this->export([
+            'vendor_invoice_number'    => 'FV 2026/77',
+            'payment_variable_symbol'  => null,
+            'payment_account_number'   => null,
+            'payment_bank_code'        => null,
+        ]);
+
+        $this->assertValidIsdoc($xml);
+        self::assertSame('FV 2026/77', $this->xpathOne($xml, '//i:Invoice/i:ID'));
+        self::assertSame('202677', $this->xpathOne(
+            $xml, '//i:PaymentMeans/i:Payment/i:Details/i:VariableSymbol'));
+    }
+
+    /**
+     * @param array<string,mixed> $overrides
+     */
+    private function export(array $overrides): string
+    {
+        $purchaseInvoice = array_merge([
+            'id'                       => 42,
+            'vendor_id'                => 8,
+            'document_kind'            => 'invoice',
+            'varsymbol'                => 'PF2607001',
+            'vendor_invoice_number'    => 'FV-2026-001',
+            'issue_date'               => '2026-07-01',
+            'tax_date'                 => '2026-07-01',
+            'due_date'                 => '2026-07-15',
+            'currency'                 => 'CZK',
+            'exchange_rate'            => null,
+            'reverse_charge'           => false,
+            'prices_include_vat'       => false,
+            'language'                 => 'cs',
+            'vendor_snapshot'          => [
+                'ic'           => '11122233',
+                'dic'          => 'CZ11122233',
+                'company_name' => 'Dodavatel s.r.o.',
+                'street'       => 'Dlouhá 5',
+                'city'         => 'Brno',
+                'zip'          => '60200',
+                'country_iso2' => 'CZ',
+            ],
+            'items'                    => [[
+                'description'            => 'Vývoj systému',
+                'quantity'               => 1.0,
+                'unit'                   => 'ks',
+                'unit_price_without_vat' => 1000.0,
+                'vat_rate_snapshot'      => 21.0,
+                'total_without_vat'      => 1000.0,
+                'total_vat'              => 210.0,
+                'total_with_vat'         => 1210.0,
+            ]],
+            'vat_breakdown'             => [[
+                'vat_rate'    => 21.0,
+                'without_vat' => 1000.0,
+                'vat'         => 210.0,
+                'with_vat'    => 1210.0,
+            ]],
+            'totals'                    => [
+                'without_vat'         => 1000.0,
+                'vat'                 => 210.0,
+                'with_vat'            => 1210.0,
+                'rounding'            => 0.0,
+                'advance_paid_amount' => 0.0,
+                'amount_to_pay'       => 1210.0,
+            ],
+            'amount_to_pay'             => 1210.0,
+            'advance_paid_amount'       => 0.0,
+            'payment_account_number'    => '1000000005',
+            'payment_bank_code'         => '0100',
+            'payment_iban'              => null,
+            'payment_bic'               => null,
+            'payment_variable_symbol'   => '2026000001',
+            'payment_constant_symbol'   => null,
+        ], $overrides);
+
+        $repo = $this->createMock(PurchaseInvoiceRepository::class);
+        $repo->expects(self::once())
+            ->method('find')
+            ->with(42, 7)
+            ->willReturn($purchaseInvoice);
+
+        $statement = $this->createMock(\PDOStatement::class);
+        $statement->expects(self::once())->method('execute')->with([7])->willReturn(true);
+        $statement->expects(self::once())->method('fetch')->with(\PDO::FETCH_ASSOC)->willReturn([
+            'ic'           => '01698401',
+            'dic'          => 'CZ01698401',
+            'company_name' => 'Naše firma s.r.o.',
+            'street'       => 'Kardinála Berana 1104/36',
+            'city'         => 'Plzeň',
+            'zip'          => '30100',
+            'country_iso2' => 'CZ',
+        ]);
+
+        $pdo = $this->createMock(\PDO::class);
+        $pdo->expects(self::once())->method('prepare')->willReturn($statement);
+
+        $db = $this->createStub(Connection::class);
+        $db->method('pdo')->willReturn($pdo);
+
+        $isdoc = new IsdocExporter(
+            $this->createStub(InvoiceRepository::class),
+            $db,
+        );
+        $service = new PurchaseInvoiceExportService(
+            $db,
+            $repo,
+            $isdoc,
+            $this->createStub(PohodaXmlExporter::class),
+        );
+
+        return $service->toIsdocXml(42, 7);
+    }
+
+    private function xpathOne(string $xml, string $expression): ?string
+    {
+        $dom = new \DOMDocument();
+        self::assertTrue($dom->loadXML($xml));
+        $xpath = new \DOMXPath($dom);
+        $xpath->registerNamespace('i', 'http://isdoc.cz/namespace/2013');
+        $xpath->registerNamespace('myi', IsdocExporter::MYINVOICE_EXTENSION_NS);
+
+        return $xpath->query($expression)->item(0)?->textContent;
+    }
+
+    private function assertValidIsdoc(string $xml): void
+    {
+        $dom = new \DOMDocument();
+        self::assertTrue($dom->loadXML($xml), 'Export není well-formed XML.');
+
+        $previous = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+        $valid = $dom->schemaValidate(self::XSD);
+        $errors = libxml_get_errors();
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        if (!$valid) {
+            self::fail(implode("\n", array_map(
+                static fn (\LibXMLError $error): string => trim($error->message),
+                $errors,
+            )));
+        }
+        self::assertTrue($valid);
+    }
+}

--- a/manual/18_Export_prijatych.md
+++ b/manual/18_Export_prijatych.md
@@ -19,6 +19,14 @@ referenční dokument."*
 Export do ISDOC 6.0 standardu — kompatibilní s Pohoda, Money S3, iDoklad a dalšími.
 Strategie: **role inversion** — v ISDOC pro přijatou fakturu je *dodavatel* =
 původní vendor, *zákazník* = naše firma (opak vystavené).
+Platební údaje exportují evidovaný bankovní účet dodavatele a variabilní symbol.
+Pokud není variabilní symbol vyplněn samostatně, odvodí se z čísla faktury
+dodavatele.
+
+Číslo dokladu dodavatele je v kořenovém elementu `<ID>`. Interní číslo přijaté
+faktury v MyInvoice (např. `PF2607002`) zůstává oddělené v
+`<Extensions><myi:InternalDocumentNumber>` s namespace
+`https://myinvoice.cz/isdoc/extensions/2026`.
 
 ### Pohoda XML
 Pohoda dataPack XML pro import do účetního software Pohoda. Direction =


### PR DESCRIPTION
# fix(isdoc): opravit identifikátory a platební údaje přijatých faktur

## Shrnutí

ISDOC export přijatých faktur nyní správně odděluje číslo dokladu dodavatele,
interní číslo MyInvoice a platební variabilní symbol. Současně obsahuje evidovaný
bankovní účet dodavatele v sekci `PaymentMeans/Payment/Details`.

## Výsledné mapování

| Zdroj v MyInvoice | ISDOC | Význam |
|---|---|---|
| `vendor_invoice_number` | `Invoice/ID` | Číslo dokladu přidělené dodavatelem |
| `varsymbol` | `Extensions/myi:InternalDocumentNumber` | Interní evidenční číslo MyInvoice, např. `PF2607002` |
| `payment_variable_symbol` | `PaymentMeans/Payment/Details/VariableSymbol` | Platební variabilní symbol |
| `payment_account_number`, `payment_bank_code`, `payment_iban`, `payment_bic` | `PaymentMeans/Payment/Details` | Účet dodavatele pro platbu |

Extension používá namespace `https://myinvoice.cz/isdoc/extensions/2026`.

## Problém

Adapter přijaté faktury předával společnému ISDOC exportéru pouze interní
`purchase_invoices.varsymbol`. Tato hodnota se nesprávně zapisovala jako kořenové
`Invoice/ID`, přestože podle ISDOC má `ID` obsahovat lidsky čitelné číslo dokladu
dodavatele. Skutečné platební pole `purchase_invoices.payment_variable_symbol`
ani bankovní údaje dodavatele se navíc nepředávaly, takže sekce `PaymentMeans`
chyběla.

## Řešení

- platební VS se bere přednostně z `payment_variable_symbol`,
- pokud samostatný platební VS chybí, použije se normalizovaná číselná podoba
  `vendor_invoice_number`, následně interního `varsymbol`,
- do ISDOC se předává evidované číslo účtu, kód banky, IBAN a BIC dodavatele,
- kořenové `Invoice/ID` obsahuje `vendor_invoice_number`,
- interní číslo MyInvoice se zapisuje jako
  `Extensions/myi:InternalDocumentNumber` v namespace
  `https://myinvoice.cz/isdoc/extensions/2026`,
- kořenové `Invoice/ID`, interní číslo a platební `VariableSymbol` zůstávají
  významově oddělené,
- platební VS se zachová také u již uhrazené faktury s nulovým `amount_to_pay`,
- pokud je evidován konstantní symbol, exportuje se místo výchozí hodnoty,
- popis chování je doplněn v OpenAPI a uživatelském manuálu.

Změna platí pro jednotlivý i hromadný ISDOC export, protože obě cesty používají
stejný `PurchaseInvoiceExportService`.

## Dopad

- Vystavené faktury zůstávají beze změny; nové mapování se aktivuje daty
  připravenými adaptérem přijatých faktur.
- Není potřeba databázová migrace ani změna uložených dokladů.
- Účetní software bez podpory MyInvoice extension ji může ignorovat; standardní
  `Invoice/ID` a `VariableSymbol` zůstávají běžnými ISDOC elementy.

## Ověření

- [x] syntax kontrola změněných PHP souborů pod PHP 8.5,
- [x] cílené ISDOC testy: 22 testů, 101 assertions,
- [x] celý balík `tests/Unit/Service/Export`: 64 testů, 425 assertions,
- [x] ISDOC výstup včetně VS a namespacované extension validní vůči XSD 6.0.2,
- [x] OpenAPI striktně parsován bez duplicitních klíčů,
- [x] všech 458 interních OpenAPI `$ref` bez dangling odkazů,
- [x] regenerován HTML a PDF manuál.

## Známý stav kontrol mimo rozsah změny

- Kompletní unit suite spustila 1 278 testů, ale na aktuálním základu selhává
  nesouvisející `CzkRecapTest::testMultipleVatGroupsRoundedPerGroup`
  (`511.66` místo očekávaných `511.67`) a OpenSSL hlásí varování při zápisu
  random state.
- `cmd/check-openapi-coverage.php` hlásí již existující drift 86 rout, které
  v OpenAPI chybějí. Změněné ISDOC endpointy jsou v OpenAPI zdokumentované.
