### PR TITLE
fix(rbac): povolit účetním správu pravidelné fakturace

### DIFF
--- a/api/src/Middleware/RoleMiddleware.php
+++ b/api/src/Middleware/RoleMiddleware.php
@@ -84,6 +84,7 @@ final class RoleMiddleware implements MiddlewareInterface
         '* #^/api/clients(/|$)#',
         '* #^/api/projects(/|$)#',
         '* #^/api/invoices(/|$)#',
+        '* #^/api/recurring(/|$)#',
         // Přijaté faktury — účetní smí plnou CRUD (vč. items, PDF, transition,
         // payment-qr, link-advance). Bez tohoto pravidla padaly všechny non-GET
         // na purchase-invoices do admin-only fallbacku (funkční mezera).

--- a/api/tests/Unit/Middleware/RoleMiddlewareTest.php
+++ b/api/tests/Unit/Middleware/RoleMiddlewareTest.php
@@ -257,6 +257,42 @@ final class RoleMiddlewareTest extends TestCase
         self::assertSame(403, $response->getStatusCode());
     }
 
+    public function testAccountantCanMutateRecurringTemplates(): void
+    {
+        foreach ([
+            ['POST', '/api/recurring'],
+            ['PUT', '/api/recurring/5'],
+            ['DELETE', '/api/recurring/5'],
+            ['POST', '/api/recurring/5/pause'],
+            ['POST', '/api/recurring/5/resume'],
+            ['POST', '/api/recurring/5/run-now'],
+        ] as [$method, $path]) {
+            $response = $this->middleware()->process(
+                $this->request($method, $path, 'accountant'),
+                $this->okHandler(),
+            );
+            self::assertSame(204, $response->getStatusCode(), "accountant $method $path");
+        }
+    }
+
+    public function testReadonlyCannotMutateRecurringTemplates(): void
+    {
+        foreach ([
+            ['POST', '/api/recurring'],
+            ['PUT', '/api/recurring/5'],
+            ['DELETE', '/api/recurring/5'],
+            ['POST', '/api/recurring/5/pause'],
+            ['POST', '/api/recurring/5/resume'],
+            ['POST', '/api/recurring/5/run-now'],
+        ] as [$method, $path]) {
+            $response = $this->middleware()->process(
+                $this->request($method, $path, 'readonly'),
+                $this->okHandler(),
+            );
+            self::assertSame(403, $response->getStatusCode(), "readonly $method $path");
+        }
+    }
+
     public function testAccountantCanReadImportJobStatusAndSigningSettings(): void
     {
         foreach (['/api/admin/imports/42', '/api/settings/signing'] as $path) {
@@ -277,7 +313,7 @@ final class RoleMiddlewareTest extends TestCase
     private function middleware(): RoleMiddleware
     {
         // Bez membershipu = žádný per-supplier override (BC větev resolveru).
-        $resolver = $this->createMock(\MyInvoice\Service\Tenant\SupplierAccessResolver::class);
+        $resolver = $this->createStub(\MyInvoice\Service\Tenant\SupplierAccessResolver::class);
         $resolver->method('resolve')->willReturn(
             new \MyInvoice\Service\Tenant\SupplierAccess(0, false, null),
         );


### PR DESCRIPTION
## Shrnutí

Opravuje RBAC pravidla pro pravidelnou fakturaci. Uživatel s rolí `accountant` mohl otevřít formulář, ale backend všechny zápisové operace nad `/api/recurring` odmítal chybou `403 forbidden`.

## Příčina

`RoleMiddleware` povoloval roli `accountant` pouze čtení pravidelných fakturací přes `READONLY_RULES`. Odpovídající zápisové pravidlo v `ACCOUNTANT_RULES` chybělo, přestože frontend i dokumentace správu pravidelných fakturací této roli povolují.

## Změny

- povolena role `accountant` pro zápisové operace nad `/api/recurring`
- přidány regresní testy pro:
  - vytvoření šablony
  - úpravu a smazání
  - pozastavení a obnovení
  - ruční spuštění
- ověřeno, že role `readonly` zůstává pro všechny uvedené operace blokovaná
- testovací resolver změněn z mocku bez očekávání na stub, aby PHPUnit 13 nevypisoval notices

## Ověření

```bash
cd api
php -l src/Middleware/RoleMiddleware.php
php -l tests/Unit/Middleware/RoleMiddlewareTest.php
php vendor/bin/phpunit tests/Unit/Middleware tests/Unit/Security/SecurityHardening202606Test.php
```

Výsledek: 76 testů, 437 assertions — vše prošlo.

## Dopad

- accountant nově může pravidelné fakturace vytvářet a spravovat
- oprávnění rolí admin a readonly se nemění
- bez databázové migrace
- bez změny OpenAPI kontraktu
 - bez změny frontendu
