### PR TITLE
fix(branding): obnovit branding mailů bez profilů

### DIFF
--- a/api/src/Service/Mail/InvoiceEmailVarsBuilder.php
+++ b/api/src/Service/Mail/InvoiceEmailVarsBuilder.php
@@ -271,22 +271,36 @@ final class InvoiceEmailVarsBuilder
             $row['id'] = $sid;
         }
 
-        // 3. Vystavený doklad používá immutable branding ze snapshotu. U draftu
-        //    načteme explicitní profil, případně výchozí profil dodavatele.
+        // 3. Profilový branding vystaveného dokladu je immutable ve snapshotu.
+        //    Bez profilového snapshotu musí vypnutý modul zachovat původní
+        //    chování: logo, přepínač a barvu načítat živě ze supplier.
         if ($row !== null && $sid > 0) {
             $hasSnapshotProfile = !empty($row['branding_profile_id']);
-            if (!$hasSnapshotProfile && !empty($invoice['branding_profile_id'])) {
-                $profileId = (int) $invoice['branding_profile_id'];
-                $bStmt = $this->db->pdo()->prepare(
-                    'SELECT bp.* FROM supplier s
-                       JOIN branding_profiles bp ON bp.id = ?
-                                                AND bp.supplier_id = s.id AND bp.is_active = 1
-                      WHERE s.id = ? AND s.branding_profiles_enabled = 1'
+            if (!$hasSnapshotProfile) {
+                $legacyStmt = $this->db->pdo()->prepare(
+                    'SELECT branding_profiles_enabled, email_branding_enabled, email_accent_color, logo_path
+                       FROM supplier WHERE id = ?'
                 );
-                $bStmt->execute([$profileId, $sid]);
-                $br = $bStmt->fetch(\PDO::FETCH_ASSOC);
-                if ($br !== false) {
-                    $row = \MyInvoice\Service\Branding\BrandingProfileOverlay::apply($row, $br);
+                $legacyStmt->execute([$sid]);
+                $legacy = $legacyStmt->fetch(\PDO::FETCH_ASSOC);
+
+                if ($legacy !== false && empty($legacy['branding_profiles_enabled'])) {
+                    $row['email_branding_enabled'] = (bool) $legacy['email_branding_enabled'];
+                    $row['email_accent_color'] = (string) ($legacy['email_accent_color'] ?: '#3B2D83');
+                    $row['logo_path'] = $legacy['logo_path'] ?: null;
+                } elseif (!empty($invoice['branding_profile_id'])) {
+                    $profileId = (int) $invoice['branding_profile_id'];
+                    $bStmt = $this->db->pdo()->prepare(
+                        'SELECT bp.* FROM supplier s
+                           JOIN branding_profiles bp ON bp.id = ?
+                                                    AND bp.supplier_id = s.id AND bp.is_active = 1
+                          WHERE s.id = ? AND s.branding_profiles_enabled = 1'
+                    );
+                    $bStmt->execute([$profileId, $sid]);
+                    $br = $bStmt->fetch(\PDO::FETCH_ASSOC);
+                    if ($br !== false) {
+                        $row = \MyInvoice\Service\Branding\BrandingProfileOverlay::apply($row, $br);
+                    }
                 }
             }
             $row['email_branding_enabled'] = (bool) ($row['email_branding_enabled'] ?? false);

--- a/api/tests/Unit/Service/Mail/InvoiceEmailVarsBuilderBrandingTest.php
+++ b/api/tests/Unit/Service/Mail/InvoiceEmailVarsBuilderBrandingTest.php
@@ -66,4 +66,145 @@ final class InvoiceEmailVarsBuilderBrandingTest extends TestCase
         self::assertSame('#123456', $vars['supplier']['email_accent_color']);
         self::assertSame('storage/supplier-logos/sup-1.png', $vars['supplier']['logo_path']);
     }
+
+    public function testEnabledBrandingProfilesLoadSelectedProfileWithoutProfileSnapshot(): void
+    {
+        $pdo = $this->brandingDatabase();
+        $pdo->exec(
+            "INSERT INTO supplier
+                (id, branding_profiles_enabled, email_branding_enabled, email_accent_color, logo_path)
+             VALUES
+                (1, 1, 0, '#AAAAAA', NULL)"
+        );
+        $pdo->exec(
+            "INSERT INTO branding_profiles
+                (id, supplier_id, display_name, tagline, email, reply_to, phone, web, email_footer,
+                 logo_path, accent_color, branding_enabled, pdf_logo_show_name, email_profile_id, is_active)
+             VALUES
+                (7, 1, 'Profilová značka', 'Profilový slogan', 'brand@example.test',
+                 'reply@example.test', '+420 111 222 333', 'https://brand.example.test',
+                 'Profilová patička', 'storage/supplier-logos/sup-1-brand-7-abcdef123456.png',
+                 '#654321', 1, 0, 9, 1)"
+        );
+
+        $vars = $this->builder($pdo)->buildReminder([
+            'supplier_id' => 1,
+            'branding_profile_id' => 7,
+            'supplier_snapshot' => $this->supplierSnapshot(),
+            'invoice_type' => 'invoice',
+            'varsymbol' => '',
+            'status' => 'draft',
+            'total_with_vat' => 1210,
+        ], 1, 'cs');
+
+        self::assertSame(7, $vars['supplier']['branding_profile_id']);
+        self::assertSame('Profilová značka', $vars['supplier']['display_name']);
+        self::assertSame('Profilová patička', $vars['supplier']['email_footer']);
+        self::assertSame('storage/supplier-logos/sup-1-brand-7-abcdef123456.png', $vars['supplier']['logo_path']);
+        self::assertSame('#654321', $vars['supplier']['email_accent_color']);
+        self::assertSame(9, $vars['supplier']['email_profile_id']);
+        self::assertSame('reply@example.test', $vars['supplier']['reply_to']);
+    }
+
+    public function testIssuedInvoiceKeepsBrandingProfileFromSnapshot(): void
+    {
+        $pdo = $this->brandingDatabase();
+        $pdo->exec(
+            "INSERT INTO supplier
+                (id, branding_profiles_enabled, email_branding_enabled, email_accent_color, logo_path)
+             VALUES
+                (1, 1, 0, '#AAAAAA', NULL)"
+        );
+
+        $snapshot = array_merge(
+            json_decode($this->supplierSnapshot(), true, flags: JSON_THROW_ON_ERROR),
+            [
+            'branding_profile_id' => 7,
+            'display_name' => 'Zmrazená značka',
+            'email_footer' => 'Zmrazená patička',
+            'logo_path' => 'storage/supplier-logos/sup-1-brand-7-abcdef123456.png',
+            'email_branding_enabled' => true,
+            'email_accent_color' => '#654321',
+            'email_profile_id' => 9,
+            ],
+        );
+
+        $vars = $this->builder($pdo)->buildReminder([
+            'supplier_id' => 1,
+            'branding_profile_id' => 7,
+            'supplier_snapshot' => json_encode($snapshot, JSON_THROW_ON_ERROR),
+            'invoice_type' => 'invoice',
+            'varsymbol' => '',
+            'status' => 'issued',
+            'total_with_vat' => 1210,
+        ], 1, 'cs');
+
+        self::assertSame(7, $vars['supplier']['branding_profile_id']);
+        self::assertSame('Zmrazená značka', $vars['supplier']['display_name']);
+        self::assertSame('Zmrazená patička', $vars['supplier']['email_footer']);
+        self::assertSame('storage/supplier-logos/sup-1-brand-7-abcdef123456.png', $vars['supplier']['logo_path']);
+        self::assertSame('#654321', $vars['supplier']['email_accent_color']);
+        self::assertSame(9, $vars['supplier']['email_profile_id']);
+    }
+
+    private function brandingDatabase(): PDO
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            'CREATE TABLE supplier (
+                id INTEGER PRIMARY KEY,
+                branding_profiles_enabled INTEGER NOT NULL,
+                email_branding_enabled INTEGER NOT NULL,
+                email_accent_color TEXT NULL,
+                logo_path TEXT NULL
+            )'
+        );
+        $pdo->exec(
+            'CREATE TABLE branding_profiles (
+                id INTEGER PRIMARY KEY,
+                supplier_id INTEGER NOT NULL,
+                display_name TEXT NULL,
+                tagline TEXT NULL,
+                email TEXT NULL,
+                reply_to TEXT NULL,
+                phone TEXT NULL,
+                web TEXT NULL,
+                email_footer TEXT NULL,
+                logo_path TEXT NULL,
+                accent_color TEXT NULL,
+                branding_enabled INTEGER NOT NULL,
+                pdf_logo_show_name INTEGER NOT NULL,
+                email_profile_id INTEGER NULL,
+                is_active INTEGER NOT NULL
+            )'
+        );
+        return $pdo;
+    }
+
+    private function builder(PDO $pdo): InvoiceEmailVarsBuilder
+    {
+        $connection = new Connection($this->createStub(Config::class));
+        (new \ReflectionProperty(Connection::class, 'pdo'))->setValue($connection, $pdo);
+
+        return new InvoiceEmailVarsBuilder(
+            $connection,
+            (new \ReflectionClass(QrPaymentGenerator::class))->newInstanceWithoutConstructor(),
+            (new \ReflectionClass(InvoicePublicLinkService::class))->newInstanceWithoutConstructor(),
+        );
+    }
+
+    private function supplierSnapshot(): string
+    {
+        return json_encode([
+            'id' => 1,
+            'company_name' => 'Testovací dodavatel s.r.o.',
+            'display_name' => 'Testovací dodavatel',
+            'street' => 'Testovací 1',
+            'city' => 'Praha',
+            'zip' => '100 00',
+            'country_name_cs' => 'Česko',
+            'email' => 'supplier@example.test',
+        ], JSON_THROW_ON_ERROR);
+    }
 }

