### PR TITLE
feat(pdf): serverový override šablony faktury

### DIFF
--- a/api/src/Service/Pdf/InvoicePdfRenderer.php
+++ b/api/src/Service/Pdf/InvoicePdfRenderer.php
@@ -7,6 +7,7 @@ namespace MyInvoice\Service\Pdf;
 use Mpdf\Mpdf;
 use MyInvoice\Bootstrap;
 use MyInvoice\Infrastructure\Config\Config;
+use MyInvoice\Infrastructure\Config\RuntimePaths;
 use MyInvoice\Infrastructure\Database\Connection;
 use MyInvoice\Repository\InvoiceRepository;
 use MyInvoice\Repository\WorkReportRepository;
@@ -33,6 +34,10 @@ final class InvoicePdfRenderer
     use SignsPdf;
 
     private ?Environment $twig = null;
+    private bool $lastRenderUsedCustomTemplate = false;
+
+    private const CUSTOM_TEMPLATE = 'templates/invoice/invoice-custom.twig';
+    private const CUSTOM_CSS = 'templates/invoice/invoice-custom.css';
 
     public function __construct(
         private readonly InvoiceRepository $repo,
@@ -70,6 +75,7 @@ final class InvoicePdfRenderer
         $tplMtime = max(
             @filemtime(Bootstrap::rootDir() . '/styles/invoice.css') ?: 0,
             @filemtime(Bootstrap::rootDir() . '/api/templates/invoice/invoice.twig') ?: 0,
+            $this->templateOverrideMtime(),
             @filemtime(__FILE__) ?: 0,
         );
         $isFresh = static fn (string $p): bool =>
@@ -231,10 +237,6 @@ final class InvoicePdfRenderer
         bool $includeWorkReport = true,
     ): array
     {
-        $cssPath = Bootstrap::rootDir() . '/styles/invoice.css';
-        $css = is_file($cssPath) ? (string) file_get_contents($cssPath) : '';
-        // Per-supplier branding barva — přebarví fialové akcenty na zvolený odstín.
-        $css .= $this->brandAccentCss($this->resolveSupplier($invoice));
         // Renderuj template BEZ inline <style> bloku — CSS pošleme do mPDF zvlášť
         $body = $this->renderHtml(
             $invoice,
@@ -242,6 +244,18 @@ final class InvoicePdfRenderer
             hasIsdocAttachment: $hasIsdocAttachment,
             includeWorkReport: $includeWorkReport,
         );
+        $cssPath = $this->lastRenderUsedCustomTemplate
+            ? RuntimePaths::storage(self::CUSTOM_CSS)
+            : Bootstrap::rootDir() . '/styles/invoice.css';
+        // Custom CSS je volitelné. Bez něj vlastní Twig používá upstream styl,
+        // což je praktické pro malé strukturální úpravy šablony.
+        if (!is_file($cssPath)) {
+            $cssPath = Bootstrap::rootDir() . '/styles/invoice.css';
+        }
+        $css = is_file($cssPath) ? (string) file_get_contents($cssPath) : '';
+        // Per-supplier branding barva — přebarví fialové akcenty na zvolený odstín.
+        // Připojuje se i ke custom CSS, aby profilové barvy fungovaly stejně.
+        $css .= $this->brandAccentCss($this->resolveSupplier($invoice));
         return ['body' => $body, 'css' => $css];
     }
 
@@ -287,20 +301,39 @@ final class InvoicePdfRenderer
         }
 
         $locale = $invoice['language'] ?? 'cs';
-        $cssPath = Bootstrap::rootDir() . '/styles/invoice.css';
-        $css = $includeCss
-            ? (is_file($cssPath) ? (string) file_get_contents($cssPath) : '')
-            : '';
-        if ($includeCss && $css !== '') {
-            $css .= $this->brandAccentCss($supplierData);
-        }
-
         $twig = $this->twig();
 
         // Translation helper
         $twig->addFunction(new \Twig\TwigFunction('t', static function (string $cs, string $en) use ($locale) {
             return $locale === 'en' ? $en : $cs;
         }));
