### PR TITLE
feat(bank): systémový parser e-mailových avíz Air Bank

### DIFF
--- a/api/src/Infrastructure/Config/Config.php
+++ b/api/src/Infrastructure/Config/Config.php
@@ -240,6 +240,7 @@ final class Config
                     'fio' => \MyInvoice\Service\Bank\EmailNotice\Parser\FioBankEmailNoticeParser::class,
                     'creditas' => \MyInvoice\Service\Bank\EmailNotice\Parser\CreditasBankEmailNoticeParser::class,
                     'moneta' => \MyInvoice\Service\Bank\EmailNotice\Parser\MonetaBankEmailNoticeParser::class,
+                    'airbank' => \MyInvoice\Service\Bank\EmailNotice\Parser\AirBankBankEmailNoticeParser::class,
                 ],
             ],
         ];

--- a/api/src/Service/Bank/EmailNotice/Parser/AirBankBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/AirBankBankEmailNoticeParser.php
@@ -11,10 +11,10 @@ use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
  * Air Bank — avízo „Zvýšení/Snížení zůstatku na účtu …" (info@airbank.cz).
  *
  * Plain-text šablona (ověřeno 2026-07; čísla anonymizována):
- *   zůstatek na účtu Podnikatelský účet CZK číslo 1234567890/3030 se zvýšil o částku 1,00 CZK.
+ *   zůstatek na účtu Podnikatelský účet CZK číslo 1000000005/3030 se zvýšil o částku 1,00 CZK.
  *   Dostupný zůstatek k 24.07.2026 v 15:20 je 1,00 CZK.
  *
- *   Příchozí úhrada z účtu Jméno Protistrany číslo 9876543210/0300
+ *   Příchozí úhrada z účtu Jméno Protistrany číslo 2000145399/0300
  *   Částka: 1,00 CZK
  *   Datum zaúčtování: 24.07.2026
  *   Variabilní symbol: 202600009   (řádek chybí, pokud plátce VS nevyplnil)
@@ -36,7 +36,7 @@ final class AirBankBankEmailNoticeParser extends AbstractBankEmailNoticeParser
         return 'Air Bank';
     }
 
