### PR TITLE
fix(import): stahuj přílohy přijatých faktur z Fakturoid pole attachments[]

### DIFF
--- a/api/src/Service/Import/FakturoidExpenseAttachment.php
+++ b/api/src/Service/Import/FakturoidExpenseAttachment.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Service\Import;
+
+/**
+ * Vytažení první přílohy (originálního dokladu dodavatele) z Fakturoid expense
+ * JSON — issue #261: import přijatých faktur četl skalární pole `attachment`,
+ * které Fakturoid API v3 nevrací, takže se přílohy nikdy nestáhly.
+ *
+ * Fakturoid API v3 vrací přílohy v poli `attachments` (seznam objektů, každý
+ * s `download_url` a `filename`). Bereme první — výdaj má typicky jeden doklad.
+ */
+final class FakturoidExpenseAttachment
+{
+    /**
+     * @param array<string,mixed> $exp Fakturoid expense JSON
+     * @return ?array{download_url:string, filename:string}  null = výdaj bez přílohy
+     */
+    public static function resolve(array $exp): ?array
+    {
+        $att = ($exp['attachments'] ?? [])[0] ?? null;
+        if (!is_array($att)) {
+            return null;
+        }
+        $url = (string) ($att['download_url'] ?? '');
+        if ($url === '') {
+            return null;
+        }
+        // Fakturoid posílá `filename`; `file_name` je defenzivní fallback.
+        $name = (string) ($att['filename'] ?? $att['file_name'] ?? '');
+        if ($name === '') {
+            $name = ((string) ($exp['number'] ?? 'expense')) . '.pdf';
+        }
+
+        return ['download_url' => $url, 'filename' => $name];
+    }
+}

--- a/api/src/Service/Import/FakturoidImportService.php
+++ b/api/src/Service/Import/FakturoidImportService.php
@@ -607,15 +607,16 @@ final class FakturoidImportService
     }
 
     /**
-     * Stáhne přílohu výdaje (originální doklad od dodavatele) z Fakturoid `attachment`
-     * URL a uloží jako PDF přijaté faktury. Symetrické k iDokladu.
+     * Stáhne přílohu výdaje (originální doklad od dodavatele) z Fakturoid a uloží
+     * jako PDF přijaté faktury. Symetrické k iDokladu. Viz issue #261 —
+     * Fakturoid vrací přílohy v poli `attachments`, ne ve skalárním `attachment`.
      */
     private function archiveExpensePdf(int $supplierId, int $purchaseInvoiceId, array $exp): void
     {
-        $url = (string) ($exp['attachment'] ?? '');
-        if ($url === '') return; // výdaj bez přílohy
+        $attachment = FakturoidExpenseAttachment::resolve($exp);
+        if ($attachment === null) return; // výdaj bez přílohy
 
-        $pdf = $this->fakturoid->downloadAttachment($supplierId, $url);
+        $pdf = $this->fakturoid->downloadAttachment($supplierId, $attachment['download_url']);
         if ($pdf === null) return;
 
         $archiveRoot = (string) $this->config->get('purchase_invoice.archive_storage', '');
@@ -630,8 +631,7 @@ final class FakturoidImportService
         if (!is_file($diskPath)) @file_put_contents($diskPath, $pdf);
 
         $relPath = \MyInvoice\Service\Import\PurchaseInvoicePdfArchiver::shardedRelPath($supplierId, $sha);
-        $name = ((string) ($exp['number'] ?? 'expense')) . '.pdf';
-        $this->purchaseRepo->setPdfMetadata($purchaseInvoiceId, $supplierId, $relPath, $sha, strlen($pdf), $name);
+        $this->purchaseRepo->setPdfMetadata($purchaseInvoiceId, $supplierId, $relPath, $sha, strlen($pdf), $attachment['filename']);
     }
 
     private function loadBookmark(int $supplierId): ?string