+
+        $customTemplate = RuntimePaths::storage(self::CUSTOM_TEMPLATE);
+        $customCss = RuntimePaths::storage(self::CUSTOM_CSS);
+        $templateName = 'invoice.twig';
+        $this->lastRenderUsedCustomTemplate = false;
+
+        if (is_file($customTemplate)) {
+            try {
+                // load() šablonu zkompiluje, takže zachytí syntaktickou chybu ještě
+                // před volbou CSS. Runtime chyby zachytí render níže.
+                $twig->load('invoice-custom.twig');
+                $templateName = 'invoice-custom.twig';
+                $this->lastRenderUsedCustomTemplate = true;
+            } catch (\Twig\Error\Error $e) {
+                error_log('[invoice-pdf] invoice-custom.twig nelze načíst, používám výchozí šablonu: ' . $e->getMessage());
+            }
+        }
+
+        $cssPath = $this->lastRenderUsedCustomTemplate && is_file($customCss)
+            ? $customCss
+            : Bootstrap::rootDir() . '/styles/invoice.css';
+        $css = $includeCss
+            ? (is_file($cssPath) ? (string) file_get_contents($cssPath) : '')
+            : '';
+        if ($includeCss && $css !== '') {
+            $css .= $this->brandAccentCss($supplierData);
+        }
 
         $logoPath = $this->resolveLogoPath($supplierData, (int) ($invoice['supplier_id'] ?? 0));
 
@@ -336,7 +369,23 @@ final class InvoicePdfRenderer
             'logo_show_name'    => $logoPath !== null && !empty($supplierData['pdf_logo_show_name']),
             'isdoc_attachment'  => $hasIsdocAttachment, // bool — badge gate
         ];
-        return $twig->render('invoice.twig', $vars);
+        try {
+            return $twig->render($templateName, $vars);
+        } catch (\Twig\Error\Error $e) {
+            if (!$this->lastRenderUsedCustomTemplate) {
+                throw $e;
+            }
+            error_log('[invoice-pdf] invoice-custom.twig selhala při renderu, používám výchozí šablonu: ' . $e->getMessage());
+            $this->lastRenderUsedCustomTemplate = false;
+            if ($includeCss) {
+                $defaultCss = Bootstrap::rootDir() . '/styles/invoice.css';
+                $vars['css'] = is_file($defaultCss) ? (string) file_get_contents($defaultCss) : '';
+                if ($vars['css'] !== '') {
+                    $vars['css'] .= $this->brandAccentCss($supplierData);
+                }
+            }
+            return $twig->render('invoice.twig', $vars);
+        }
     }
 
     private function newMpdf(string $tmpDir): Mpdf
@@ -352,6 +401,50 @@ final class InvoicePdfRenderer
             'autoPageBreak'     => true,
             ...MpdfFontConfig::options(),
         ]);