-    public function defaultProvider(): ?BankEmailNoticeProvider
+    public function defaultProvider(): BankEmailNoticeProvider
     {
         return new BankEmailNoticeProvider(
             id: null,
@@ -139,7 +139,9 @@ final class AirBankBankEmailNoticeParser extends AbstractBankEmailNoticeParser
         [$cpAccount, $cpBank] = $this->splitAccount((string) ($counterparty['account'] ?? ''));
         $cpName = isset($counterparty['name']) ? $this->cleanNullable((string) $counterparty['name']) : null;
 
-        $outgoing = preg_match('/se\s+snizil\s+o\s+castku|snizeni\s+zustatku/iu', $folded) === 1;
+        $subject = $this->compact(mb_strtolower($this->foldDiacritics($message->subject), 'UTF-8'));
+        preg_match('/(?<direction>zvyseni|snizeni)\s+zustatku/u', $subject, $directionMatch);
+        $outgoing = ($directionMatch['direction'] ?? '') === 'snizeni';
         $direction = $outgoing ? 'odchozí' : 'příchozí';
 
         return new ParsedBankEmailNotice(

--- a/api/src/Service/Bank/EmailNotice/Parser/AirBankBankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/AirBankBankEmailNoticeParser.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Bank\EmailNotice\Parser;
+
+use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\ParsedBankEmailNotice;
+
+/**
+ * Air Bank — avízo „Zvýšení/Snížení zůstatku na účtu …" (info@airbank.cz).
+ *
+ * Plain-text šablona (ověřeno 2026-07; čísla anonymizována):
+ *   zůstatek na účtu Podnikatelský účet CZK číslo 1234567890/3030 se zvýšil o částku 1,00 CZK.
+ *   Dostupný zůstatek k 24.07.2026 v 15:20 je 1,00 CZK.
+ *
+ *   Příchozí úhrada z účtu Jméno Protistrany číslo 9876543210/0300
+ *   Částka: 1,00 CZK
+ *   Datum zaúčtování: 24.07.2026
+ *   Variabilní symbol: 202600009   (řádek chybí, pokud plátce VS nevyplnil)
+ *   Kód transakce: 100000000001
+ *
+ * Směr nese předmět/tělo (zvýšil = příchozí, snížil = odchozí/záporná částka).
+ * VS je volitelný — avízo bez VS se uloží s prázdným symbolem (párování pak
+ * podle částky + protiúčtu / ručně).
+ */
+final class AirBankBankEmailNoticeParser extends AbstractBankEmailNoticeParser
+{
+    public function key(): string
+    {
+        return 'airbank';
+    }
+
+    protected function parserLabel(): string
+    {
+        return 'Air Bank';
+    }
+
+    public function defaultProvider(): ?BankEmailNoticeProvider
+    {
+        return new BankEmailNoticeProvider(
+            id: null,
+            supplierId: null,
+            providerRef: 'system:' . $this->key(),
+            code: $this->key(),
+            name: 'Air Bank - Zvýšení/Snížení zůstatku',
+            parserType: $this->key(),
+            enabled: true,
+            senderWhitelist: 'info@airbank.cz',
+            subjectPattern: 'Zvýšení\\s+zůstatku|Snížení\\s+zůstatku|Zvyseni\\s+zustatku|Snizeni\\s+zustatku',
+            bodyPattern: 'se\\s+zvýšil\\s+o\\s+částku|se\\s+snížil\\s+o\\s+částku|se\\s+zvysil\\s+o\\s+castku|se\\s+snizil\\s+o\\s+castku',
+            fieldPatterns: [],
+            normalizerConfig: [],
+            system: true,
+        );
+    }
+
+    public function supports(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): bool
+    {
+        if (!$this->senderMatchesDomain($message, 'airbank.cz')) {
+            return false;
+        }
+
+        $subject = $this->compact(mb_strtolower($this->foldDiacritics($message->subject), 'UTF-8'));
+        if (
+            !str_contains($subject, 'zvyseni zustatku')
+            && !str_contains($subject, 'snizeni zustatku')
+        ) {
+            return false;
+        }
+
+        $text = $this->compact(mb_strtolower($this->foldDiacritics($this->normalizeText($message->text)), 'UTF-8'));
+        return (str_contains($text, 'se zvysil o castku') || str_contains($text, 'se snizil o castku'))
+            && (str_contains($text, 'castka:') || str_contains($text, 'cislo '));
+    }
+
+    public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
+    {
+        $text = $this->normalizeText($message->text);
+        $folded = $this->foldDiacritics($text);
+
+        $recipient = $this->required(
+            $folded,
+            '/zustatek\s+na\s+uctu.*?cislo\s+(?<value>[0-9]+\/[0-9]{4})/iu',
+            'cílový účet',
+        );
+
+        $amountCurrency = $this->match(
+            $folded,
+            '/(?:^|\R)\s*Castka:\s*(?<amount>[+\-]?[0-9][0-9 .]*,[0-9]{2})\s*(?<currency>[A-Za-z]{3}|Kc|€)/iu',
+        );
+        if ($amountCurrency === null) {
+            // Fallback: úvodní věta „se zvýšil/snížil o částku X CZK"
+            $amountCurrency = $this->match(
+                $folded,
+                '/se\s+(?:zvysil|snizil)\s+o\s+castku\s+(?<amount>[+\-]?[0-9][0-9 .]*,[0-9]{2})\s*(?<currency>[A-Za-z]{3}|Kc|€)/iu',
+            );
+        }
+        if ($amountCurrency === null) {
+            throw new \RuntimeException($this->parserLabel() . ' parser nenašel částku a měnu.');
+        }
+
+        $postedAt = $this->optional(
+            $folded,
+            '/Datum\s+zauctovani:\s*(?<value>\d{1,2}\.\d{1,2}\.\d{4})/iu',
+        );
+        if ($postedAt === null) {
+            if (!$message->date instanceof \DateTimeImmutable) {
+                throw new \RuntimeException($this->parserLabel() . ' parser nenašel datum.');
+            }
+            $postedAt = $message->date->format('d.m.Y');
+        }
+
+        $variableSymbol = $this->optional($folded, '/Variabilni\s+symbol:\s*(?<value>[0-9]+)/iu');
+        $bankRef = $this->optional($folded, '/Kod\s+transakce:\s*(?<value>[0-9]+)/iu');
+        $balance = $this->optional(
+            $folded,
+            '/Dostupny\s+zustatek.*?je\s+(?<value>[+\-]?[0-9][0-9 .]*,[0-9]{2})/iu',
+        );
+
+        // Protistrana: příchozí „z účtu Jméno číslo A/BBBB", odchozí „na účet … číslo …"
+        $counterparty = $this->match(
+            $text,
+            '/Příchozí\s+úhrada\s+z\s+účtu\s+(?<name>.+?)\s+číslo\s+(?<account>[0-9\-]+\/[0-9]{4})/iu',
+        );
+        if ($counterparty === null) {
+            $counterparty = $this->match(
+                $folded,
+                '/Prichozi\s+uhrada\s+z\s+uctu\s+(?<name>.+?)\s+cislo\s+(?<account>[0-9\-]+\/[0-9]{4})/iu',
+            );
+        }
+        if ($counterparty === null) {
+            $counterparty = $this->match(
+                $folded,
+                '/Odchozi\s+uhrada\s+na\s+ucet\s+(?<name>.+?)\s+cislo\s+(?<account>[0-9\-]+\/[0-9]{4})/iu',
+            );
+        }
+
+        [$cpAccount, $cpBank] = $this->splitAccount((string) ($counterparty['account'] ?? ''));
+        $cpName = isset($counterparty['name']) ? $this->cleanNullable((string) $counterparty['name']) : null;
+
+        $outgoing = preg_match('/se\s+snizil\s+o\s+castku|snizeni\s+zustatku/iu', $folded) === 1;
+        $direction = $outgoing ? 'odchozí' : 'příchozí';
+
+        return new ParsedBankEmailNotice(
+            variableSymbol: $this->normalizeSymbol((string) $variableSymbol),
+            amount: $this->applyDirection($this->parseAmount((string) $amountCurrency['amount']), $direction),
+            currency: $this->normalizeCurrency((string) ($amountCurrency['currency'] ?? 'CZK')),
+            postedAt: $this->parseDate($postedAt),
+            recipientAccount: $this->normalizeAccount($recipient),
+            counterpartyAccount: $cpAccount,
+            counterpartyBank: $cpBank,
+            counterpartyName: $cpName,
+            bankRef: $bankRef,
+            balance: $balance !== null ? $this->parseAmount($balance) : null,
+        );
+    }
+}

--- a/api/tests/Unit/Bank/AirBankBankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/AirBankBankEmailNoticeParserTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Bank;
+
+use MyInvoice\Service\Bank\EmailNotice\BankEmailNoticeMessage;
+use MyInvoice\Service\Bank\EmailNotice\Parser\AirBankBankEmailNoticeParser;
+use MyInvoice\Service\Bank\EmailNotice\Parser\BankEmailNoticeProvider;
+use PHPUnit\Framework\TestCase;
+
+final class AirBankBankEmailNoticeParserTest extends TestCase
+{
+    public function testParsesIncomingNoticeWithVariableSymbol(): void
+    {
+        $body = <<<TEXT
+Dobrý den,
+
+zůstatek na účtu Podnikatelský účet CZK číslo 1234567890/3030 se zvýšil o částku 1,00 CZK. Dostupný zůstatek k 24.07.2026 v 15:20 je 2,00 CZK.
+
+Pro úplnost uvádíme detaily této úhrady:
+
+Příchozí úhrada z účtu Firma Demo s.r.o. číslo 9876543210/0300
+Částka: 1,00 CZK
+Datum zaúčtování: 24.07.2026
+Variabilní symbol: 202600009
+Kód transakce: 100000000001
+
+
+Nechceme, aby Vás naše upozornění jakkoliv obtěžovala.
+TEXT;
+
+        $parser = new AirBankBankEmailNoticeParser();
+        $message = $this->message($body, 'Zvýšení zůstatku na účtu Podnikatelský účet CZK');
+        $provider = $this->provider($parser);
+
+        self::assertTrue($parser->supports($message, $provider));
+
+        $parsed = $parser->parse($message, $provider);
+
+        self::assertSame('202600009', $parsed->variableSymbol);
+        self::assertSame(1.0, $parsed->amount);
+        self::assertSame('CZK', $parsed->currency);
+        self::assertSame('2026-07-24', $parsed->postedAt);
+        self::assertSame('1234567890/3030', $parsed->recipientAccount);
+        self::assertSame('9876543210', $parsed->counterpartyAccount);
+        self::assertSame('0300', $parsed->counterpartyBank);
+        self::assertSame('Firma Demo s.r.o.', $parsed->counterpartyName);
+        self::assertSame('100000000001', $parsed->bankRef);
+        self::assertSame(2.0, $parsed->balance);
+    }
+
+    public function testParsesIncomingNoticeWithoutVariableSymbol(): void
+    {
+        $body = <<<TEXT
+zůstatek na účtu Podnikatelský účet CZK číslo 1234567890/3030 se zvýšil o částku 1,00 CZK. Dostupný zůstatek k 24.07.2026 v 15:20 je 1,00 CZK.
+
+Příchozí úhrada z účtu Jan Novák číslo 9876543210/0300
+Částka: 1,00 CZK
+Datum zaúčtování: 24.07.2026
+Kód transakce: 100000000002
+TEXT;
+
+        $parser = new AirBankBankEmailNoticeParser();
+        $parsed = $parser->parse(
+            $this->message($body, 'Zvýšení zůstatku na účtu Podnikatelský účet CZK'),
+            $this->provider($parser),
+        );
+
+        self::assertSame('', $parsed->variableSymbol);
+        self::assertSame(1.0, $parsed->amount);
+        self::assertSame('1234567890/3030', $parsed->recipientAccount);
+        self::assertSame('100000000002', $parsed->bankRef);
+    }
+
+    public function testParsesEurIncomingNotice(): void
+    {
+        $body = <<<TEXT
+zůstatek na účtu Podnikatelský účet EUR číslo 1234567891/3030 se zvýšil o částku 12,50 EUR. Dostupný zůstatek k 01.08.2026 v 10:00 je 100,00 EUR.
+
+Příchozí úhrada z účtu Client Demo číslo 1111222233/0100
+Částka: 12,50 EUR
+Datum zaúčtování: 01.08.2026
+Variabilní symbol: 2608001
+Kód transakce: 100000000003
+TEXT;
+
+        $parser = new AirBankBankEmailNoticeParser();
+        $parsed = $parser->parse(
+            $this->message($body, 'Zvýšení zůstatku na účtu Podnikatelský účet EUR'),
+            $this->provider($parser),
+        );
+
+        self::assertSame('2608001', $parsed->variableSymbol);
+        self::assertSame(12.5, $parsed->amount);
+        self::assertSame('EUR', $parsed->currency);
+        self::assertSame('1234567891/3030', $parsed->recipientAccount);
+    }
+
+    public function testParsesOutgoingNoticeAsNegativeAmount(): void
+    {
+        $body = <<<TEXT
+zůstatek na účtu Podnikatelský účet CZK číslo 1234567890/3030 se snížil o částku 500,00 CZK. Dostupný zůstatek k 02.08.2026 v 09:00 je 9 500,00 CZK.
+
+Odchozí úhrada na účet Dodavatel Demo číslo 19-2000145399/0800
+Částka: 500,00 CZK
+Datum zaúčtování: 02.08.2026
+Variabilní symbol: 2026001
+Kód transakce: 100000000004
+TEXT;
+
+        $parser = new AirBankBankEmailNoticeParser();
+        $message = $this->message($body, 'Snížení zůstatku na účtu Podnikatelský účet CZK');
+        $provider = $this->provider($parser);
+
+        self::assertTrue($parser->supports($message, $provider));
+
+        $parsed = $parser->parse($message, $provider);
+
+        self::assertSame('2026001', $parsed->variableSymbol);
+        self::assertSame(-500.0, $parsed->amount);
+        self::assertSame('CZK', $parsed->currency);
+        self::assertSame('1234567890/3030', $parsed->recipientAccount);
+        self::assertSame('19-2000145399', $parsed->counterpartyAccount);
+        self::assertSame('0800', $parsed->counterpartyBank);
+    }
+
+    public function testSupportsDiacriticFoldedSubjectAndBody(): void
+    {
+        $body = <<<TEXT
+zustatek na uctu Podnikatelsky ucet CZK cislo 1234567890/3030 se zvysil o castku 1,00 CZK.
+Castka: 1,00 CZK
+Datum zauctovani: 24.07.2026
+Variabilni symbol: 1
+TEXT;
+
+        $parser = new AirBankBankEmailNoticeParser();
+        $message = $this->message($body, 'Zvyseni zustatku na uctu Podnikatelsky ucet CZK');
+        self::assertTrue($parser->supports($message, $this->provider($parser)));
+    }
+
+    public function testRejectsSpoofedSenderDomain(): void
+    {
+        $parser = new AirBankBankEmailNoticeParser();
+        $message = new BankEmailNoticeMessage(
+            uid: 1,
+            messageId: '<spoof@evil.com>',
+            date: new \DateTimeImmutable('2026-07-24 15:21:00'),
+            sender: 'Air Bank <attacker@airbank.cz.evil.com>',
+            subject: 'Zvýšení zůstatku na účtu',
+            text: "zůstatek na účtu číslo 1/3030 se zvýšil o částku 1,00 CZK.\nČástka: 1,00 CZK",
+            raw: '',
+        );
+        self::assertFalse($parser->supports($message, $this->provider($parser)));
+    }
+
+    public function testThrowsWithoutAmount(): void
+    {
+        $body = "zůstatek na účtu číslo 1234567890/3030 se zvýšil.\nDatum zaúčtování: 24.07.2026";
+        $parser = new AirBankBankEmailNoticeParser();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('částku');
+        $parser->parse(
+            $this->message($body, 'Zvýšení zůstatku na účtu'),
+            $this->provider($parser),
+        );
+    }
+
+    private function message(string $body, string $subject): BankEmailNoticeMessage
+    {
+        return new BankEmailNoticeMessage(
+            uid: 1,
+            messageId: '<sanitized-sample@airbank.cz>',
+            date: new \DateTimeImmutable('2026-07-24 15:21:00'),
+            sender: 'info@airbank.cz',
+            subject: $subject,
+            text: $body,
+            raw: $body,
+        );
+    }
+
+    private function provider(AirBankBankEmailNoticeParser $parser): BankEmailNoticeProvider
+    {
+        $provider = $parser->defaultProvider();
+        self::assertInstanceOf(BankEmailNoticeProvider::class, $provider);
+        return $provider;
+    }
+}

--- a/api/tests/Unit/Bank/AirBankBankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/AirBankBankEmailNoticeParserTest.php
@@ -16,11 +16,11 @@ final class AirBankBankEmailNoticeParserTest extends TestCase
         $body = <<<TEXT
 Dobrý den,
 
-zůstatek na účtu Podnikatelský účet CZK číslo 1234567890/3030 se zvýšil o částku 1,00 CZK. Dostupný zůstatek k 24.07.2026 v 15:20 je 2,00 CZK.
+zůstatek na účtu Podnikatelský účet CZK číslo 1000000005/3030 se zvýšil o částku 1,00 CZK. Dostupný zůstatek k 24.07.2026 v 15:20 je 2,00 CZK.
 
 Pro úplnost uvádíme detaily této úhrady:
 
-Příchozí úhrada z účtu Firma Demo s.r.o. číslo 9876543210/0300
+Příchozí úhrada z účtu Firma Demo s.r.o. číslo 2000145399/0300
 Částka: 1,00 CZK
 Datum zaúčtování: 24.07.2026
 Variabilní symbol: 202600009
@@ -42,8 +42,8 @@ TEXT;
         self::assertSame(1.0, $parsed->amount);
         self::assertSame('CZK', $parsed->currency);
         self::assertSame('2026-07-24', $parsed->postedAt);
-        self::assertSame('1234567890/3030', $parsed->recipientAccount);
-        self::assertSame('9876543210', $parsed->counterpartyAccount);
+        self::assertSame('1000000005/3030', $parsed->recipientAccount);
+        self::assertSame('2000145399', $parsed->counterpartyAccount);
         self::assertSame('0300', $parsed->counterpartyBank);
         self::assertSame('Firma Demo s.r.o.', $parsed->counterpartyName);
         self::assertSame('100000000001', $parsed->bankRef);
@@ -53,9 +53,9 @@ TEXT;
     public function testParsesIncomingNoticeWithoutVariableSymbol(): void
     {
         $body = <<<TEXT
-zůstatek na účtu Podnikatelský účet CZK číslo 1234567890/3030 se zvýšil o částku 1,00 CZK. Dostupný zůstatek k 24.07.2026 v 15:20 je 1,00 CZK.
+zůstatek na účtu Podnikatelský účet CZK číslo 1000000005/3030 se zvýšil o částku 1,00 CZK. Dostupný zůstatek k 24.07.2026 v 15:20 je 1,00 CZK.
 
-Příchozí úhrada z účtu Jan Novák číslo 9876543210/0300
+Příchozí úhrada z účtu Jan Novák číslo 2000145399/0300
 Částka: 1,00 CZK
 Datum zaúčtování: 24.07.2026
 Kód transakce: 100000000002
@@ -69,14 +69,14 @@ TEXT;
 
         self::assertSame('', $parsed->variableSymbol);
         self::assertSame(1.0, $parsed->amount);
-        self::assertSame('1234567890/3030', $parsed->recipientAccount);
+        self::assertSame('1000000005/3030', $parsed->recipientAccount);
         self::assertSame('100000000002', $parsed->bankRef);
     }
 
     public function testParsesEurIncomingNotice(): void
     {
         $body = <<<TEXT
-zůstatek na účtu Podnikatelský účet EUR číslo 1234567891/3030 se zvýšil o částku 12,50 EUR. Dostupný zůstatek k 01.08.2026 v 10:00 je 100,00 EUR.
+zůstatek na účtu Podnikatelský účet EUR číslo 2000145399/3030 se zvýšil o částku 12,50 EUR. Dostupný zůstatek k 01.08.2026 v 10:00 je 100,00 EUR.
 
 Příchozí úhrada z účtu Client Demo číslo 1111222233/0100
 Částka: 12,50 EUR
@@ -94,13 +94,13 @@ TEXT;
         self::assertSame('2608001', $parsed->variableSymbol);
         self::assertSame(12.5, $parsed->amount);
         self::assertSame('EUR', $parsed->currency);
-        self::assertSame('1234567891/3030', $parsed->recipientAccount);
+        self::assertSame('2000145399/3030', $parsed->recipientAccount);
     }
 
     public function testParsesOutgoingNoticeAsNegativeAmount(): void
     {
         $body = <<<TEXT
-zůstatek na účtu Podnikatelský účet CZK číslo 1234567890/3030 se snížil o částku 500,00 CZK. Dostupný zůstatek k 02.08.2026 v 09:00 je 9 500,00 CZK.
+zůstatek na účtu Podnikatelský účet CZK číslo 1000000005/3030 se snížil o částku 500,00 CZK. Dostupný zůstatek k 02.08.2026 v 09:00 je 9 500,00 CZK.
 
 Odchozí úhrada na účet Dodavatel Demo číslo 19-2000145399/0800
 Částka: 500,00 CZK
@@ -120,7 +120,7 @@ TEXT;
         self::assertSame('2026001', $parsed->variableSymbol);
         self::assertSame(-500.0, $parsed->amount);
         self::assertSame('CZK', $parsed->currency);
-        self::assertSame('1234567890/3030', $parsed->recipientAccount);
+        self::assertSame('1000000005/3030', $parsed->recipientAccount);
         self::assertSame('19-2000145399', $parsed->counterpartyAccount);
         self::assertSame('0800', $parsed->counterpartyBank);
     }
@@ -128,7 +128,7 @@ TEXT;
     public function testSupportsDiacriticFoldedSubjectAndBody(): void
     {
         $body = <<<TEXT
-zustatek na uctu Podnikatelsky ucet CZK cislo 1234567890/3030 se zvysil o castku 1,00 CZK.
+zustatek na uctu Podnikatelsky ucet CZK cislo 1000000005/3030 se zvysil o castku 1,00 CZK.
 Castka: 1,00 CZK
 Datum zauctovani: 24.07.2026
 Variabilni symbol: 1
@@ -137,6 +137,31 @@ TEXT;
         $parser = new AirBankBankEmailNoticeParser();
         $message = $this->message($body, 'Zvyseni zustatku na uctu Podnikatelsky ucet CZK');
         self::assertTrue($parser->supports($message, $this->provider($parser)));
+    }
+
+    public function testUsesSubjectDirectionWhenBodyQuotesOppositeNotice(): void
+    {
+        $body = <<<TEXT
+zůstatek na účtu Podnikatelský účet CZK číslo 1000000005/3030 se zvýšil o částku 1,00 CZK.
+Příchozí úhrada z účtu Firma Demo s.r.o. číslo 2000145399/0300
+Částka: 1,00 CZK
+Datum zaúčtování: 24.07.2026
+Kód transakce: 100000000005
+
+----- Původní zpráva -----
+zůstatek na účtu Podnikatelský účet CZK číslo 1000000005/3030 se snížil o částku 50,00 CZK.
+Odchozí úhrada na účet Dodavatel Demo číslo 19-2000145399/0800
+Částka: 50,00 CZK
+Datum zaúčtování: 23.07.2026
+Kód transakce: 100000000000
+TEXT;
+
+        $parser = new AirBankBankEmailNoticeParser();
+        $message = $this->message($body, 'FW: Zvýšení zůstatku na účtu Podnikatelský účet CZK');
+        $provider = $this->provider($parser);
+
+        self::assertTrue($parser->supports($message, $provider));
+        self::assertSame(1.0, $parser->parse($message, $provider)->amount);
     }
 
     public function testRejectsSpoofedSenderDomain(): void
@@ -148,7 +173,7 @@ TEXT;
             date: new \DateTimeImmutable('2026-07-24 15:21:00'),
             sender: 'Air Bank <attacker@airbank.cz.evil.com>',
             subject: 'Zvýšení zůstatku na účtu',
-            text: "zůstatek na účtu číslo 1/3030 se zvýšil o částku 1,00 CZK.\nČástka: 1,00 CZK",
+            text: "zůstatek na účtu číslo 1000000005/3030 se zvýšil o částku 1,00 CZK.\nČástka: 1,00 CZK",
             raw: '',
         );
         self::assertFalse($parser->supports($message, $this->provider($parser)));
@@ -156,7 +181,7 @@ TEXT;
 
     public function testThrowsWithoutAmount(): void
     {
-        $body = "zůstatek na účtu číslo 1234567890/3030 se zvýšil.\nDatum zaúčtování: 24.07.2026";
+        $body = "zůstatek na účtu číslo 1000000005/3030 se zvýšil.\nDatum zaúčtování: 24.07.2026";
         $parser = new AirBankBankEmailNoticeParser();
 
         $this->expectException(\RuntimeException::class);

--- a/manual/37_Bankovni_ucty.md
+++ b/manual/37_Bankovni_ucty.md
@@ -100,7 +100,7 @@ Provider říká, jak poznat e-mail dané banky a jak z něj vytěžit platební
 
 Typy providerů:
 
-- **Systémový provider** — dodaný aplikací, např. Raiffeisenbank, UniCredit Bank, ČSOB, Česká spořitelna, Fio banka, Banka CREDITAS nebo MONETA Money Bank.
+- **Systémový provider** — dodaný aplikací, např. Raiffeisenbank, UniCredit Bank, ČSOB, Česká spořitelna, Fio banka, Banka CREDITAS, MONETA Money Bank nebo Air Bank.
 - **Regex provider** — vlastní provider dodavatele, konfigurovaný v UI.
 
 Systémový provider se přímo needituje (je společný pro všechny). Když ho chceš
@@ -114,6 +114,13 @@ o příchozí nebo odchozí platbě; u starší či odlišné šablony použije 
 údaj znaménko částky. U odchozí úhrady je vlastním účtem pole **Z účtu** a
 protiúčtem pole **Na účet**; u příchozí úhrady je to opačně. Díky tomu se odchozí
 avízo mapuje na účet, ze kterého byla platba skutečně odepsána.
+
+U Air Bank se avíza zapínají v internetovém bankovnictví pod **Účty a karty →
+Možnosti → Info o dění na účtu** (odesílatel `info@airbank.cz`, předměty
+„Zvýšení/Snížení zůstatku“). Nastavení v IB není úplně intuitivní — praktický
+postup je např. v návodu FAPI
+[Nastavení zasílání e-mailů o příchozích platbách z Air Bank](https://napoveda.fapi.cz/article/40-nastaveni-zasilani-e-mailu-o-prichozich-platbach-z-air-bank)
+(místo FAPI adresy uveď mailbox napojený v MyInvoice).
 
 Detekce e-mailu i vytěžení polí pracují **tolerantně k diakritice**: pokud avízo
 dorazí v jiném kódování nebo s rozbitou diakritikou (typicky u přeposlaných

--- a/web/src/pages/admin/BankAccounts.vue
+++ b/web/src/pages/admin/BankAccounts.vue
@@ -552,6 +552,7 @@ function parserTypeLabel(parserType: BankEmailProvider['parser_type']): string {
     case 'fio': return 'Fio banka'
     case 'creditas': return 'Creditas'
     case 'moneta': return 'MONETA Money Bank'
+    case 'airbank': return 'Air Bank'
     default: return t('bank_accounts.parser_builtin')
   }
 }


### PR DESCRIPTION
## Summary
- Systémový parser avíz Air Bank (`Zvýšení` / `Snížení zůstatku`), odesílatel `info@airbank.cz`.
- Vytěží cílový účet z úvodní věty (`zůstatek na účtu … číslo N/BBBB`), částku/měnu, datum zaúčtování, volitelný VS, kód transakce, protiúčet a disponibilní zůstatek.
- Registrace parseru v configu, label ve FE a zmínka v manuálu.
- Manuál odkazuje na postup zapnutí avíz v Air Bank IB ([Nastavení zasílání e-mailů o příchozích platbách z Air Bank](https://napoveda.fapi.cz/article/40-nastaveni-zasilani-e-mailu-o-prichozich-platbach-z-air-bank)) — místo FAPI adresy použij mailbox napojený v MyInvoice.

## Test plan
- [ ] `cd api && php vendor/bin/phpunit --filter AirBankBankEmailNoticeParserTest`
- [ ] V UI: Bankovní účty → mapování Air Bank účtu na systémový provider Air Bank
- [ ] Test parseru / IMAP scan s avízem „Zvýšení zůstatku“ (se VS i bez) → transakce bez `match_failed` na účet


Made with [Cursor](https://cursor.com)