### PR TITLE
fix(banka): oprava stran odchozího avíza Raiffeisenbank

### DIFF
--- a/api/src/Service/Bank/EmailNotice/Parser/RaiffeisenbankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/RaiffeisenbankEmailNoticeParser.php
@@ -58,25 +58,41 @@ final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParse
         $text = $this->normalizeText($message->text);
 
         $postedAt = $this->required($text, '/Datum\s+a\s+čas\s*(?<value>\d{1,2}\.\s*\d{1,2}\.\s*\d{4}\s+\d{1,2}:\d{2})/iu', 'datum');
-        $recipientAccount = $this->required($text, '/Na\s+účet\s*(?<value>[0-9\-]+\/[0-9]{4})/iu', 'cílový účet');
         $amountCurrency = $this->match($text, '/Částka\s+v\s+měně\s+účtu\s*(?<amount>[+\-]?[0-9 .]+,[0-9]{2})\s*(?<currency>[A-Z]{3})/iu');
         if ($amountCurrency === null) {
             throw new \RuntimeException('Raiffeisenbank parser nenašel částku a měnu.');
         }
-        $counterparty = $this->match($text, '/Z\s+účtu\s*(?<account>[0-9\-]+\/[0-9]{4})(?<name>.*?)Variabilní\s+symbol/isu');
+        $amount = $this->parseAmount((string) $amountCurrency['amount']);
+        $to = $this->match(
+            $text,
+            '/Na\s+účet\s*(?<account>[0-9\-]+\/[0-9]{4})(?<name>.*?)(?=Částka\s+v\s+měně\s+účtu|Variabilní\s+symbol)/isu',
+        );
+        if ($to === null) {
+            throw new \RuntimeException('Raiffeisenbank parser nenašel účet příjemce.');
+        }
+        $from = $this->match(
+            $text,
+            '/Z\s+účtu\s*(?<account>[0-9\-]+\/[0-9]{4})(?<name>.*?)(?=Částka\s+v\s+měně\s+účtu|Variabilní\s+symbol)/isu',
+        );
         $variableSymbol = $this->required($text, '/Variabilní\s+symbol\s*(?<value>[0-9]+)/iu', 'variabilní symbol');
         $constantSymbol = $this->optional($text, '/Konstantní\s+symbol\s*(?<value>[0-9]+)/iu');
         $note = $this->optional($text, '/Zpráva\s+pro\s+příjemce\s*(?<value>.*?)Disponibilní\s+zůstatek/isu');
         $balance = $this->optional($text, '/Disponibilní\s+zůstatek(?:\s+po\s+pohybu)?\s*(?<value>[+\-]?[0-9][0-9 .]*,[0-9]{2})/iu');
 
+        $isOutgoing = $amount < 0;
+        if ($isOutgoing && $from === null) {
+            throw new \RuntimeException('Raiffeisenbank parser nenašel vlastní účet plátce.');
+        }
+        $ownAccount = (string) ($isOutgoing ? $from['account'] : $to['account']);
+        $counterparty = $isOutgoing ? $to : $from;
         [$counterpartyAccount, $counterpartyBank] = $this->splitAccount((string) ($counterparty['account'] ?? ''));
 
         return new ParsedBankEmailNotice(
             variableSymbol: $variableSymbol,
-            amount: $this->parseAmount((string) $amountCurrency['amount']),
+            amount: $amount,
             currency: strtoupper((string) $amountCurrency['currency']),
             postedAt: $this->parseDate($postedAt),
-            recipientAccount: $recipientAccount,
+            recipientAccount: $ownAccount,
             counterpartyAccount: $counterpartyAccount,
             counterpartyBank: $counterpartyBank,
             counterpartyName: $this->cleanNullable((string) ($counterparty['name'] ?? '')),

--- a/api/src/Service/Bank/EmailNotice/Parser/RaiffeisenbankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/RaiffeisenbankEmailNoticeParser.php
@@ -79,7 +79,7 @@ final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParse
         $note = $this->optional($text, '/Zpráva\s+pro\s+příjemce\s*(?<value>.*?)Disponibilní\s+zůstatek/isu');
         $balance = $this->optional($text, '/Disponibilní\s+zůstatek(?:\s+po\s+pohybu)?\s*(?<value>[+\-]?[0-9][0-9 .]*,[0-9]{2})/iu');
 
-        $isOutgoing = $amount < 0;
+        $isOutgoing = $this->isOutgoingTransfer($text, $amount);
         if ($isOutgoing && $from === null) {
             throw new \RuntimeException('Raiffeisenbank parser nenašel vlastní účet plátce.');
         }
@@ -100,6 +100,20 @@ final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParse
             message: $note,
             balance: $balance !== null ? $this->parseAmount($balance) : null,
         );