+    }
+
+    /**
+     * Vrací mtime markeru konfigurace lokální šablony. Samotné maximum mtime
+     * nestačí: po smazání custom souboru by hodnota klesla a dříve vygenerované
+     * PDF by zůstalo považované za čerstvé. Marker se proto obnoví při každé
+     * změně existence nebo mtime Twigu/CSS a spolehlivě invaliduje cache i při
+     * aktivaci, deaktivaci a opravě rozbité šablony.
+     */
+    private function templateOverrideMtime(): int
+    {
+        $template = RuntimePaths::storage(self::CUSTOM_TEMPLATE);
+        $css = RuntimePaths::storage(self::CUSTOM_CSS);
+        $signature = implode(':', [
+            is_file($template) ? '1' : '0',
+            (string) (@filemtime($template) ?: 0),
+            is_file($css) ? '1' : '0',
+            (string) (@filemtime($css) ?: 0),
+        ]);
+
+        $marker = RuntimePaths::storage('cache/invoice-template-override.state');
+        $current = is_file($marker) ? trim((string) @file_get_contents($marker)) : '';
+        if (!hash_equals($current, $signature)) {
+            $dir = dirname($marker);
+            if (!is_dir($dir)) {
+                @mkdir($dir, 0755, true);
+            }
+            // Atomická náhrada přes sibling soubor řeší i střídání uživatelů:
+            // CLI může běžet jako root, zatímco PHP-FPM jako www-data. O přepsání
+            // rozhodují práva adresáře, takže rootem vlastněný starý marker
+            // nezablokuje pozdější invalidaci z webového procesu.
+            $tmpMarker = $marker . '.' . bin2hex(random_bytes(6)) . '.tmp';
+            if (@file_put_contents($tmpMarker, $signature . "\n", LOCK_EX) !== false) {
+                $nextMtime = max(time() + 1, (@filemtime($marker) ?: 0) + 1);
+                @unlink($marker);
+                if (@rename($tmpMarker, $marker)) {
+                    @touch($marker, $nextMtime);
+                } else {
+                    @unlink($tmpMarker);
+                }
+            }
+        }
+
+        return @filemtime($marker) ?: 0;
     }
 
     /**
@@ -403,7 +496,13 @@ final class InvoicePdfRenderer
     {
         // Vždy nový Environment — addFunction() lze volat jen před init,
         // a po jednom render() se environment zamkne. Cache=false stejně.
-        $loader = new FilesystemLoader(dirname(__DIR__, 3) . '/templates/invoice');
+        $customDir = dirname(RuntimePaths::storage(self::CUSTOM_TEMPLATE));
+        $paths = [];
+        if (is_dir($customDir)) {
+            $paths[] = $customDir;
+        }
+        $paths[] = dirname(__DIR__, 3) . '/templates/invoice';
+        $loader = new FilesystemLoader($paths);
         return new Environment($loader, [
             'autoescape' => 'html',
             'cache' => false,

--- a/api/tests/Architecture/InvoiceCustomTemplateOverrideTest.php
+++ b/api/tests/Architecture/InvoiceCustomTemplateOverrideTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guard serverového PDF override: musí zůstat mimo UI/API, v runtime datech
+ * a s fallbackem na vestavěnou šablonu.
+ */
+final class InvoiceCustomTemplateOverrideTest extends TestCase
+{
+    public function testOverrideIsRuntimeOnlyAndHasSafeFallback(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $renderer = file_get_contents($root . '/api/src/Service/Pdf/InvoicePdfRenderer.php');
+        self::assertIsString($renderer);
+
+        self::assertStringContainsString(
+            "RuntimePaths::storage(self::CUSTOM_TEMPLATE)",
+            $renderer,
+        );
+        self::assertStringContainsString(
+            "private const CUSTOM_TEMPLATE = 'templates/invoice/invoice-custom.twig';",
+            $renderer,
+        );
+        self::assertStringContainsString(
+            "return \$twig->render('invoice.twig', \$vars);",
+            $renderer,
+        );
+        self::assertStringContainsString(
+            'catch (\\Twig\\Error\\Error $e)',
+            $renderer,
+        );
+        self::assertStringContainsString(
+            '$this->templateOverrideMtime()',
+            $renderer,
+        );
+    }
+
+    public function testNoCustomTemplateUploadOrEditorIsExposed(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $routes = file_get_contents($root . '/api/src/Routes.php');
+        $openApi = file_get_contents($root . '/api/openapi.yaml');
+        $settingsUi = file_get_contents($root . '/web/src/components/settings/BrandingProfilesSettings.vue');
+
+        self::assertIsString($routes);
+        self::assertIsString($openApi);
+        self::assertIsString($settingsUi);
+        self::assertStringNotContainsString('invoice-custom.twig', $routes);
+        self::assertStringNotContainsString('invoice-custom.twig', $openApi);
+        self::assertStringNotContainsString('invoice-custom.twig', $settingsUi);
+    }
+}

