### PR TITLE
fix(bank): vyrovnat úplnou cizoměnovou úhradu

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2231,11 +2231,14 @@ paths:
         schema: { type: integer, format: int64 }
     post:
       tags: [Bank]
-      summary: Ručně přiřadí transakci k faktuře (a označí ji paid)
+      summary: Ručně přiřadí transakci k faktuře a zaeviduje úhradu
       description: |
         Použij když automatický matching nezachytil platbu (variabilní symbol
-        chybí nebo neodpovídá). Označí transakci jako `matched`, fakturu jako
-        `paid` s `paid_at = transaction.posted_at`.
+        chybí nebo neodpovídá). Zaeviduje platbu v měně faktury; plné pokrytí
+        ji označí jako `paid` s `paid_at = transaction.posted_at`, nižší platba
+        zůstane částečnou úhradou. U CZK platby cizoměnové faktury odpovídající
+        celému zbytku se v platbě uloží celý zbytek v měně faktury; přesná CZK
+        částka zůstává na bankovní transakci.
       requestBody:
         required: true
         content:
@@ -7099,7 +7102,7 @@ components:
         id: { type: integer, format: int64 }
         invoice_id: { type: integer, format: int64 }
         paid_on: { type: string, format: date }
-        amount: { type: number, format: float, description: "Částka v měně faktury (> 0)" }
+        amount: { type: number, format: float, description: "Částka v měně faktury (> 0). U úplné FX úhrady jde o vypořádaný zbytek faktury; skutečnou částku a měnu bankovního pohybu nese navázaná BankTransaction." }
         currency: { type: string, example: CZK, description: "Denormalizovaný kód měny faktury v okamžiku platby" }
         variable_symbol: { type: [string, "null"] }
         bank_reference: { type: [string, "null"] }

--- a/api/src/Action/Bank/BankStatementAction.php
+++ b/api/src/Action/Bank/BankStatementAction.php
@@ -1523,7 +1523,7 @@ final class BankStatementAction
                 $tol = $absTol;
             } elseif ($txCcy === $local) {
                 // Cizoměnová faktura placená v CZK → přepočet kurzem faktury (CZK = částka × kurz).
-                $expected = $invMag * $rate;
+                $expected = round($invMag * $rate, 2);
                 $tol = max($absTol, $expected * $pct);
                 $converted = $expected;
             } elseif ($allowRawAmountFallback) {
@@ -1827,7 +1827,7 @@ final class BankStatementAction
         // Cizoměnová faktura placená v CZK → přepočet kurzem faktury. Bez platného kurzu
         // NEpřevádíme (žádný tichý fallback 1:1 — to by vyrobilo nesmyslnou částku platby).
         if ($txCcy === 'CZK' && $rate > 0) {
-            return $remaining * $rate;
+            return round($remaining * $rate, 2);
         }
         return null;
     }