+    }
+
+    private function isOutgoingTransfer(string $text, float $amount): bool
+    {
+        $folded = mb_strtolower($this->foldDiacritics($text));
+        if (preg_match(
+            '/na\s+ucte\s+byla\s+provedena\s+nasledujici\s+(?<direction>prichozi|odchozi)\s+platba/u',
+            $folded,
+            $match,
+        ) === 1) {
+            return $match['direction'] === 'odchozi';
+        }
+
+        return $amount < 0;
     }
 
 }

--- a/api/tests/Unit/Bank/RaiffeisenbankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/RaiffeisenbankEmailNoticeParserTest.php
@@ -14,6 +14,8 @@ final class RaiffeisenbankEmailNoticeParserTest extends TestCase
     public function testParsesSanitizedNoticeSample(): void
     {
         $text = <<<TEXT
+Vážená klientko, vážený kliente,
+na účtě byla provedena následující příchozí platba:
 Datum a čas
 01. 06. 2026 10:15
 Na účet
@@ -65,6 +67,8 @@ TEXT;
     public function testParsesOutgoingNoticeWithOwnAccountInFromField(): void
     {
         $text = <<<TEXT
+Vážená klientko, vážený kliente,
+na účtě byla provedena následující odchozí platba:
 Datum a čas
 02. 08. 2026 16:07
 Z účtu

--- a/api/tests/Unit/Bank/RaiffeisenbankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/RaiffeisenbankEmailNoticeParserTest.php
@@ -61,4 +61,56 @@ TEXT;
         self::assertSame('Faktura 2606001', $parsed->message);
         self::assertSame(99999.99, $parsed->balance);
     }
+
+    public function testParsesOutgoingNoticeWithOwnAccountInFromField(): void
+    {
+        $text = <<<TEXT
+Datum a čas
+02. 08. 2026 16:07
+Z účtu
+1000000005/5500Firma Test s.r.o.
+Částka v měně účtu
+-1.234,56 CZK
+Typ pohybu
+Odchozí úhrada
+Na účet
+2000000018/0800Příjemce Demo s.r.o.
+Variabilní symbol
+2608001
+Konstantní symbol
+308
+Zpráva pro příjemce
+Faktura 2608001
+Disponibilní zůstatek po pohybu
++98.765,43 CZK
+TEXT;
+
+        $message = new BankEmailNoticeMessage(
+            uid: 2,
+            messageId: '<sanitized-outgoing@rb.cz>',
+            date: new \DateTimeImmutable('2026-08-02 16:07:00'),
+            sender: 'Raiffeisenbank <info@rb.cz>',
+            subject: 'Pohyb na účtě',
+            text: $text,
+            raw: $text,
+        );
+
+        $parser = new RaiffeisenbankEmailNoticeParser();
+        $provider = $parser->defaultProvider();
+        self::assertInstanceOf(BankEmailNoticeProvider::class, $provider);
+
+        $parsed = $parser->parse($message, $provider);
+
+        self::assertSame('2608001', $parsed->variableSymbol);
+        self::assertSame(-1234.56, $parsed->amount);
+        self::assertSame('CZK', $parsed->currency);
+        self::assertSame('2026-08-02', $parsed->postedAt);
+        self::assertSame('1000000005/5500', $parsed->recipientAccount);
+        self::assertSame('2000000018', $parsed->counterpartyAccount);
+        self::assertSame('0800', $parsed->counterpartyBank);
+        self::assertSame('Příjemce Demo s.r.o.', $parsed->counterpartyName);
+        self::assertSame('308', $parsed->constantSymbol);
+        self::assertSame('Faktura 2608001', $parsed->message);
+        self::assertSame(98765.43, $parsed->balance);
+    }
 }

--- a/manual/37_Bankovni_ucty.md
+++ b/manual/37_Bankovni_ucty.md
@@ -9,7 +9,7 @@ a **Bankovní avíza z e-mailu**. Záložky kromě výpisů vidí jen administr�
 Tato kapitola popisuje správu **bankovních účtů dodavatele** (pro PDF faktury,
 QR platby a GPC výpisy) a **bankovních e-mailových avíz přes IMAP**. Bankovní avízo je
 e-mail od banky s údaji o platbě — MyInvoice ho umí pravidelně načítat, vytěžit