--- a/manual/11_Faktura_PDF.md
+++ b/manual/11_Faktura_PDF.md
@@ -113,7 +113,31 @@ Vygenerované PDF obsahuje:
 > loga se pak vykreslí obchodní (nebo firemní) název. Sémantické barvy zůstávají
 > vždy stejné (dobropis červená, storno šedá).
 
-### 11.2.1 Přepočet do CZK (faktury v cizí měně)
+### 11.2.1 Serverová vlastní šablona
+
+Správce self-hosted instalace může bez webového editoru nahradit vzhled faktury
+vlastními soubory v persistentním datovém adresáři:
+
+- `storage/templates/invoice/invoice-custom.twig`
+- `storage/templates/invoice/invoice-custom.css` (volitelné)
+
+V Dockeru s `MYINVOICE_DATA_DIR=/data` jsou absolutní cesty
+`/data/storage/templates/invoice/invoice-custom.*`. Soubory jsou v datovém
+volume, takže je nový image ani rebuild nepřepíše. Pokud vlastní CSS chybí,
+použije se výchozí `styles/invoice.css`.
+
+Vlastní šablona je určena výhradně správci serveru, který má přístup k
+souborovému systému a vědomě přebírá odpovědnost za správnost výsledného
+daňového dokladu. Aplikace ji nenabízí k editaci ani uploadu přes web či API.
+Po každé změně je nutné ověřit faktury s více položkami, sazbami DPH, dlouhými
+texty, QR platbou, dobropisem, zálohou a případným výkazem práce.
+
+Když `invoice-custom.twig` neexistuje, nelze jej zkompilovat nebo selže při
+renderování, aplikace zapíše chybu do logu a automaticky použije vestavěnou
+`invoice.twig` a její CSS. Přidání, změna i odstranění vlastního Twigu/CSS
+invaliduje PDF cache.
+
+### 11.2.2 Přepočet do CZK (faktury v cizí měně)
 
 Pokud je faktura v jiné měně než CZK, PDF obsahuje navíc:
 