@@ -2045,12 +2045,23 @@ final class BankStatementAction
             $partialPayment = false;
             if (in_array($invoice['status'], ['issued', 'sent', 'reminded'], true)) {
                 $remaining = round((float) ($invoice['amount_to_pay'] ?? 0) - (float) ($invoice['paid_total'] ?? 0), 2);
+                $txAmount = (float) ($txRow['amount'] ?? 0);
+                $txCurrency = isset($txRow['tx_currency']) && $txRow['tx_currency'] !== null
+                    ? (string) $txRow['tx_currency']
+                    : null;
                 $invAmount = $this->txAmountInInvoiceCurrency(
-                    (float) ($txRow['amount'] ?? 0),
+                    $txAmount,
                     (string) ($invoice['currency'] ?? 'CZK'),
                     (float) ($invoice['exchange_rate'] ?? 0),
-                    isset($txRow['tx_currency']) && $txRow['tx_currency'] !== null ? (string) $txRow['tx_currency'] : null,
+                    $txCurrency,
                     $remaining,
+                    $this->isFullFxSettlement(
+                        $txAmount,
+                        $remaining,
+                        (string) ($invoice['currency'] ?? 'CZK'),
+                        (float) ($invoice['exchange_rate'] ?? 0),
+                        $txCurrency,
+                    ),
                 );
 
                 // Idempotence: transakce už mohla platbu založit (legacy auto_partial flag
@@ -2150,20 +2161,61 @@ final class BankStatementAction
 
     /**
      * Částka transakce v měně faktury (mirror StatementMatcher::txAmountInInvoiceCurrency):
-     * stejná/neznámá měna → přímo; CZK platba cizoměnové faktury → děleno kurzem faktury;
-     * jinak $fallback (zbývající částka — manuální match = uživatel říká „tahle platba
-     * patří k téhle faktuře", bez převoditelné měny bereme doplacení zbytku).
+     * stejná/neznámá měna → přímo; úplná FX úhrada → celý zbytek faktury;
+     * částečná CZK platba cizoměnové faktury → děleno kurzem faktury. Jiná
+     * nepřevoditelná kombinace použije $fallback, protože manuální match potvrzuje vazbu.
      */
-    private function txAmountInInvoiceCurrency(float $txAmount, string $invCcy, float $rate, ?string $txCurrency, float $fallback): float
+    private function txAmountInInvoiceCurrency(
+        float $txAmount,
+        string $invCcy,
+        float $rate,
+        ?string $txCurrency,
+        float $fallback,
+        bool $settleRemaining = false,
+    ): float
     {
         if ($txCurrency === null || strtoupper($txCurrency) === strtoupper($invCcy)) {
             return round($txAmount, 2);
+        }
+        if ($settleRemaining) {
+            return round($fallback, 2);
         }
         if (strtoupper($txCurrency) === 'CZK') {
             $r = $rate > 0 ? $rate : 1.0;
             return round($txAmount / $r, 2);
         }
         return round($fallback, 2);
+    }
+
+    /**
+     * Ručně potvrzená CZK platba vypořádá celý cizoměnový zbytek jen tehdy,
+     * když se vejde do stejné 4% FX tolerance jako nabídka kandidátů. Výrazně nižší
+     * platba zůstává částečnou úhradou přepočtenou kurzem faktury.
+     */
+    private function isFullFxSettlement(
+        float $txAmount,
+        float $remaining,
+        string $invCcy,
+        float $rate,
+        ?string $txCurrency,
+    ): bool
+    {
+        if ($txAmount <= 0.0 || $remaining <= 0.0 || $txCurrency === null) {
+            return false;
+        }
+        $txCcy = strtoupper($txCurrency);
+        if ($txCcy === strtoupper($invCcy)) {
+            return false;
+        }
+        $expected = $this->remainingInTxCurrency($remaining, $invCcy, $rate, $txCcy);
+        if ($expected === null) {
+            return false;
+        }
+        $tolerance = max(
+            self::CANDIDATE_AMOUNT_TOLERANCE,
+            abs($expected) * self::CANDIDATE_FX_TOLERANCE_PCT,
+        );
+        return abs($txAmount - $expected) <= $tolerance;
     }
 
     /**

--- a/api/src/Service/Bank/StatementMatcher.php
+++ b/api/src/Service/Bank/StatementMatcher.php
@@ -134,7 +134,9 @@ final class StatementMatcher
         // Relativní tolerance kvůli kurzovému driftu; partial tier zde nemá smysl (= exact).
         if (strtoupper($txCurrency) === self::LOCAL_CURRENCY) {
             $r = $rate > 0 ? $rate : 1.0;
-            $czk = $invoiceAmount * $r;
+            // Bankovní pohyb je na haléře; nezaokrouhlený mezivýsledek nesmí
+            // na hraně tolerance rozhodnout jinak než skutečná peněžní částka.
+            $czk = round($invoiceAmount * $r, 2);
             $tol = max($exact, $czk * self::FX_MATCH_TOLERANCE_PCT);
             return ['expected' => $czk, 'exact' => $tol, 'partial' => $tol];
         }
@@ -342,7 +344,8 @@ final class StatementMatcher
 
         $diff = abs($amount - $m['expected']);
         // Exact = doplacení v toleranci; drobný přeplatek do partial tier (≤ 1 Kč)
-        // bereme taky jako úhradu (zaeviduje se reálná částka, payment_status to ukáže).
+        // bereme taky jako úhradu. Ve stejné měně evidujeme skutečnou částku;
+        // cross-currency exact vypořádá celý zbytek v měně faktury.
         $isExact = $diff <= $m['exact']
             || (!$alreadyPaid && $amount > $m['expected'] && $diff <= $m['partial']);
         if ($isExact) {
@@ -355,7 +358,13 @@ final class StatementMatcher
                     if ($this->payments !== null) {
                         $this->payments->recordPayment(
                             (int) $inv['id'],
-                            $this->txAmountInInvoiceCurrency($amount, $inv, $txCurrency, $remaining),
+                            $this->txAmountInInvoiceCurrency(
+                                $amount,
+                                $inv,
+                                $txCurrency,
+                                $remaining,
+                                settleRemaining: true,
+                            ),
                             (string) $row['posted_at'],
                             [
                                 'source'              => 'bank',
@@ -474,14 +483,25 @@ final class StatementMatcher
 
     /**
      * Částka transakce vyjádřená v měně faktury (pro záznam do invoice_payments).
-     * Stejná/neznámá měna → přímo; CZK platba cizoměnové faktury → děleno kurzem
-     * faktury (zrcadlí expectedMatch); jinak $fallback (typicky zbývající částka).
+     * Stejná/neznámá měna → přímo. U přijaté úplné FX úhrady ukládáme
+     * celý zbytek v měně faktury; skutečná CZK částka zůstává na bankovní transakci.
+     * Částečná CZK platba se nadále přepočítá kurzem faktury. Jiná nepřevoditelná
+     * kombinace měn použije $fallback.
      */
-    private function txAmountInInvoiceCurrency(float $txAmount, array $inv, ?string $txCurrency, float $fallback): float
+    private function txAmountInInvoiceCurrency(
+        float $txAmount,
+        array $inv,
+        ?string $txCurrency,
+        float $fallback,
+        bool $settleRemaining = false,
+    ): float
     {
         $invCcy = strtoupper((string) $inv['currency']);
         if ($txCurrency === null || strtoupper($txCurrency) === $invCcy) {
             return round($txAmount, 2);
+        }
+        if ($settleRemaining) {
+            return round($fallback, 2);
         }
         if (strtoupper($txCurrency) === self::LOCAL_CURRENCY) {
             $r = (float) ($inv['exchange_rate'] ?: 0);

--- a/api/tests/Integration/Bank/FxPaymentSettlementTest.php
+++ b/api/tests/Integration/Bank/FxPaymentSettlementTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Integration\Bank;
+
+use MyInvoice\Action\Bank\BankStatementAction;
+use MyInvoice\Bootstrap;
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Middleware\SupplierScopeMiddleware;
+use MyInvoice\Service\Bank\StatementMatcher;
+use PDO;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response as Psr7Response;
+
+/**
+ * Regrese: úplná EUR faktura zaplacená na CZK účet se nesmí po spárování
+ * tvářit jako částečně uhrazená jen proto, že banka použila jiný kurz než doklad.
+ * Skutečná CZK částka zůstává v bank_transactions; invoice_payments eviduje
+ * vypořádání v měně faktury.
+ */
+#[Group('integration')]
+final class FxPaymentSettlementTest extends TestCase
+{
+    private const FILE_MARKER = '__fx_payment_settlement_test__';
+    private const CLIENT_MARKER = '__fx_payment_settlement_client__';
+    private const CURRENCY_MARKER = 'TEST EUR FX settlement';
+    private const TEST_VS = ['209970001', '209970002', '209970003'];
+
+    private Connection $db;
+    private StatementMatcher $matcher;
+    private BankStatementAction $action;
+    private int $supplierId = 0;
+    private int $clientId = 0;
+    private int $currencyId = 0;
+    private int $countryId = 0;
+    private int $userId = 0;
+    private string $account = '';
+    private ?string $bankCode = null;
+
+    protected function setUp(): void
+    {
+        $rootDir = dirname(__DIR__, 4);
+        if (!is_file($rootDir . '/cfg.php')) {
+            $this->markTestSkipped('cfg.php neexistuje — test vyžaduje DB.');
+        }
+        try {
+            $container = Bootstrap::buildApp()->getContainer();
+            $this->db = $container->get(Connection::class);
+            $this->matcher = $container->get(StatementMatcher::class);
+            $this->action = $container->get(BankStatementAction::class);
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('DI/DB nedostupné: ' . $e->getMessage());
+        }
+
+        $pdo = $this->db->pdo();
+        $account = $pdo->query(
+            "SELECT supplier_id, account_number, bank_code FROM currencies
+              WHERE code = 'CZK' AND account_number IS NOT NULL AND account_number <> ''
+              ORDER BY id LIMIT 1"
+        )->fetch(PDO::FETCH_ASSOC);
+        if (!$account) {
+            $this->markTestSkipped('Chybí CZK měna s bankovním účtem.');
+        }
+        $this->supplierId = (int) $account['supplier_id'];
+        $this->account = (string) $account['account_number'];
+        $this->bankCode = $account['bank_code'] !== null ? (string) $account['bank_code'] : null;
+        $this->countryId = (int) ($pdo->query('SELECT id FROM countries ORDER BY id LIMIT 1')->fetchColumn() ?: 0);
+        $this->userId = (int) ($pdo->query('SELECT id FROM users ORDER BY id LIMIT 1')->fetchColumn() ?: 0);
+        if ($this->countryId === 0 || $this->userId === 0) {
+            $this->markTestSkipped('Chybí country/user pro integrační test.');
+        }
+
+        $this->cleanup();
+        $this->seedPartyAndCurrency();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->db)) {
+            $this->cleanup();
+        }
+    }
+
+    private function cleanup(): void
+    {
+        $pdo = $this->db->pdo();
+        $placeholders = implode(',', array_fill(0, count(self::TEST_VS), '?'));
+        $invoiceParams = [$this->supplierId, ...self::TEST_VS];
+
+        $pdo->prepare(
+            "DELETE FROM activity_log
+              WHERE entity_type = 'invoice'
+                AND entity_id IN (
+                    SELECT id FROM invoices WHERE supplier_id = ? AND varsymbol IN ($placeholders)
+                )"
+        )->execute($invoiceParams);
+        $pdo->prepare(
+            "DELETE FROM activity_log
+              WHERE entity_type = 'bank_transaction'
+                AND entity_id IN (
+                    SELECT bt.id FROM bank_transactions bt
+                    JOIN bank_statements bs ON bs.id = bt.statement_id
+                    WHERE bs.file_name LIKE ?
+                )"
+        )->execute(['%' . self::FILE_MARKER . '%']);
+        $pdo->prepare('DELETE FROM bank_statements WHERE file_name LIKE ?')
+            ->execute(['%' . self::FILE_MARKER . '%']);
+        $pdo->prepare("DELETE FROM invoices WHERE supplier_id = ? AND varsymbol IN ($placeholders)")
+            ->execute($invoiceParams);
+        $pdo->prepare('DELETE FROM clients WHERE supplier_id = ? AND company_name = ?')
+            ->execute([$this->supplierId, self::CLIENT_MARKER]);
+        $pdo->prepare('DELETE FROM currencies WHERE supplier_id = ? AND label = ?')
+            ->execute([$this->supplierId, self::CURRENCY_MARKER]);
+
+        $this->clientId = $this->currencyId = 0;
+    }
+
+    private function seedPartyAndCurrency(): void
+    {
+        $pdo = $this->db->pdo();
+        $pdo->prepare(
+            'INSERT INTO currencies
+                (supplier_id, code, label, symbol, name_cs, name_en, decimals, is_active, is_default)
+             VALUES (?, "EUR", ?, "€", "euro", "euro", 2, 0, 0)'
+        )->execute([$this->supplierId, self::CURRENCY_MARKER]);
+        $this->currencyId = (int) $pdo->lastInsertId();
+
+        // Prázdný e-mail zaručí, že případně zapnuté poděkování neodešle SMTP zprávu.
+        $pdo->prepare(
+            'INSERT INTO clients
+                (supplier_id, company_name, street, city, zip, country_id, main_email,
+                 language, currency_default_id, is_customer, is_vendor)
+             VALUES (?, ?, "Test 1", "Praha", "11000", ?, "", "cs", ?, 1, 0)'
+        )->execute([$this->supplierId, self::CLIENT_MARKER, $this->countryId, $this->currencyId]);
+        $this->clientId = (int) $pdo->lastInsertId();
+    }
+
+    /** @return array{invoice_id:int,statement_id:int,transaction_id:int} */
+    private function seedPayment(
+        string $varsymbol,
+        float $txAmount,
+        float $invoiceAmount = 1000.0,
+        float $exchangeRate = 24.5,
+    ): array
+    {
+        $pdo = $this->db->pdo();
+        $date = '2099-07-15';
+        $pdo->prepare(
+            "INSERT INTO invoices
+                (invoice_type, varsymbol, client_id, supplier_id, issue_date, tax_date, due_date,
+                 currency_id, exchange_rate, exchange_rate_date, status,
+                 total_without_vat, total_with_vat, paid_total, created_by)
+             VALUES ('invoice', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'issued', ?, ?, 0, ?)"
+        )->execute([
+            $varsymbol, $this->clientId, $this->supplierId, $date, $date, $date,
+            $this->currencyId, $exchangeRate, $date, $invoiceAmount, $invoiceAmount, $this->userId,
+        ]);
+        $invoiceId = (int) $pdo->lastInsertId();
+
+        $pdo->prepare(
+            'INSERT INTO bank_statements
+                (file_name, file_hash, account_number, bank_code, currency, statement_date)
+             VALUES (?, ?, ?, ?, "CZK", ?)'
+        )->execute([
+            self::FILE_MARKER . $varsymbol . '.gpc',
+            hash('sha256', self::FILE_MARKER . $varsymbol),
+            $this->account,
+            $this->bankCode,
+            $date,
+        ]);
+        $statementId = (int) $pdo->lastInsertId();
+
+        $pdo->prepare(
+            'INSERT INTO bank_transactions
+                (statement_id, posted_at, amount, currency, variable_symbol)
+             VALUES (?, ?, ?, "CZK", ?)'
+        )->execute([$statementId, $date, $txAmount, $varsymbol]);
+
+        return [
+            'invoice_id' => $invoiceId,
+            'statement_id' => $statementId,
+            'transaction_id' => (int) $pdo->lastInsertId(),
+        ];
+    }
+
+    /** @return array{status:int,body:array<string,mixed>} */
+    private function manualMatch(int $transactionId, int $invoiceId): array
+    {
+        $request = (new ServerRequestFactory())
+            ->createServerRequest('POST', '/api/bank-transactions/' . $transactionId . '/match')
+            ->withAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, $this->supplierId)
+            ->withAttribute(AuthMiddleware::ATTR_USER, ['id' => $this->userId, 'role' => 'admin'])
+            ->withParsedBody(['invoice_id' => $invoiceId]);
+        $response = $this->action->manualMatch(
+            $request,
+            new Psr7Response(),
+            ['id' => (string) $transactionId],
+        );
+        $response->getBody()->rewind();
+        $body = json_decode((string) $response->getBody(), true) ?: [];
+        return ['status' => $response->getStatusCode(), 'body' => is_array($body) ? $body : []];
+    }
+
+    /** @return array<string,mixed> */
+    private function paymentRow(int $transactionId): array
+    {
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT amount, currency, bank_transaction_id FROM invoice_payments
+              WHERE bank_transaction_id = ?'
+        );
+        $stmt->execute([$transactionId]);
+        return $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    public function testAutomaticFullFxMatchSettlesWholeInvoice(): void
+    {
+        $seed = $this->seedPayment(self::TEST_VS[0], 24300.00);
+
+        $result = $this->matcher->match($seed['transaction_id']);
+
+        self::assertSame('auto_exact', $result['status'] ?? null);
+        self::assertSame($seed['invoice_id'], $result['invoice_id'] ?? null);
+        $invoice = $this->db->pdo()->query(
+            "SELECT status, paid_total, exchange_rate FROM invoices WHERE id = {$seed['invoice_id']}"
+        )->fetch(PDO::FETCH_ASSOC);
+        self::assertSame('paid', $invoice['status'] ?? null);
+        self::assertSame(1000.0, (float) ($invoice['paid_total'] ?? 0));
+        self::assertSame(24.5, (float) ($invoice['exchange_rate'] ?? 0), 'Kurz dokladu se nesmí změnit.');
+
+        $payment = $this->paymentRow($seed['transaction_id']);
+        self::assertSame(1000.0, (float) ($payment['amount'] ?? 0));
+        self::assertSame('EUR', $payment['currency'] ?? null);
+        $bankAmount = (float) $this->db->pdo()->query(
+            "SELECT amount FROM bank_transactions WHERE id = {$seed['transaction_id']}"
+        )->fetchColumn();
+        self::assertSame(24300.0, $bankAmount, 'Skutečná CZK částka musí zůstat na bankovní transakci.');
+    }
+
+    public function testManualFullFxMatchSettlesWholeInvoice(): void
+    {
+        // 123,45 × 24,50 = 3 024,525 CZK; skutečný pohyb 3 018,41 CZK nelze
+        // zpětně vyjádřit zaokrouhleným kurzem tak, aby součin seděl na haléř.
+        $seed = $this->seedPayment(self::TEST_VS[1], 3018.41, 123.45);
+
+        $result = $this->manualMatch($seed['transaction_id'], $seed['invoice_id']);
+
+        self::assertSame(200, $result['status'], json_encode($result['body']));
+        self::assertArrayNotHasKey('partial_payment', $result['body']);
+        $payment = $this->paymentRow($seed['transaction_id']);
+        self::assertSame(123.45, (float) ($payment['amount'] ?? 0));
+        self::assertSame(
+            'paid',
+            $this->db->pdo()->query("SELECT status FROM invoices WHERE id = {$seed['invoice_id']}")->fetchColumn(),
+        );
+    }
+
+    public function testManualPartialFxMatchStillUsesInvoiceRate(): void
+    {
+        $seed = $this->seedPayment(self::TEST_VS[2], 10000.00);
+
+        $result = $this->manualMatch($seed['transaction_id'], $seed['invoice_id']);
+
+        self::assertSame(200, $result['status'], json_encode($result['body']));
+        self::assertTrue($result['body']['partial_payment'] ?? false);
+        $payment = $this->paymentRow($seed['transaction_id']);
+        self::assertSame(408.16, (float) ($payment['amount'] ?? 0));
+        self::assertSame(
+            'issued',
+            $this->db->pdo()->query("SELECT status FROM invoices WHERE id = {$seed['invoice_id']}")->fetchColumn(),
+        );
+    }
+}