--- a/api/tests/Unit/Service/Import/FakturoidExpenseAttachmentTest.php
+++ b/api/tests/Unit/Service/Import/FakturoidExpenseAttachmentTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Import;
+
+use MyInvoice\Service\Import\FakturoidExpenseAttachment;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #261 — import přijatých faktur z Fakturoidu četl skalární pole
+ * `attachment`, které API v3 nevrací (přílohy jsou v `attachments[]`), takže se
+ * originální doklady dodavatelů nikdy nestáhly.
+ */
+final class FakturoidExpenseAttachmentTest extends TestCase
+{
+    public function testResolvesUrlAndFilenameFromAttachments(): void
+    {
+        $att = FakturoidExpenseAttachment::resolve([
+            'number'      => 'N2026-001',
+            'attachments' => [
+                ['download_url' => 'https://app.fakturoid.cz/download/1', 'filename' => 'doklad.pdf'],
+            ],
+        ]);
+        self::assertSame(
+            ['download_url' => 'https://app.fakturoid.cz/download/1', 'filename' => 'doklad.pdf'],
+            $att,
+        );
+    }
+
+    /** Bere první přílohu — výdaj má typicky jeden originální doklad. */
+    public function testTakesFirstAttachment(): void
+    {
+        $att = FakturoidExpenseAttachment::resolve([
+            'attachments' => [
+                ['download_url' => 'https://app.fakturoid.cz/download/first', 'filename' => 'a.pdf'],
+                ['download_url' => 'https://app.fakturoid.cz/download/second', 'filename' => 'b.pdf'],
+            ],
+        ]);
+        self::assertSame('https://app.fakturoid.cz/download/first', $att['download_url']);
+        self::assertSame('a.pdf', $att['filename']);
+    }
+
+    /** Chybí-li `filename`, název se odvodí z čísla dokladu. */
+    public function testFilenameFallsBackToExpenseNumber(): void
+    {
+        $att = FakturoidExpenseAttachment::resolve([
+            'number'      => 'N2026-007',
+            'attachments' => [['download_url' => 'https://app.fakturoid.cz/download/7']],
+        ]);
+        self::assertSame('N2026-007.pdf', $att['filename']);
+    }
+
+    /** Bez čísla i názvu padá na neutrální `expense.pdf`. */
+    public function testFilenameFallsBackToExpensePdf(): void
+    {
+        $att = FakturoidExpenseAttachment::resolve([
+            'attachments' => [['download_url' => 'https://app.fakturoid.cz/download/x']],
+        ]);
+        self::assertSame('expense.pdf', $att['filename']);
+    }
+
+    /** Výdaj bez příloh → null (žádné PDF ke stažení). */
+    public function testNoAttachmentsReturnsNull(): void
+    {
+        self::assertNull(FakturoidExpenseAttachment::resolve([]));
+        self::assertNull(FakturoidExpenseAttachment::resolve(['attachments' => []]));
+    }
+
+    /** Prázdná/chybějící `download_url` → null. */
+    public function testMissingDownloadUrlReturnsNull(): void
+    {
+        self::assertNull(FakturoidExpenseAttachment::resolve([
+            'attachments' => [['filename' => 'doklad.pdf']],
+        ]));
+        self::assertNull(FakturoidExpenseAttachment::resolve([
+            'attachments' => [['download_url' => '', 'filename' => 'doklad.pdf']],
+        ]));
+    }
+
+    /** Regrese #261: skalární `attachment` (které Fakturoid neposílá) se ignoruje. */
+    public function testScalarAttachmentFieldIsIgnored(): void
+    {
+        self::assertNull(FakturoidExpenseAttachment::resolve([
+            'attachment' => 'https://app.fakturoid.cz/download/legacy',
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary
- `FakturoidImportService::archiveExpensePdf()` četl skalární pole `attachment`, které Fakturoid API v3 u expense **nevrací** — přílohy přijatých faktur (originální doklady dodavatelů) se proto nikdy nestáhly. Chyba byla tichá: `failed_count` zůstal 0 a v logu importu nic nebylo.
- Přílohy se nově čtou z pole `attachments[]` (`download_url` + `filename`), symetricky k vydaným fakturám i k iDokladu.
- Vytažení první přílohy je v čisté statické třídě `FakturoidExpenseAttachment` (obdoba `ImportedPaymentStateMapper`), pokryté unit testem (přítomnost `attachments[]`, výběr první přílohy, fallback názvu, prázdný/chybějící seznam, ignorování skalárního `attachment`).

Closes #261.

## Test plan
- [ ] `cd api && php vendor/bin/phpunit --filter FakturoidExpenseAttachmentTest`
- [ ] V UI: Systém → Externí integrace → Fakturoid → import se zapnutým stahováním příloh na účtu, kde mají přijaté faktury přiložené PDF → `purchase_invoices.pdf_path` je vyplněné a soubory jsou v `storage/purchase-invoices/`.
- Ověřeno proti reálnému Fakturoid účtu: před opravou 0 stažených příloh přijatých faktur, po opravě staženy všechny.