@@ -127,7 +151,7 @@ Pokud je faktura starší a nemá zafixovaný kurz (legacy data), MyInvoice ho
 **doplní automaticky** při příštím otevření detailu nebo PDF (cache → ČNB →
 poslední známý). Detail viz [§ 10.4.2 Faktura v cizí měně](10_Faktura_editor.md#1042-faktura-v-cizi-mene-eur-usd-prepocet-do-czk).
 
-### 11.2.2 PDF/A-3b (archivní formát)
+### 11.2.3 PDF/A-3b (archivní formát)
 
 Všechna generovaná PDF (faktury, přijaté faktury, výkazy práce, Kniha DPH,
 Kniha jízd) jsou ve formátu **PDF/A-3b** (ISO 19005-3) — standardu pro

--- a/manual/15_Exporty.md
+++ b/manual/15_Exporty.md
@@ -149,7 +149,7 @@ zakázka se podle `project_number` najde nebo automaticky vytvoří.
 ### 15.3.5 ISDOC v PDF příloze (3.6.2+)
 
 Samotné PDF je konformní **PDF/A-3b** (ISO 19005-3, viz
-[§ 11.2.2](11_Faktura_PDF.md#1122-pdfa-3b-archivni-format)). Při generování se
+[§ 11.2.3](11_Faktura_PDF.md#1123-pdfa-3b-archivni-format)). Při generování se
 do něj ISDOC XML přibalí jako příloha (PDF/A-3 associated file). Účetní
 programy si data extrahují přímo z PDF — stačí přeposlat jediný soubor. Pod
 variabilním symbolem se v PDF zobrazí vizuální `ISDOC` badge.

--- a/manual/38_Elektronicke_podpisy.md
+++ b/manual/38_Elektronicke_podpisy.md
@@ -32,7 +32,7 @@ nastaveným TSA serverem o **PAdES-T**. Odchozí e-mail se podepisuje jako
 ale e-mail nešifruje.
 
 > 📁 **Podpis zachovává archivní formát.** Faktury se generují jako PDF/A-3b
-> ([§ 11.2.2](11_Faktura_PDF.md#1122-pdfa-3b-archivni-format)) a elektronický
+> ([§ 11.2.3](11_Faktura_PDF.md#1123-pdfa-3b-archivni-format)) a elektronický
 > podpis tuto archivní konformitu **zachová** — podepsaný dokument je stále
 > validní PDF/A-3b (ověřeno nástrojem veraPDF).
 


### PR DESCRIPTION
## Co se mění

Přidává se volitelný serverový override PDF šablony vystavené faktury:

- `storage/templates/invoice/invoice-custom.twig`
- `storage/templates/invoice/invoice-custom.css` (volitelné)

V Dockeru s `MYINVOICE_DATA_DIR=/data` jde o
`/data/storage/templates/invoice/invoice-custom.*`, tedy o persistentní volume,
které přežije rebuild i výměnu image při aktualizaci.

Pokud vlastní Twig neexistuje, nelze jej zkompilovat nebo selže při renderování,
renderer chybu zapíše do logu a použije vestavěnou `invoice.twig` a její CSS.
Změna existence nebo mtime vlastního Twigu/CSS zároveň invaliduje PDF cache,
včetně přechodu zpět na výchozí šablonu po smazání override.

## Proč

V review PR #229 byly uživatelsky editovatelné PDF šablony přes web správně
odmítnuty: mPDF podporuje jen podmnožinu CSS, rozbitý layout daňového dokladu je
rizikový a tehdejší návrh navíc otevíral čtení lokálních souborů/SSRF.

Relevantní review:

- https://github.com/radekhulan/myinvoice/pull/229#issuecomment-5033768078
- dřívější rozhodnutí k webovým šablonám: https://github.com/radekhulan/myinvoice/issues/43

Tento návrh webovou editaci nevrací. Není zde route, API endpoint, upload,
databázové pole ani UI. Soubor může vložit pouze správce self-hosted serveru,
který už má oprávnění měnit aplikační soubory a vědomě přebírá odpovědnost za
otestování výsledného dokladu. Jde tedy o explicitní deployment customization,
nikoli o zpracování nedůvěryhodné uživatelské šablony.

Praktický problém přímé úpravy `api/templates/invoice/invoice.twig` je, že ji
další release přepíše nebo způsobí konflikt při aktualizaci. Oddělený soubor v
runtime datovém adresáři dovolí správci vlastní vzhled zachovat přes aktualizace,
zatímco chybový fallback udrží generování faktur funkční, pokud se upstream
proměnné nebo Twig pravidla změní.

## Bezpečnost a rozsah

- žádná editace ani upload přes web/API,
- žádné ukládání šablony do DB nebo snapshotu faktury,
- žádná změna chování, pokud override soubor neexistuje,
- při Twig syntaktické i renderovací chybě se použije upstream šablona,
- konkrétní vlastní šablona není součástí PR.

Správce musí vlastní výstup otestovat na více položkách, sazbách DPH, dlouhých
textech, QR platbě, záloze, dobropisu a výkazu práce; manuál na tuto odpovědnost
výslovně upozorňuje.

## Ověření

- produkční Docker build včetně Vue/TypeScript buildu a generování manuálu,
- celý PHPUnit: 1 973 testů, 6 738 assertions, bez selhání
  (55 podmíněně přeskočených, 17 existujících PHPUnit notices),
- nový architektonický guard: 2 testy, 12 assertions,
- ruční mPDF render s platným `invoice-custom.twig`,
- ruční ověření syntakticky rozbitého Twigu — automatický fallback na
  vestavěnou šablonu,
- ruční ověření persistence po rebuild/recreate Docker kontejneru,
- ruční ověření renderu pod uživatelem `www-data`.