-z něj VS, částku, měnu, datum a cílový účet a vytvořit z něj bankovní transakci
+z něj VS, částku, měnu, datum a vlastní účet a vytvořit z něj bankovní transakci
 stejně jako z [výpisu](24_Banka.md).
 
 ## 37.1 Bankovní účty
@@ -108,6 +108,11 @@ upravit, použij u něj tlačítko **Duplikovat** — vytvoří se editovatelná
 ve které si dolaď vzory a otestuj ji přes **Test parseru**. V mapování účtu pak
 přepneš účet z původního providera na svou kopii. Duplikovat lze i vlastní regex
 provider.
+
+Systémový provider Raiffeisenbank rozlišuje směr převodu podle znaménka částky.
+U odchozí úhrady je vlastním účtem pole **Z účtu** a protiúčtem pole **Na účet**;
+u příchozí úhrady je to opačně. Díky tomu se odchozí avízo mapuje na účet, ze
+kterého byla platba skutečně odepsána.
 
 Detekce e-mailu i vytěžení polí pracují **tolerantně k diakritice**: pokud avízo
 dorazí v jiném kódování nebo s rozbitou diakritikou (typicky u přeposlaných

--- a/manual/37_Bankovni_ucty.md
+++ b/manual/37_Bankovni_ucty.md
@@ -109,10 +109,11 @@ ve které si dolaď vzory a otestuj ji přes **Test parseru**. V mapování úč
 přepneš účet z původního providera na svou kopii. Duplikovat lze i vlastní regex
 provider.
 
-Systémový provider Raiffeisenbank rozlišuje směr převodu podle znaménka částky.
-U odchozí úhrady je vlastním účtem pole **Z účtu** a protiúčtem pole **Na účet**;
-u příchozí úhrady je to opačně. Díky tomu se odchozí avízo mapuje na účet, ze
-kterého byla platba skutečně odepsána.
+Systémový provider Raiffeisenbank rozlišuje směr převodu podle úvodního textu
+o příchozí nebo odchozí platbě; u starší či odlišné šablony použije jako záložní
+údaj znaménko částky. U odchozí úhrady je vlastním účtem pole **Z účtu** a
+protiúčtem pole **Na účet**; u příchozí úhrady je to opačně. Díky tomu se odchozí
+avízo mapuje na účet, ze kterého byla platba skutečně odepsána.
 
 Detekce e-mailu i vytěžení polí pracují **tolerantně k diakritice**: pokud avízo
 dorazí v jiném kódování nebo s rozbitou diakritikou (typicky u přeposlaných


### PR DESCRIPTION
## Shrnutí

Opravuje rozpoznání směru platby a přiřazení vlastního účtu a protiúčtu v e-mailových avízech Raiffeisenbank.

## Problém

Parser dosud vždy považoval pole `Na účet` za vlastní účet dodavatele. To platí pro příchozí platby, ale u odchozí úhrady jsou strany opačně:

- vlastní účet je v poli `Z účtu`,
- účet příjemce je v poli `Na účet`.

Odchozí avízo se proto pokoušelo namapovat na účet příjemce a končilo například chybou `match_failed`.

## Řešení

- Směr platby se primárně určuje z úvodního textu avíza:
  - `na účtě byla provedena následující příchozí platba`,
  - `na účtě byla provedena následující odchozí platba`.
- Rozpoznání je tolerantní k chybějící diakritice.
- Znaménko částky slouží jako fallback pro starší nebo odlišnou šablonu.
- U příchozí platby je vlastním účtem `Na účet`.
- U odchozí platby je vlastním účtem `Z účtu`.
- Druhá strana se uloží jako protiúčet včetně kódu banky a názvu protistrany.
- Aktualizován uživatelský manuál.

## Testování

- Doplněn syntetický test odchozího avíza.
- Ověřeno zpracování příchozího i odchozího avíza.
- `RaiffeisenbankEmailNoticeParserTest`: 2 testy, 25 assertions — OK.
- Manuál byl úspěšně regenerován do HTML a PDF.

## Databáze a API

- Bez databázové migrace.
- Bez změny veřejného API.