--- a/api/tests/Unit/Service/Mail/InvoiceEmailVarsBuilderBrandingTest.php
+++ b/api/tests/Unit/Service/Mail/InvoiceEmailVarsBuilderBrandingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Mail;
+
+use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Service\Invoice\InvoicePublicLinkService;
+use MyInvoice\Service\Mail\InvoiceEmailVarsBuilder;
+use MyInvoice\Service\Qr\QrPaymentGenerator;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class InvoiceEmailVarsBuilderBrandingTest extends TestCase
+{
+    public function testDisabledBrandingProfilesKeepLegacySupplierBrandingForIssuedInvoice(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec(
+            'CREATE TABLE supplier (
+                id INTEGER PRIMARY KEY,
+                branding_profiles_enabled INTEGER NOT NULL,
+                email_branding_enabled INTEGER NOT NULL,
+                email_accent_color TEXT NULL,
+                logo_path TEXT NULL
+            )'
+        );
+        $pdo->exec(
+            "INSERT INTO supplier
+                (id, branding_profiles_enabled, email_branding_enabled, email_accent_color, logo_path)
+             VALUES
+                (1, 0, 1, '#123456', 'storage/supplier-logos/sup-1.png')"
+        );
+
+        $connection = new Connection($this->createStub(Config::class));
+        (new \ReflectionProperty(Connection::class, 'pdo'))->setValue($connection, $pdo);
+
+        $builder = new InvoiceEmailVarsBuilder(
+            $connection,
+            (new \ReflectionClass(QrPaymentGenerator::class))->newInstanceWithoutConstructor(),
+            (new \ReflectionClass(InvoicePublicLinkService::class))->newInstanceWithoutConstructor(),
+        );
+
+        $vars = $builder->buildReminder([
+            'supplier_id' => 1,
+            'supplier_snapshot' => json_encode([
+                'id' => 1,
+                'company_name' => 'Testovací dodavatel s.r.o.',
+                'display_name' => 'Testovací dodavatel',
+                'street' => 'Testovací 1',
+                'city' => 'Praha',
+                'zip' => '100 00',
+                'country_name_cs' => 'Česko',
+                'email' => 'supplier@example.test',
+            ], JSON_THROW_ON_ERROR),
+            'invoice_type' => 'invoice',
+            'varsymbol' => '',
+            'status' => 'issued',
+            'total_with_vat' => 1210,
+        ], 1, 'cs');
+
+        self::assertSame('Testovací dodavatel', $vars['supplier']['display_name']);
+        self::assertTrue($vars['supplier']['email_branding_enabled']);
+        self::assertSame('#123456', $vars['supplier']['email_accent_color']);
+        self::assertSame('storage/supplier-logos/sup-1.png', $vars['supplier']['logo_path']);
+    }
+}


### PR DESCRIPTION
## Co se mění

- při vypnutých brandingových profilech se pro e-maily znovu načte původní živý branding dodavatele (`email_branding_enabled`, akcentní barva a logo)
- profilový branding uložený ve snapshotu dokladu zůstává nedotčený
- regresní testy pokrývají vypnutý modul, aktivní profil načtený z faktury i profilový snapshot vystaveného dokladu

## Proč

Po začlenění brandingových profilů přestal `InvoiceEmailVarsBuilder` u dokladů bez profilového snapshotu načítat původní branding ze `supplier`. Chybějící hodnoty následně skončily jako `false`/`null`, takže skutečně odeslaný e-mail byl bez loga a barev, přestože náhled fungoval. Oprava řeší #240 a funguje i pro faktury vystavené ve v4.50.x.

Doplněné testy současně potvrzují, že zapnutý multibranding předává do mailového kontextu zobrazovaný název, patičku, logo, barvu, odesílací profil a reply-to jak z aktivního profilu, tak z immutable snapshotu.

## Ověření

- `php vendor/bin/phpunit tests/Unit/Service/Mail`
- 60 testů, 228 assertions
- `git diff --check`