--- a/api/tests/Unit/Service/Bank/StatementMatcherTest.php
+++ b/api/tests/Unit/Service/Bank/StatementMatcherTest.php
@@ -42,6 +42,26 @@ final class StatementMatcherTest extends TestCase
         return $r;
     }
 
+    private function paymentAmount(
+        float $txAmount,
+        string $invCcy,
+        float $rate,
+        ?string $txCcy,
+        float $remaining,
+        bool $settleRemaining = false,
+    ): float
+    {
+        $ref = new \ReflectionMethod($this->matcher, 'txAmountInInvoiceCurrency');
+        return (float) $ref->invoke(
+            $this->matcher,
+            $txAmount,
+            ['currency' => $invCcy, 'exchange_rate' => $rate],
+            $txCcy,
+            $remaining,
+            $settleRemaining,
+        );
+    }
+
     public function testSameCurrencyComparesDirectly(): void
     {
         $m = $this->expectedMatch(2520.0, 'EUR', 24.36, 'EUR');
@@ -68,6 +88,14 @@ final class StatementMatcherTest extends TestCase
         self::assertSame(63000.0, $m['expected']);
         self::assertEqualsWithDelta(2520.0, $m['exact'], 0.001);
         self::assertSame($m['exact'], $m['partial']);
+    }
+
+    public function testCzkExpectedAmountIsRoundedToCents(): void
+    {
+        // 123,45 × 24,50 = 3 024,525; bankovní pohyb lze porovnávat jen na haléře.
+        $m = $this->expectedMatch(123.45, 'EUR', 24.5, 'CZK');
+        self::assertNotNull($m);
+        self::assertSame(3024.53, $m['expected']);
     }
 
     public function testCzkPaymentOfCzkInvoiceIsDirect(): void
@@ -112,5 +140,27 @@ final class StatementMatcherTest extends TestCase
         self::assertNotNull($m);
         self::assertSame(0.5, $m['expected']);
         self::assertSame(0.05, $m['exact']);
+    }
+
+    public function testFullFxSettlementRecordsWholeInvoiceRemainder(): void
+    {
+        // Banka připsala 24 300 CZK za plnou fakturu 1 000 EUR @ 24,50.
+        // Rozdíl je kurz banky/spread; po přijetí jako exact musí být faktura vyrovnaná.
+        self::assertSame(1000.0, $this->paymentAmount(24300.0, 'EUR', 24.5, 'CZK', 1000.0, true));
+        // Efektivní bankovní kurz nemusí jít vyjádřit tak, aby násobení po
+        // zaokrouhlení vrátilo přesně CZK pohyb; ani tehdy se hodnoty neslévají.
+        self::assertSame(123.45, $this->paymentAmount(3018.41, 'EUR', 24.5, 'CZK', 123.45, true));
+    }
+
+    public function testPartialFxSettlementStillConvertsByInvoiceRate(): void
+    {
+        self::assertSame(408.16, $this->paymentAmount(10000.0, 'EUR', 24.5, 'CZK', 1000.0));
+    }
+
+    public function testSameCurrencyExactSettlementKeepsActualPaymentAmount(): void
+    {
+        // Nové pravidlo je pouze pro cross-currency; haléřová odchylka ve stejné
+        // měně zůstává skutečnou evidovanou částkou.
+        self::assertSame(999.98, $this->paymentAmount(999.98, 'EUR', 24.5, 'EUR', 1000.0, true));
     }
 }

--- a/manual/24_Banka.md
+++ b/manual/24_Banka.md
@@ -108,6 +108,13 @@ připraví koncept **daňového dokladu k přijaté platbě** (viz § 11.1.2);
 doplatek zálohy, ke které už existuje finální doklad, se eviduje na finál.
 Stejně fungují platby z **e-mailových avíz** ([37. Bankovní účty](37_Bankovni_ucty.md)).
 
+U cizoměnové faktury placené na **CZK účet** se přepočet kurzem dokladu
+použije jen k rozpoznání platby. Pokud se CZK pohyb vejde do devizové tolerance,
+zaeviduje se jako úhrada celého zbývajícího obnosu v měně faktury. Skutečná
+CZK částka zůstává beze změny na bankovní transakci; nemusí se rovnat
+částce faktury násobené kurzem dokladu. Výrazně nižší platba se nadále
+eviduje jako částečná úhrada přepočtená kurzem faktury.
+
 ### 24.4.2 Manuální párování
 
 Pro transakce, které se nespárovaly automaticky (typicky chybí VS, nebo
@@ -117,9 +124,12 @@ Pro transakce, které se nespárovaly automaticky (typicky chybí VS, nebo
 2. Najdeš fakturu (číslo / klient / částka).
 3. Vyber a potvrď.
 
-Zaeviduje se platba ve výši transakce — plné pokrytí označí fakturu `paid`
-(`paid_at` = datum transakce), nižší částka je částečná úhrada. Activity log:
-`bank.matched_manual`.
+Ve stejné měně se zaeviduje platba ve výši transakce. U CZK platby
+cizoměnové faktury, která odpovídá celému zbytku v devizové toleranci, se
+faktura vyrovná celým zbytkem v její měně; přesný CZK pohyb zůstane na
+bankovní transakci. Výrazně nižší částka je částečná úhrada.
+Plné pokrytí označí fakturu `paid` (`paid_at` = datum transakce).
+Activity log: `bank.matched_manual`.
 
 #### Sloučená úhrada (jedna platba na více faktur)
 

--- a/source/15-castecne-uhrady-plan.md
+++ b/source/15-castecne-uhrady-plan.md
@@ -132,6 +132,7 @@ deduction řádky finálu + advance výpočet; VarsymbolGenerator alias; Invoice
 ## Mimo rozsah (vědomě)
 
 - Částečné úhrady přijatých faktur (payment_matches už N:N umí; UI sumarizace případně později).
-- Kurzové rozdíly částečných úhrad cizoměnových faktur (platba se eviduje v měně faktury,
-  CZK platba EUR faktury se přepočítá kurzem faktury — shodně s dnešním matcherem).
+- Kurzové rozdíly částečných úhrad cizoměnových faktur (platba se eviduje v měně faktury;
+  částečná CZK platba EUR faktury se přepočítá kurzem faktury, zatímco úplný FX match
+  vyrovná celý zbytek a skutečnou CZK částku ponechá na bankovní transakci).
 - Přeplatky → automatický dobropis / vratka.


### PR DESCRIPTION
# Úplné vypořádání cizoměnové faktury zaplacené v CZK

## Shrnutí

Tento PR opravuje automatické i ruční párování úplné platby cizoměnové vydané faktury na CZK bankovním účtu.

Pokud se CZK pohyb vejde do existující devizové tolerance a je přijat jako úhrada celého zbytku, `invoice_payments` nyní eviduje celý vypořádaný zbytek v měně faktury. Skutečná CZK částka zůstává beze změny na bankovní transakci.

## Problém

Matcher správně toleroval rozdíl mezi kurzem dokladu a kurzem banky, ale po úspěšném `auto_exact` matchi znovu vydělil skutečnou CZK částku kurzem faktury. Například platba 24 300 Kč za fakturu 1 000 EUR s kurzem 24,50 se proto uložila jako 991,84 EUR. Faktura zůstala částečně uhrazená, přestože matcher tutéž transakci vyhodnotil jako úplnou platbu.

Stejný problém byl v ručním párování.

## Řešení

- automatický úplný FX match uloží celý zbývající obnos v měně faktury,
- ruční 1:1 match použije stejné pravidlo, pokud CZK platba odpovídá celému zbytku v existující 4% FX toleranci,
- skutečná částka a měna pohybu zůstává v `bank_transactions`,
- kurz, částka ani DPH původního dokladu se nemění,
- výrazně nižší platba zůstává částečnou úhradou a nadále se přepočítá kurzem faktury,
- párování ve stejné měně zachovává dosavadní chování a skutečnou částku platby,
- CZK ekvivalent použitý pro porovnání se před vyhodnocením zaokrouhlí na haléře.

Změna využívá stávající datový model a nevyžaduje migraci.

## Dvě nezávislé peněžní hodnoty

Při FX úhradě se záměrně nevynucuje rovnost `cizí měna × zaokrouhlený kurz = CZK pohyb`.

Příklad z regresního testu:

| Údaj | Hodnota |
|---|---:|
| Zbytek faktury | 123,45 EUR |
| Kurz dokladu | 24,50 CZK/EUR |
| Přepočtená hodnota před zaokrouhlením | 3 024,525 CZK |
| Skutečný bankovní pohyb | 3 018,41 CZK |
| Evidovaná úhrada faktury | 123,45 EUR |

Výsledkem je plně uhrazená faktura, nezměněný kurz dokladu a přesně zachovaný bankovní pohyb.

## Rozsah

PR opravuje sdílenou platební sémantiku v MyInvoice.

Mimo rozsah zůstává explicitní dvojí alokace u složitých částečných nebo rozdělených plateb v různých měnách.

## API a dokumentace

- OpenAPI popisuje rozdíl mezi vypořádanou částkou v měně faktury a skutečným bankovním pohybem.
- Manuál bankovního párování popisuje automatickou i ruční FX úhradu.
- Veřejné API ani databázové schéma nezískává nová pole.

## Ověření

- [x] Automatický úplný FX match
- [x] Ruční úplný FX match včetně nezaokrouhlitelného efektivního kurzu
- [x] Ruční částečná FX platba zůstává částečná
- [x] Stejná měna zachová skutečnou částku
- [x] Cílené testy: 16 testů, 45 assertions
- [x] Unit sada: 1 610 testů, 5 447 assertions
- [x] Bankovní integrační sada: 46 testů, 202 assertions; 1 test přeskočen kvůli jedinému supplierovi v testovací DB
- [x] Architecture sada: 11 testů, 66 assertions
- [x] Striktní OpenAPI YAML kontrola bez duplicit a s 465 platnými lokálními `$ref`
- [x] Regenerace HTML a PDF manuálu
